### PR TITLE
Control best moment to send RECEIVED command

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1177,7 +1177,7 @@ void ChatRoom::createChatdChat(const karere::SetOfIds& initialUsers)
 {
     mChat = &parent.client.chatd->createChat(
         mChatid, mShardNo, mUrl, this, initialUsers,
-        parent.client.newStrongvelope(chatid()), mCreationTs);
+        parent.client.newStrongvelope(chatid()), mCreationTs, mIsGroup);
     if (mOwnPriv == chatd::PRIV_NOTPRESENT)
         mChat->disable(true);
 }

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1030,9 +1030,13 @@ void Connection::execCommand(const StaticBuffer& buf)
                 CHATD_LOG_DEBUG("%s: recv HISTDONE - history retrieval finished", ID_CSTR(chatid));
                 mClient.chats(chatid).onHistDone();
                 if (mClient.chats(chatid).getLastIdReceivedFromServer() != karere::Id()
-                        && ! mClient.chats(chatid).isGroup())
+                        && ! mClient.chats(chatid).isGroup()
+                        && (mClient.chats(chatid).getLastIdxConfirmedToServerAtHistDone() == CHATD_IDX_INVALID
+                            || mClient.chats(chatid).getLastIdxConfirmedToServerAtHistDone()
+                            < mClient.chats(chatid).getLastIdxReceivedFromServer()))
                 {
                     sendBuf(Command(OP_RECEIVED) + chatid + mClient.chats(chatid).getLastIdReceivedFromServer());
+                    mClient.chats(chatid).setLastIdxConfirmedToServerAtHistDone(mClient.chats(chatid).getLastIdxReceivedFromServer());
                 }
                 break;
             }
@@ -1251,6 +1255,16 @@ Idx Chat::getLastIdxReceivedFromServer() const
 Id Chat::getLastIdReceivedFromServer() const
 {
     return mLastIdReceivedFromServer;
+}
+
+Idx Chat::getLastIdxConfirmedToServerAtHistDone() const
+{
+    return mLastIdxConfirmedToServerAtHistDone;
+}
+
+void Chat::setLastIdxConfirmedToServerAtHistDone(Idx idx)
+{
+    mLastIdxConfirmedToServerAtHistDone = idx;
 }
 
 bool Chat::isGroup() const

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2110,7 +2110,7 @@ void Chat::handleTruncate(const Message& msg, Idx idx)
             }
         }
 
-        if (mLastIdxReceivedFromServer <= idx)
+        if (mClient.isMessageReceivedConfirmationActive() && mLastIdxReceivedFromServer <= idx)
         {
             mLastIdxReceivedFromServer = CHATD_IDX_INVALID;
             mLastIdReceivedFromServer = karere::Id::null();

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2114,6 +2114,7 @@ void Chat::handleTruncate(const Message& msg, Idx idx)
         {
             mLastIdxReceivedFromServer = CHATD_IDX_INVALID;
             mLastIdReceivedFromServer = karere::Id::null();
+            // TODO: the update of those variables should be persisted
         }
     }
 
@@ -2421,6 +2422,7 @@ void Chat::msgIncomingAfterDecrypt(bool isNew, bool isLocal, Message& msg, Idx i
         {
             mLastIdxReceivedFromServer = idx;
             mLastIdReceivedFromServer = msgid;
+            // TODO: the update of those variables should be persisted
 
             sendCommand(Command(OP_RECEIVED) + mChatId + msgid);
         }

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2437,15 +2437,14 @@ void Chat::msgIncomingAfterDecrypt(bool isNew, bool isLocal, Message& msg, Idx i
 
         if (mClient.isMessageConfirmationActive() && !isGroup() &&
                 (msg.userid != mClient.mUserId) && // message is not ours
+                mConnection.isLoggedIn() &&   // skip NEWMSGs received in response to JOINRANGEHIST
                 ((mLastIdxReceivedFromServer == CHATD_IDX_INVALID) ||   // no local history
                  (idx > mLastIdxReceivedFromServer)))   // newer message than last received
         {
             mLastIdxReceivedFromServer = idx;
             mLastIdReceivedFromServer = msgid;
-            if (!isFetchingFromServer())
-            {
-                sendCommand(Command(OP_RECEIVED) + mChatId + msgid);
-            }
+
+            sendCommand(Command(OP_RECEIVED) + mChatId + msgid);
         }
     }
     if (msg.backRefId && !mRefidToIdxMap.emplace(msg.backRefId, idx).second)

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -206,9 +206,9 @@ void Client::notifyUserActive()
     sendKeepalive();
 }
 
