### PR TITLE
Fix heartbeat and tests

### DIFF
--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -128,6 +128,11 @@ int MegaChatApi::getConnectionState()
     return pImpl->getConnectionState();
 }
 
+int MegaChatApi::getChatConnectionState(MegaChatHandle chatid)
+{
+    return pImpl->getChatConnectionState(chatid);
+}
+
 void MegaChatApi::retryPendingConnections(MegaChatRequestListener *listener)
 {
     pImpl->retryPendingConnections(listener);
@@ -859,6 +864,11 @@ void MegaChatListener::onChatOnlineStatusUpdate(MegaChatApi* api, MegaChatHandle
 }
 
 void MegaChatListener::onChatPresenceConfigUpdate(MegaChatApi *api, MegaChatPresenceConfig *config)
+{
+
+}
+
+void MegaChatListener::onChatConnectionStateUpdate(MegaChatApi *api, MegaChatHandle chatid, int newState)
 {
 
 }

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -776,11 +776,6 @@ bool MegaChatRoom::isActive() const
     return false;
 }
 
-bool MegaChatRoom::isOnline() const
-{
-    return false;
-}
-
 MegaChatPeerList * MegaChatPeerList::createInstance()
 {
     return new MegaChatPeerListPrivate();

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -771,6 +771,11 @@ bool MegaChatRoom::isActive() const
     return false;
 }
 
+bool MegaChatRoom::isOnline() const
+{
+    return false;
+}
+
 MegaChatPeerList * MegaChatPeerList::createInstance()
 {
     return new MegaChatPeerListPrivate();

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2799,6 +2799,12 @@ public:
      */
     virtual bool isActive() const;
 
+    /**
+     * @brief Returns true if the chatroom is connected and ready to receive new messages
+     * @return True if the chat is connected and ready to receive new messages
+     */
+    virtual bool isOnline() const;
+
     virtual int getChanges() const;
     virtual bool hasChanged(int changeType) const;
 };

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -1132,6 +1132,12 @@ public:
         CONNECTED       = 3     /// A call to connect() succeed
     };
 
+    enum
+    {
+        CHAT_CONNECTION_OFFLINE = 0,    /// Connection with chatd is not ready
+        CHAT_CONNECTION_ONLINE  = 1     /// Connection with chatd is ready and logged in
+    };
+
 
     // chat will reuse an existent megaApi instance (ie. the one for cloud storage)
     /**
@@ -1270,7 +1276,7 @@ public:
     void disconnect(MegaChatRequestListener *listener = NULL);
 
     /**
-     * @brief Returnes the current state of the connection
+     * @brief Returns the current state of the connection
      *
      * It can be one of the following values:
      *  - MegaChatApi::DISCONNECTED = 0
@@ -1280,6 +1286,18 @@ public:
      * @return The state of connection
      */
     int getConnectionState();
+
+    /**
+     * @brief Returns the current state of the connection to chatd
+     *
+     * The possible values are:
+     *  - MegaChatApi::CHAT_CONNECTION_OFFLINE      = 0
+     *  - MegaChatApi::CHAT_CONNECTION_ONLINE       = 1
+     *
+     * @param chatid MegaChatHandle that identifies the chat room
+     * @return The state of connection
+     */
+    int getChatConnectionState(MegaChatHandle chatid);
     
     /**
      * @brief Refresh DNS servers and retry pending connections
@@ -2878,6 +2896,19 @@ public:
      * @param config New presence configuration
      */
     virtual void onChatPresenceConfigUpdate(MegaChatApi* api, MegaChatPresenceConfig *config);
+
+    /**
+     * @brief This function is called when the connection state to a chatroom has changed
+     *
+     * The possible values are:
+     *  - MegaChatApi::CHAT_CONNECTION_OFFLINE      = 0
+     *  - MegaChatApi::CHAT_CONNECTION_ONLINE       = 1
+     *
+     * @param api MegaChatApi connected to the account
+     * @param chatid MegaChatHandle that identifies the chat room
+     * @param newState New state of the connection
+     */
+    virtual void onChatConnectionStateUpdate(MegaChatApi* api, MegaChatHandle chatid, int newState);
 };
 
 /**

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2817,12 +2817,6 @@ public:
      */
     virtual bool isActive() const;
 
