### PR TITLE
Protect against repeated logouts

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -483,7 +483,11 @@ void Client::onRequestFinish(::mega::MegaApi* apiObj, ::mega::MegaRequest *reque
         {
             if (wptr.deleted())
                 return;
-            setInitState(kInitErrSidInvalid);
+
+            if (initState() != kInitErrSidInvalid)
+            {
+                setInitState(kInitErrSidInvalid);
+            }
         });
         return;
     }


### PR DESCRIPTION
If karere has multiple pending SDK requests and the session becomes
invalid, a logout() attempt is done for each failed SDK request. Only
one would be necessary :)