-bool Client::isMessageConfirmationActive() const
+bool Client::isMessageReceivedConfirmationActive() const
 {
-    return mMessageConfirmation;
+    return mMessageReceivedConfirmation;
 }
 
 void Chat::connect(const std::string& url)
@@ -2414,7 +2414,7 @@ void Chat::msgIncomingAfterDecrypt(bool isNew, bool isLocal, Message& msg, Idx i
         CALL_DB(addMsgToHistory, msg, idx);
 
 
-        if (mClient.isMessageConfirmationActive() && !isGroup() &&
+        if (mClient.isMessageReceivedConfirmationActive() && !isGroup() &&
                 (msg.userid != mClient.mUserId) && // message is not ours
                 ((mLastIdxReceivedFromServer == CHATD_IDX_INVALID) ||   // no local history
                  (idx > mLastIdxReceivedFromServer)))   // newer message than last received

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -773,6 +773,7 @@ Chat::Chat(Connection& conn, Id chatid, Listener* listener,
     mLastSeenId = info.lastSeenId;
     mLastReceivedId = info.lastRecvId;
     mLastSeenIdx = mDbInterface->getIdxOfMsgid(mLastSeenId);
+    mLastReceivedFromServerIdx = mLastSeenIdx;
     mLastReceivedIdx = mDbInterface->getIdxOfMsgid(mLastReceivedId);
 
     if ((mHaveAllHistory = mDbInterface->haveAllHistory()))
@@ -2377,9 +2378,10 @@ void Chat::msgIncomingAfterDecrypt(bool isNew, bool isLocal, Message& msg, Idx i
 
         verifyMsgOrder(msg, idx);
         CALL_DB(addMsgToHistory, msg, idx);
-        if ((msg.userid != mClient.mUserId) &&
-           ((mLastReceivedIdx == CHATD_IDX_INVALID) || (idx > mLastReceivedIdx)))
+        if ((msg.userid != mClient.mUserId)
+                && ((mLastReceivedFromServerIdx == CHATD_IDX_INVALID) || (idx > mLastReceivedFromServerIdx)))
         {
+            mLastReceivedFromServerIdx = idx;
             sendCommand(Command(OP_RECEIVED) + mChatId + msgid);
         }
     }

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2130,7 +2130,7 @@ void Chat::handleTruncate(const Message& msg, Idx idx)
             }
         }
 
-        if (idx == highnum())
+        if (mLastIdxReceivedFromServer <= idx)
         {
             mLastIdxReceivedFromServer = CHATD_IDX_INVALID;
             mLastIdReceivedFromServer = karere::Id::null();

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -497,6 +497,7 @@ protected:
     Idx mLastReceivedIdx = CHATD_IDX_INVALID;
     karere::Id mLastSeenId;
     Idx mLastSeenIdx = CHATD_IDX_INVALID;
+    Idx mLastReceivedFromServerIdx = CHATD_IDX_INVALID;
     Listener* mListener;
     ChatState mOnlineState = kChatStateOffline;
     Priv mOwnPrivilege = PRIV_INVALID;

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -505,7 +505,6 @@ protected:
     Idx mLastSeenIdx = CHATD_IDX_INVALID;
     Idx mLastIdxReceivedFromServer = CHATD_IDX_INVALID;
     karere::Id mLastIdReceivedFromServer;
-    Idx mLastIdxConfirmedToServerAtHistDone = CHATD_IDX_INVALID;
     Listener* mListener;
     ChatState mOnlineState = kChatStateOffline;
     Priv mOwnPrivilege = PRIV_INVALID;
@@ -973,7 +972,6 @@ public:
     Idx lastIdxReceivedFromServer() const;
     karere::Id lastIdReceivedFromServer() const;
     Idx lastIdxConfirmedToServerAtHistDone() const;
-    void setLastIdxConfirmedToServerAtHistDone(Idx idx);
     bool isGroup() const;
 protected:
     void msgSubmit(Message* msg);

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -499,7 +499,8 @@ protected:
     Idx mLastReceivedIdx = CHATD_IDX_INVALID;
     karere::Id mLastSeenId;
     Idx mLastSeenIdx = CHATD_IDX_INVALID;
-    Idx mLastReceivedFromServerIdx = CHATD_IDX_INVALID;
+    Idx mLastIdxReceivedFromServer = CHATD_IDX_INVALID;
+    karere::Id mLastIdReceivedFromServer;
     Listener* mListener;
     ChatState mOnlineState = kChatStateOffline;
     Priv mOwnPrivilege = PRIV_INVALID;
@@ -962,6 +963,9 @@ public:
      */
     static uint64_t generateRefId(const ICrypto* aCrypto);
     Message *getManualSending(uint64_t rowid, chatd::ManualSendReason& reason);
+
+    Idx getLastIdxReceivedFromServer() const;
+    karere::Id getLastIdReceivedFromServer() const;
 protected:
     void msgSubmit(Message* msg);
     bool msgEncryptAndSend(OutputQueue::iterator it);

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -569,7 +569,7 @@ protected:
     std::map<karere::Id, Message*> mPendingEdits;
     std::map<BackRefId, Idx> mRefidToIdxMap;
     Chat(Connection& conn, karere::Id chatid, Listener* listener,
-         const karere::SetOfIds& users, uint32_t chatCreationTs, ICrypto* crypto, bool isGroup);
+    const karere::SetOfIds& users, uint32_t chatCreationTs, ICrypto* crypto, bool isGroup);
     void push_forward(Message* msg) { mForwardList.emplace_back(msg); }
     void push_back(Message* msg) { mBackwardList.emplace_back(msg); }
     Message* oldest() const { return (!mBackwardList.empty()) ? mBackwardList.back().get() : mForwardList.front().get(); }

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -560,11 +560,12 @@ protected:
      */
     Idx mDecryptOldHaltedAt = CHATD_IDX_INVALID;
     uint32_t mLastMsgTs;
+    bool mIsGroup;
     // ====
     std::map<karere::Id, Message*> mPendingEdits;
     std::map<BackRefId, Idx> mRefidToIdxMap;
     Chat(Connection& conn, karere::Id chatid, Listener* listener,
-         const karere::SetOfIds& users, uint32_t chatCreationTs, ICrypto* crypto);
+         const karere::SetOfIds& users, uint32_t chatCreationTs, ICrypto* crypto, bool isGroup);
     void push_forward(Message* msg) { mForwardList.emplace_back(msg); }
     void push_back(Message* msg) { mBackwardList.emplace_back(msg); }
     Message* oldest() const { return (!mBackwardList.empty()) ? mBackwardList.back().get() : mForwardList.front().get(); }