-    /**
-     * @brief Returns true if the chatroom is connected and ready to receive new messages
-     * @return True if the chat is connected and ready to receive new messages
-     */
-    virtual bool isOnline() const;
-
     virtual int getChanges() const;
     virtual bool hasChanged(int changeType) const;
 };

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -3670,7 +3670,6 @@ MegaChatRoomPrivate::MegaChatRoomPrivate(const MegaChatRoom *chat)
     this->title = chat->getTitle();
     this->unreadCount = chat->getUnreadCount();
     this->active = chat->isActive();
-    this->online = chat->isOnline();
     this->changed = chat->getChanges();
     this->uh = chat->getUserTyping();
 }
@@ -3684,7 +3683,6 @@ MegaChatRoomPrivate::MegaChatRoomPrivate(const ChatRoom &chat)
     this->title = chat.titleString();
     this->unreadCount = chat.chat().unreadMsgCount();
     this->active = chat.isActive();
-    this->online = chat.chatdOnlineState() == kChatStateOnline;
     this->uh = MEGACHAT_INVALID_HANDLE;
 
     if (group)
@@ -3901,11 +3899,6 @@ const char *MegaChatRoomPrivate::getTitle() const
 bool MegaChatRoomPrivate::isActive() const
 {
     return active;
-}
-
-bool MegaChatRoomPrivate::isOnline() const
-{
-    return online;
 }
 
 int MegaChatRoomPrivate::getChanges() const

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -3633,6 +3633,7 @@ MegaChatRoomPrivate::MegaChatRoomPrivate(const MegaChatRoom *chat)
     this->title = chat->getTitle();
     this->unreadCount = chat->getUnreadCount();
     this->active = chat->isActive();
+    this->online = chat->isOnline();
     this->changed = chat->getChanges();
     this->uh = chat->getUserTyping();
 }
@@ -3646,6 +3647,7 @@ MegaChatRoomPrivate::MegaChatRoomPrivate(const ChatRoom &chat)
     this->title = chat.titleString();
     this->unreadCount = chat.chat().unreadMsgCount();
     this->active = chat.isActive();
+    this->online = chat.chatdOnlineState() == kChatStateOnline;
     this->uh = MEGACHAT_INVALID_HANDLE;
 
     if (group)
@@ -3862,6 +3864,11 @@ const char *MegaChatRoomPrivate::getTitle() const
 bool MegaChatRoomPrivate::isActive() const
 {
     return active;
+}
+
+bool MegaChatRoomPrivate::isOnline() const
+{
+    return online;
 }
 
 int MegaChatRoomPrivate::getChanges() const

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1386,7 +1386,7 @@ int MegaChatApiImpl::getConnectionState()
 
 int MegaChatApiImpl::getChatConnectionState(MegaChatHandle chatid)
 {
-    int ret = 0;
+    int ret = MegaChatApi::CHAT_CONNECTION_OFFLINE;
 
     sdkMutex.lock();
     ChatRoom *room = findChatRoom(chatid);

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -4290,7 +4290,7 @@ void MegaChatListItemHandler::onLastTsUpdated(uint32_t ts)
     chatApi.fireOnChatListItemUpdate(item);
 }
 
-void MegaChatListItemHandler::onOnlineChatState(const ChatState state)
+void MegaChatListItemHandler::onChatOnlineState(const ChatState state)
 {
     // apps are not interested on this event
 }

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -773,6 +773,7 @@ public:
     void fireOnChatInitStateUpdate(int newState);
     void fireOnChatOnlineStatusUpdate(MegaChatHandle userhandle, int status, bool inProgress);
     void fireOnChatPresenceConfigUpdate(MegaChatPresenceConfig *config);
+    void fireOnChatConnectionStateUpdate(MegaChatHandle chatid, int newState);
 
     // ============= API requests ================
 
@@ -780,6 +781,8 @@ public:
     void connect(MegaChatRequestListener *listener = NULL);
     void disconnect(MegaChatRequestListener *listener = NULL);
     int getConnectionState();
+    int getChatConnectionState(MegaChatHandle chatid);
+    static int convertChatConnectionState(chatd::ChatState state);
     void retryPendingConnections(MegaChatRequestListener *listener = NULL);
     void logout(MegaChatRequestListener *listener = NULL);
     void localLogout(MegaChatRequestListener *listener = NULL);

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -479,7 +479,6 @@ public:
     virtual bool isGroup() const;
     virtual const char *getTitle() const;
     virtual bool isActive() const;
