### PR TITLE
Check the chatd is logged in

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -531,7 +531,7 @@ bool Connection::sendBuf(Buffer&& buf)
 //Copy the data to preserve the original
     auto rc = ws_send_msg_ex(mWebSocket, buf.buf(), buf.dataSize(), 1);
     buf.free(); //just in case, as it's content is xor-ed with the websock datamask so it's unusable
-    return rc;
+    return (rc == 0);
 }
 bool Chat::sendCommand(Command&& cmd)
 {

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -749,8 +749,8 @@ HistSource Chat::getHistoryFromDbOrServer(unsigned count)
 
 void Chat::requestHistoryFromServer(int32_t count)
 {
-    // the connection must be established (for a JOIN + HIST), but not yet logged in
-    assert(mConnection.state() >= Connection::kStateConnected);
+    // the connection must be established, but might not be logged in yet (for a JOIN + HIST)
+    assert(mConnection.isConnected() || mConnection.isLoggedIn());
     mLastServerHistFetchCount = mLastHistDecryptCount = 0;
     mServerFetchState = (count > 0)
         ? kHistFetchingNewFromServer

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -525,7 +525,7 @@ void Connection::reset() //immediate disconnect
 
 bool Connection::sendBuf(Buffer&& buf)
 {
-    if (!isLoggedIn())
+    if (!isLoggedIn() && !isConnected())
         return false;
 //WARNING: ws_send_msg_ex() is destructive to the buffer - it applies the websocket mask directly
 //Copy the data to preserve the original

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -217,7 +217,7 @@ void Chat::connect(const std::string& url)
             CHATID_LOG_ERROR("Error connecting to server: %s", err.what());
         });
     }
-    else if (mConnection.isOnline())
+    else if (mConnection.isConnected())
     {
         login();
     }
@@ -428,7 +428,7 @@ Promise<void> Connection::reconnect(const std::string& url)
             return mConnectPromise
             .then([this]() -> promise::Promise<void>
             {
-                assert(mState >= kStateConnected);
+                assert(isConnected());
                 enableInactivityTimer();
                 return rejoinExistingChats();
             });
@@ -519,14 +519,13 @@ void Connection::reset() //immediate disconnect
 
 bool Connection::sendBuf(Buffer&& buf)
 {
-    if (!isOnline())
+    if (!isLoggedIn())
         return false;
 //WARNING: ws_send_msg_ex() is destructive to the buffer - it applies the websocket mask directly
 //Copy the data to preserve the original
     auto rc = ws_send_msg_ex(mWebSocket, buf.buf(), buf.dataSize(), 1);
     buf.free(); //just in case, as it's content is xor-ed with the websock datamask so it's unusable
-    bool result = (!rc && isOnline());
-    return result;
+    return rc;
 }
 bool Chat::sendCommand(Command&& cmd)
 {
@@ -615,7 +614,7 @@ void Chat::join()
 {
 //We don't have any local history, otherwise joinRangeHist() would be called instead of this
 //Reset handshake state, as we may be reconnecting
-    assert(mConnection.isOnline());
+    assert(mConnection.isConnected());
     mUserDump.clear();
     setOnlineState(kChatStateJoining);
     mServerFetchState = kHistNotFetching;
@@ -725,7 +724,7 @@ HistSource Chat::getHistoryFromDbOrServer(unsigned count)
         }
         else
         {
-            if (!mConnection.isOnline())
+            if (!mConnection.isLoggedIn());
                 return kHistSourceServerOffline;
 
             auto wptr = weakHandle();
@@ -744,7 +743,8 @@ HistSource Chat::getHistoryFromDbOrServer(unsigned count)
 
 void Chat::requestHistoryFromServer(int32_t count)
 {
-    assert(mConnection.isOnline());
+    // the connection must be established (for a JOIN + HIST), but not yet logged in
+    assert(mConnection.state() >= Connection::kStateConnected);
     mLastServerHistFetchCount = mLastHistDecryptCount = 0;
     mServerFetchState = (count > 0)
         ? kHistFetchingNewFromServer
@@ -1691,7 +1691,7 @@ void Chat::flushOutputQueue(bool fromStart)
 //the crypto module would get out of sync with the I/O sequence, which means
 //that it must have been reset/freshly initialized, and we have to skip
 //the KEYID responses for the keys we flush from the output queue
-    if(mEncryptionHalted || !mConnection.isOnline())
+    if(mEncryptionHalted || !mConnection.isLoggedIn())
         return;
 
     if (fromStart)
@@ -1750,7 +1750,7 @@ void Chat::removeManualSend(uint64_t rowid)
 // after a reconnect, we tell the chatd the oldest and newest buffered message
 void Chat::joinRangeHist(const ChatDbInfo& dbInfo)
 {
-    assert(mConnection.isOnline());
+    assert(mConnection.isConnected());
     assert(dbInfo.oldestDbId && dbInfo.newestDbId);
     mUserDump.clear();
     setOnlineState(kChatStateJoining);

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -730,7 +730,7 @@ HistSource Chat::getHistoryFromDbOrServer(unsigned count)
         }
         else
         {
-            if (!mConnection.isLoggedIn());
+            if (!mConnection.isLoggedIn())
                 return kHistSourceServerOffline;
 
             auto wptr = weakHandle();

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -307,9 +307,15 @@ void Connection::onSocketClose(int errcode, int errtype, const std::string& reas
 
     if (oldState < kStateLoggedIn) //tell retry controller that the connect attempt failed
     {
-        assert(!mLoginPromise.done());
-        mConnectPromise.reject(reason, errcode, errtype);
-        mLoginPromise.reject(reason, errcode, errtype);
+        assert(!mLoginPromise.succeeded());
+        if (!mConnectPromise.done())
+        {
+            mConnectPromise.reject(reason, errcode, errtype);
+        }
+        if (!mConnectPromise.done())
+        {
+            mLoginPromise.reject(reason, errcode, errtype);
+        }
     }
     else
     {

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -302,9 +302,13 @@ protected:
     promise::Promise<void> mLoginPromise;
     Connection(Client& client, int shardNo): mClient(client), mShardNo(shardNo){}
     State state() { return mState; }
-    bool isOnline() const
+    bool isConnected() const
     {
-        return mState >= kStateConnected; //(mWebSocket && (ws_get_state(mWebSocket) == WS_STATE_CONNECTED));
+        return mState == kStateConnected;
+    }
+    bool isLoggedIn() const
+    {
+        return mState == kStateLoggedIn;
     }
     static void websockConnectCb(ws_t ws, void* arg);
     static void websockCloseCb(ws_t ws, int errcode, int errtype, const char *reason,

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -191,8 +191,15 @@ void Client::onSocketClose(int errcode, int errtype, const std::string& reason)
 
     if (mConnState < kLoggedIn) //tell retry controller that the connect attempt failed
     {
-        assert(!mLoginPromise.done());
-        mConnectPromise.reject(reason, errcode, errtype);
+        assert(!mLoginPromise.succeeded());
+        if (!mConnectPromise.done())
+        {
+            mConnectPromise.reject(reason, errcode, errtype);
+        }
+        if (!mConnectPromise.done())
+        {
+            mLoginPromise.reject(reason, errcode, errtype);
+        }
     }
     else
     {


### PR DESCRIPTION
There are certain operations that should not be performed until chatd connection is logged in (sent `JOIN`), but it wasn't enforced.
This branch also prevents resolution of promises already resolved.