@@ -966,6 +967,7 @@ public:
 
     Idx getLastIdxReceivedFromServer() const;
     karere::Id getLastIdReceivedFromServer() const;
+    bool isGroup() const;
 protected:
     void msgSubmit(Message* msg);
     bool msgEncryptAndSend(OutputQueue::iterator it);
@@ -1039,7 +1041,7 @@ public:
      * with the newly created Chat object.
      */
     Chat& createChat(karere::Id chatid, int shardNo, const std::string& url,
-        Listener* listener, const karere::SetOfIds& initialUsers, ICrypto* crypto, uint32_t chatCreationTs);
+        Listener* listener, const karere::SetOfIds& initialUsers, ICrypto* crypto, uint32_t chatCreationTs, bool isGroup);
     /** @brief Leaves the specified chatroom */
     void leave(karere::Id chatid);
     promise::Promise<void> disconnect();

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -971,7 +971,6 @@ public:
 
     Idx lastIdxReceivedFromServer() const;
     karere::Id lastIdReceivedFromServer() const;
-    Idx lastIdxConfirmedToServerAtHistDone() const;
     bool isGroup() const;
 protected:
     void msgSubmit(Message* msg);

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -501,6 +501,7 @@ protected:
     Idx mLastSeenIdx = CHATD_IDX_INVALID;
     Idx mLastIdxReceivedFromServer = CHATD_IDX_INVALID;
     karere::Id mLastIdReceivedFromServer;