-    virtual bool isOnline() const;
 
     virtual int getChanges() const;
     virtual bool hasChanged(int changeType) const;
@@ -505,7 +504,6 @@ private:
     std::vector<std::string> peerEmails;
     bool group;
     bool active;
-    bool online;
 
     std::string title;
     int unreadCount;

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -285,7 +285,7 @@ public:
     virtual void onRejoinedChat();
     virtual void onLastMessageUpdated(const chatd::LastTextMsg& msg);
     virtual void onLastTsUpdated(uint32_t ts);
-    virtual void onOnlineChatState(const chatd::ChatState state);
+    virtual void onChatOnlineState(const chatd::ChatState state);
 
     virtual const karere::ChatRoom& getChatRoom() const;
 

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -479,6 +479,7 @@ public:
     virtual bool isGroup() const;
     virtual const char *getTitle() const;
     virtual bool isActive() const;
+    virtual bool isOnline() const;
 
     virtual int getChanges() const;
     virtual bool hasChanged(int changeType) const;
@@ -504,6 +505,7 @@ private:
     std::vector<std::string> peerEmails;
     bool group;
     bool active;
+    bool online;
 
     std::string title;
     int unreadCount;

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -353,6 +353,8 @@ Client::reconnect(const std::string& url)
             return mConnectPromise
             .then([this]()
             {
+                mTsLastPingSent = 0;
+                mTsLastRecv = time(NULL);
                 mHeartbeatEnabled = true;
                 return login();
             });

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -1959,6 +1959,19 @@ void MegaChatApiTest::TEST_ChangeMyOwnName(unsigned int a1)
 
 int MegaChatApiTest::loadHistory(unsigned int accountIndex, MegaChatHandle chatid, TestChatRoomListener *chatroomListener)
 {
+    unsigned int tWaited = 0;    // microseconds
+    while (tWaited < maxTimeout)
+    {
+        MegaChatRoom *chatRoom = megaChatApi[accountIndex]->getChatRoom(chatid);
+        bool isOnline = chatRoom->isOnline();
+        delete chatRoom;
+        if (isOnline)
+        {
+            break;
+        }
+        usleep(pollingT);
+    }
+
     chatroomListener->msgCount[accountIndex] = 0;
     while (1)
     {

--- a/tests/sdk_test/sdk_test.h
+++ b/tests/sdk_test/sdk_test.h
@@ -237,6 +237,7 @@ private:
     bool requestFlagsChat[NUM_ACCOUNTS][megachat::MegaChatRequest::TOTAL_OF_REQUEST_TYPES];
     bool initStateChanged[NUM_ACCOUNTS];
     int initState[NUM_ACCOUNTS];
+    bool mChatConnectionOnline[NUM_ACCOUNTS];
     int lastError[NUM_ACCOUNTS];
     int lastErrorChat[NUM_ACCOUNTS];
     std::string lastErrorMsgChat[NUM_ACCOUNTS];
@@ -302,6 +303,7 @@ public:
     virtual void onChatListItemUpdate(megachat::MegaChatApi* api, megachat::MegaChatListItem *item);
     virtual void onChatOnlineStatusUpdate(megachat::MegaChatApi* api, megachat::MegaChatHandle userhandle, int status, bool inProgress);
     virtual void onChatPresenceConfigUpdate(megachat::MegaChatApi* api, megachat::MegaChatPresenceConfig *config);
+    virtual void onChatConnectionStateUpdate(megachat::MegaChatApi* api, megachat::MegaChatHandle chatid, int state);
 
     virtual void onTransferStart(mega::MegaApi *api, mega::MegaTransfer *transfer);
     virtual void onTransferFinish(mega::MegaApi* api, mega::MegaTransfer *transfer, mega::MegaError* error);


### PR DESCRIPTION
This pull request resets `mTsLastPingSent` and `mTsLastRecv` when the heartbeat is enabled. When a connection fails and there is a reconnect some time later, `mTsLastPingSent` causes a reconnect loop if the last keepalive sent for the previous connection was more than 15 seconds ago.

`mTsLastRecv` is reset just for consistency and to not send the first keepalive immediately after a connection.

Some tests were also randomly failing because they weren't waiting for the chatrooms to be connected and ready to receive new messages. This pull requests adds a new getter to `MegaChatRoom` that allows tests to know when the chat is ready and continue.