### PR TITLE
Provide backwards compatibility for attachment JSON

### DIFF
--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -4914,6 +4914,10 @@ MegaNodeList *JSonUtils::parseAttachNodeJSon(const char *json)
         std::string nameString = iteratorName->value.GetString();
 
         rapidjson::Value::ConstMemberIterator iteratorKey = file.FindMember("k");
+        if (!iteratorKey->value.IsArray())
+        {
+            iteratorKey = file.FindMember("key");
+        }
         if (iteratorKey == file.MemberEnd() || !iteratorKey->value.IsArray()
                 || iteratorKey->value.Capacity() != 8)
         {


### PR DESCRIPTION
During a short period of time, Webclient sent the nodekey as `key`
instead of `k`.