+    Idx mLastIdxConfirmedToServerAtHistDone = CHATD_IDX_INVALID;
     Listener* mListener;
     ChatState mOnlineState = kChatStateOffline;
     Priv mOwnPrivilege = PRIV_INVALID;
@@ -967,6 +968,8 @@ public:
 
     Idx getLastIdxReceivedFromServer() const;
     karere::Id getLastIdReceivedFromServer() const;
+    Idx getLastIdxConfirmedToServerAtHistDone() const;
+    void setLastIdxConfirmedToServerAtHistDone(Idx idx);
     bool isGroup() const;
 protected:
     void msgSubmit(Message* msg);

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -1013,6 +1013,7 @@ protected:
     std::map<karere::Id, std::shared_ptr<Chat>> mChatForChatId;
     karere::Id mUserId;
     static bool sWebsockCtxInitialized;
+    bool mMessageConfirmation = false;
     Connection& chatidConn(karere::Id chatid)
     {
         auto it = mConnectionForChatId.find(chatid);
@@ -1053,6 +1054,7 @@ public:
     bool manualResendWhenUserJoins() const { return options & kOptManualResendWhenUserJoins; }
     void notifyUserIdle();
     void notifyUserActive();
+    bool isMessageConfirmationActive() const;
     friend class Connection;
     friend class Chat;
 };

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -1046,7 +1046,7 @@ public:
      * with the newly created Chat object.
      */
     Chat& createChat(karere::Id chatid, int shardNo, const std::string& url,
-        Listener* listener, const karere::SetOfIds& initialUsers, ICrypto* crypto, uint32_t chatCreationTs, bool isGroup);
+    Listener* listener, const karere::SetOfIds& initialUsers, ICrypto* crypto, uint32_t chatCreationTs, bool isGroup);
     /** @brief Leaves the specified chatroom */
     void leave(karere::Id chatid);
     promise::Promise<void> disconnect();

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -1015,7 +1015,7 @@ protected:
     std::map<karere::Id, std::shared_ptr<Chat>> mChatForChatId;
     karere::Id mUserId;
     static bool sWebsockCtxInitialized;
-    bool mMessageConfirmation = false;
+    bool mMessageReceivedConfirmation = false;
     Connection& chatidConn(karere::Id chatid)
     {
         auto it = mConnectionForChatId.find(chatid);
@@ -1056,7 +1056,7 @@ public:
     bool manualResendWhenUserJoins() const { return options & kOptManualResendWhenUserJoins; }
     void notifyUserIdle();
     void notifyUserActive();
-    bool isMessageConfirmationActive() const;
+    bool isMessageReceivedConfirmationActive() const;
     friend class Connection;
     friend class Chat;
 };

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -966,9 +966,9 @@ public:
     static uint64_t generateRefId(const ICrypto* aCrypto);
     Message *getManualSending(uint64_t rowid, chatd::ManualSendReason& reason);
 
-    Idx getLastIdxReceivedFromServer() const;
-    karere::Id getLastIdReceivedFromServer() const;
-    Idx getLastIdxConfirmedToServerAtHistDone() const;
+    Idx lastIdxReceivedFromServer() const;
+    karere::Id lastIdReceivedFromServer() const;
+    Idx lastIdxConfirmedToServerAtHistDone() const;
     void setLastIdxConfirmedToServerAtHistDone(Idx idx);
     bool isGroup() const;
 protected:

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -433,6 +433,11 @@ void MegaChatApi::sendTypingNotification(MegaChatHandle chatid, MegaChatRequestL
     pImpl->sendTypingNotification(chatid, listener);
 }
 
