### PR TITLE
Fix duplicated error-management

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -418,9 +418,11 @@ Promise<void> Connection::reconnect(const std::string& url)
             })
             .fail([this](const promise::Error& err)
             {
-                int errType =  (err.type() == ERRTYPE_MEGASDK) ? WS_ERRTYPE_DNS : err.type();
-                mConnectPromise.reject(err.msg(), err.code(), errType);
-                mLoginPromise.reject(err.msg(), err.code(), errType);
+                if (err.type() == ERRTYPE_MEGASDK)
+                {
+                    mConnectPromise.reject(err.msg(), err.code(), err.type());
+                    mLoginPromise.reject(err.msg(), err.code(), err.type());
+                }
             });
             
             return mConnectPromise

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -345,9 +345,11 @@ Client::reconnect(const std::string& url)
             })
             .fail([this](const promise::Error& err)
             {
-                int errType =  (err.type() == ERRTYPE_MEGASDK) ? WS_ERRTYPE_DNS : err.type();
-                mConnectPromise.reject(err.msg(), err.code(), errType);
-                mLoginPromise.reject(err.msg(), err.code(), errType);
+                if (err.type() == ERRTYPE_MEGASDK)
+                {
+                    mConnectPromise.reject(err.msg(), err.code(), err.type());
+                    mLoginPromise.reject(err.msg(), err.code(), err.type());
+                }
             });
             
             return mConnectPromise


### PR DESCRIPTION
If the `ws_connect()` fails, `libws` will call `websockCloseCb()` and the `checkLibwsCall()` will throw an exception, resulting on the `.fail()` handler --> two managements of the same error.