### PR TITLE
Keep subscribed to presence for non-contacts participating on groupchats

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2418,6 +2418,10 @@ void ContactList::syncWithApi(mega::MegaUserList& users)
     for (int i=0; i<size; i++)
     {
         auto& user = *users.get(i);
+        if (user.getVisibility() == ::mega::MegaUser::VISIBILITY_INACTIVE)
+        {
+            continue;
+        }
         apiUsers.insert(user.getHandle());
         addUserFromApi(user);
     }

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2444,7 +2444,10 @@ void ContactList::onUserAddRemove(mega::MegaUser& user)
     if (user.getVisibility() == ::mega::MegaUser::VISIBILITY_INACTIVE)
     {
         auto it = this->find(user.getHandle());
-        removeUser(it);
+        if (it != this->end())
+        {
+            removeUser(it);
+        }
     }
     else
     {

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2399,7 +2399,7 @@ void Contact::onVisibilityChanged(int newVisibility)
     auto& client = mClist.client;
     if (newVisibility == ::mega::MegaUser::VISIBILITY_HIDDEN)
     {
-        client.presenced().removePeer(mUserid, true);
+        client.presenced().removePeer(mUserid);
         if (mChatRoom)
             mChatRoom->notifyExcludedFromChat();
     }

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2365,6 +2365,10 @@ bool ContactList::addUserFromApi(mega::MegaUser& user)
     if (item)
     {
         int newVisibility = user.getVisibility();
+        if (item->visibility() == newVisibility)
+        {
+            return false;
+        }
         client.db.query("update contacts set visibility = ? where userid = ?",
             newVisibility, userid);
         item->onVisibilityChanged(newVisibility);


### PR DESCRIPTION
Tests to perform:
 - User A is a contact of User B and both participate on groupchat1. User A removes B, but still sees status of B in groupchat1.
 - User B cancels his account, User A sends `DELPEER` for that user and removes the `Contact` object.