### PR TITLE
Rotate key upon user's leave

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1703,7 +1703,7 @@ void Chat::flushOutputQueue(bool fromStart)
     while (mNextUnsent != mSending.end())
     {
         ManualSendReason reason =
-             (manualResendWhenUserJoins() && !mNextUnsent->isEdit() && (mNextUnsent->recipients < mUsers))
+             (manualResendWhenUserJoins() && !mNextUnsent->isEdit() && (mNextUnsent->recipients != mUsers))
             ? kManualSendUsersChanged : kManualSendInvalidReason;
 
         if ((reason == kManualSendInvalidReason) && (time(NULL) - mNextUnsent->msg->ts > CHATD_MAX_EDIT_AGE))


### PR DESCRIPTION
Change the key when a user leaves, so even if he rejoins and access to
messages that were sent when he didn't participate, he won't be able to
decrypt them.