+bool MegaChatApi::isMessageReceptionConfirmationActive() const
+{
+    return pImpl->isMessageReceptionConfirmationActive();
+}
+
 MegaStringList *MegaChatApi::getChatAudioInDevices()
 {
     return pImpl->getChatAudioInDevices();

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2333,6 +2333,13 @@ public:
      */
     void sendTypingNotification(MegaChatHandle chatid, MegaChatRequestListener *listener = NULL);
 
+    /**
+     * @brief Returns whether a flag is active to send the confirmation when message is
+     * received
+     * @return True if flag is active. False if flag is inactive
+     */
+    bool isMessageReceptionConfirmationActive() const;
+
     // Audio/Video device management
     mega::MegaStringList *getChatAudioInDevices();
     mega::MegaStringList *getChatVideoInDevices();

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2367,7 +2367,8 @@ public:
 
     /**
      * @brief Returns whether a flag is active to send the confirmation when message is
-     * received
+     * received. In case flag is inactive, messages may never reach the status delivered,
+     * since the target user will not send the required acknowledge to the server upon reception.
      * @return True if flag is active. False if flag is inactive
      */
     bool isMessageReceptionConfirmationActive() const;

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -262,7 +262,7 @@ public:
         STATUS_SENDING_MANUAL       = 1,    /// Message is too old to auto-retry sending, or group composition has changed, or user has read-only privilege, or user doesn't belong to chatroom. User must explicitly confirm re-sending. All further messages queued for sending also need confirmation
         STATUS_SERVER_RECEIVED      = 2,    /// Message confirmed by server, but not yet delivered to recepient(s)
         STATUS_SERVER_REJECTED      = 3,    /// Message is rejected by server for some reason (the message was confirmed but we didn't receive the confirmation because went offline or closed the app before)
-        STATUS_DELIVERED            = 4,    /// Peer confirmed message receipt. Used only for 1on1 chats
+        STATUS_DELIVERED            = 4,    /// Peer confirmed message receipt. Available only for 1on1 chats, but currently not in use.
         // for incoming messages
         STATUS_NOT_SEEN             = 5,    /// User hasn't read this message yet
         STATUS_SEEN                 = 6     /// User has read this message
@@ -2251,6 +2251,9 @@ public:
      * the transition through STATUS_SERVER_RECEIVED. In other words, the protocol doesn't allow
      * to know when an edit has been delived to the target user, but only when the edit has been
      * received by the server, so for convenience the status of the original message is kept.
+     * @note if MegaChatApi::isMessageReceptionConfirmationActive returns false, messages may never
+     * reach the status delivered, since the target user will not send the required acknowledge to the
+     * server upon reception.
      * 
      * You take the ownership of the returned value.
      *
@@ -2969,6 +2972,9 @@ public:
      * MegaChatMessage::getCode() equal to 0 and the corresponding MegaChatMessage::getTempId().
      * The app should discard the message in sending status, in pro of the confirmed message to avoid
      * duplicated message in the history.
+     * @note if MegaChatApi::isMessageReceptionConfirmationActive returns false, messages may never
+     * reach the status delivered, since the target user will not send the required acknowledge to the
+     * server upon reception.
      *
      * The SDK retains the ownership of the MegaChatMessage in the second parameter. The MegaChatMessage
      * object will be valid until this function returns. If you want to save the MegaChatMessage object,

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2366,10 +2366,17 @@ public:
     void sendTypingNotification(MegaChatHandle chatid, MegaChatRequestListener *listener = NULL);
 
     /**
-     * @brief Returns whether a flag is active to send the confirmation when message is
-     * received. In case flag is inactive, messages may never reach the status delivered,
-     * since the target user will not send the required acknowledge to the server upon reception.
-     * @return True if flag is active. False if flag is inactive
+     * @brief Returns whether reception of messages is acknowledged
+     *
+     * In case this function returns true, an acknowledgement will be sent for each
+     * received message, so the sender will eventually know the message is received.
+     *
+     * In case this function returns false, the acknowledgement is not sent and, in
+     * consequence, messages at the sender-side will not reach the status MegaChatMessage::STATUS_DELIVERED.
+     *
+     * @note This feature is only available for 1on1 chatrooms.
+     *
+     * @return True if received messages are acknowledged. False if they are not.
      */
     bool isMessageReceptionConfirmationActive() const;
 

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -2299,7 +2299,7 @@ void MegaChatApiImpl::sendTypingNotification(MegaChatHandle chatid, MegaChatRequ
 
 bool MegaChatApiImpl::isMessageReceptionConfirmationActive() const
 {
-    return mClient->chatd->isMessageConfirmationActive();
+    return mClient->chatd->isMessageReceivedConfirmationActive();
 }
 
 MegaStringList *MegaChatApiImpl::getChatAudioInDevices()

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -2268,6 +2268,11 @@ void MegaChatApiImpl::sendTypingNotification(MegaChatHandle chatid, MegaChatRequ
     waiter->notify();
 }
 
+bool MegaChatApiImpl::isMessageReceptionConfirmationActive() const
+{
+    return mClient->chatd->isMessageConfirmationActive();
+}
+
 MegaStringList *MegaChatApiImpl::getChatAudioInDevices()
 {
     return NULL;

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -844,6 +844,7 @@ public:
     MegaChatMessage *getLastMessageSeen(MegaChatHandle chatid);
     void removeUnsentMessage(MegaChatHandle chatid, MegaChatHandle rowid);
     void sendTypingNotification(MegaChatHandle chatid, MegaChatRequestListener *listener = NULL);
+    bool isMessageReceptionConfirmationActive() const;
 
     // Audio/Video devices
     mega::MegaStringList *getChatAudioInDevices();

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -1181,7 +1181,6 @@ void MegaChatApiTest::TEST_GroupChatManagement(unsigned int a1, unsigned int a2)
     ASSERT_CHAT_TEST(chatroomListener->hasArrivedMessage(a2, msgId), "Wrong message id at destination");
     MegaChatMessage *messageReceived = megaChatApi[a2]->getMessage(chatid, msgId);   // message should be already received, so in RAM
     ASSERT_CHAT_TEST(messageReceived && !strcmp(msg0.c_str(), messageReceived->getContent()), "Content of message doesn't match");
-    ASSERT_CHAT_TEST(waitForResponse(msgDelivered), "Timeout expired for receiving delivery notification");    // for delivery
 
     delete messageSent;
     messageSent = NULL;

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -1822,6 +1822,13 @@ void MegaChatApiTest::TEST_SendContact(unsigned int a1, unsigned int a2)
     ASSERT_CHAT_TEST(msgReceived->getUsersCount() == 1, "Wrong number of users in message. Count: " + std::to_string(msgReceived->getUsersCount()));
     ASSERT_CHAT_TEST(strcmp(msgReceived->getUserEmail(0), mAccounts[a2].getEmail().c_str()) == 0, "Wrong email address in message. Address: " + std::string(msgReceived->getUserEmail(0)));
 
+    // Check if reception confirmation is active and, in this case, only 1on1 rooms have acknowledgement of receipt
+    if (megaChatApi[a1]->isMessageReceptionConfirmationActive()
+            && !megaChatApi[a1]->getChatRoom(chatid)->isGroup())
+    {
+        ASSERT_CHAT_TEST(waitForResponse(flagDelivered), "Timeout expired for receiving delivery notification");    // for delivery
+    }
+
     megaChatApi[a1]->closeChatRoom(chatid, chatroomListener);
     megaChatApi[a2]->closeChatRoom(chatid, chatroomListener);
 
@@ -2220,8 +2227,9 @@ MegaChatMessage * MegaChatApiTest::sendTextMessageOrUpdate(unsigned int senderAc
     ASSERT_CHAT_TEST(messageReceived, "Failed to retrieve the message at the receiver account");
     ASSERT_CHAT_TEST(!strcmp(textToSend.c_str(), messageReceived->getContent()), "Content of message received doesn't match the content of sent message");
 
-    // only 1on1 rooms have acknowledgement of receipt
-    if (!megaChatApi[senderAccountIndex]->getChatRoom(chatid)->isGroup())
+    // Check if reception confirmation is active and, in this case, only 1on1 rooms have acknowledgement of receipt
+    if (megaChatApi[senderAccountIndex]->isMessageReceptionConfirmationActive()
+            && !megaChatApi[senderAccountIndex]->getChatRoom(chatid)->isGroup())
     {
         ASSERT_CHAT_TEST(waitForResponse(flagDelivered), "Timeout expired for receiving delivery notification");    // for delivery
     }


### PR DESCRIPTION
Previously RECEIVED command was sent for all new and old messages. Now, RECEIVED command is not sent while system is fetching and it is sent only once after received HISTDONE. It is never sent for a group-chat. For the rest of cases it is sent like before.