### PR TITLE
Management of invalid session

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -459,7 +459,7 @@ Client::InitState Client::init(const char* sid)
     if (sid)
     {
         initWithDbSession(sid);
-        if (mInitState == kInitErrNoCache ||
+        if (mInitState == kInitErrNoCache ||    // not found, uncompatible db version, cannot open
                 mInitState == kInitErrCorruptCache)
         {
             wipeDb(sid);

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -459,7 +459,8 @@ Client::InitState Client::init(const char* sid)
     if (sid)
     {
         initWithDbSession(sid);
-        if (mInitState == kInitErrNoCache)
+        if (mInitState == kInitErrNoCache ||
+                mInitState == kInitErrCorruptCache)
         {
             wipeDb(sid);
         }

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -452,7 +452,10 @@ void Client::setInitState(InitState newState)
 Client::InitState Client::init(const char* sid)
 {
     if (mInitState > kInitCreated)
+    {
+        KR_LOG_ERROR("init: karere is already initialized. Current state: %s", initStateStr());
         return kInitErrAlready;
+    }
 
     api.sdk.addGlobalListener(this);
 

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -483,7 +483,11 @@ void Client::onRequestFinish(::mega::MegaApi* apiObj, ::mega::MegaRequest *reque
         {
             if (wptr.deleted())
                 return;
-            setInitState(kInitErrSidInvalid);
+
+            if (initState() != kInitErrSidInvalid)
+            {
+                setInitState(kInitErrSidInvalid);
+            }
         });
         return;
     }

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -1117,8 +1117,8 @@ public:
 
     enum
     {
-        INIT_ERROR                  = -1,   /// Initialization failed --> force a logout
-        INIT_WAITING_NEW_SESSION    = 1,    /// No \c sid provided at init() --> force a login
+        INIT_ERROR                  = -1,   /// Initialization failed --> disable chat
+        INIT_WAITING_NEW_SESSION    = 1,    /// No \c sid provided at init() --> force a login+fetchnodes
         INIT_OFFLINE_SESSION        = 2,    /// Initialization successful for offline operation
         INIT_ONLINE_SESSION         = 3,    /// Initialization successful for online operation --> login+fetchnodes completed
         INIT_NO_CACHE               = 7     /// Cache not available for \c sid provided --> remove SDK cache and force a login+fetchnodes
@@ -1211,9 +1211,15 @@ public:
     /**
      * @brief Initializes karere
      *
-     * If a session id is provided, karere will try to resume the session from cache.
-     * If no session is provided, karere will listen to login event in order to register a new
-     * session.
+     * If no session is provided, karere will listen to the fetchnodes event in order to register
+     * a new session and create its cache. It will return MegaChatApi::INIT_WAITING_NEW_SESSION.
+     *
+     * If a session id is provided, karere will try to resume the session from its cache and will
+     * return MegaChatApi::INIT_OFFLINE_SESSION.
+     *
+     * If a session id is provided but the correspoding cache is not available, it will return
+     * MegaChatApi::INIT_NO_CACHE and the app should go through a new fetchnodes in order to
+     * re-create a new cache from scratch.
      *
      * The initialization status is notified via `MegaChatListener::onChatInitStateUpdate`. See
      * the documentation of the callback for possible values.
@@ -1221,6 +1227,7 @@ public:
      * This function should be called before MegaApi::login and MegaApi::fetchnodes.
      *
      * @param sid Session id that wants to be resumed, or NULL if a new session will be created.
+     * @return The initialization state
      */
     int init(const char *sid);
 

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -1296,7 +1296,11 @@ public:
      * The associated request type with this request is MegaChatRequest::TYPE_LOGOUT.
      *
      * The request will fail with MegaChatError::ERROR_ACCESS when this function is
-     * called without a previous call to \c MegaChatApi::init.
+     * called without a previous call to \c MegaChatApi::init or when MEGAchat is already
+     * logged out.
+     *
+     * @note MEGAchat automatically logs out when it detects the MegaApi instance has an
+     * invalid session id. No need to call it explicitely, except to disable the chat.
      *
      * @param listener MegaChatRequestListener to track this request
      */

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -994,8 +994,6 @@ void MegaChatApiImpl::setLoggerClass(MegaChatLogger *megaLogger)
 
 int MegaChatApiImpl::init(const char *sid)
 {
-    int ret;
-
     sdkMutex.lock();
     if (!mClient)
     {
@@ -1003,10 +1001,18 @@ int MegaChatApiImpl::init(const char *sid)
         terminating = false;
     }
 
-    ret = MegaChatApiImpl::convertInitState(mClient->init(sid));
+    int state = mClient->init(sid);
+    if (state != karere::Client::kInitErrNoCache &&
+            state != karere::Client::kInitWaitingNewSession &&
+            state != karere::Client::kInitHasOfflineSession)
+    {
+        // there's been an error during initialization
+        localLogout();
+    }
+
     sdkMutex.unlock();
 
-    return ret;
+    return MegaChatApiImpl::convertInitState(state);
 }
 
 int MegaChatApiImpl::getInitState()

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -163,9 +163,12 @@ void MegaChatApiTest::logout(unsigned int accountIndex, bool closeSession)
     ASSERT_CHAT_TEST(!lastError[accountIndex], "Error sdk logout. Error: " + std::to_string(lastError[accountIndex]));
 
     flagRequestLogout = &requestFlagsChat[accountIndex][MegaChatRequest::TYPE_LOGOUT]; *flagRequestLogout = false;
-    closeSession ? megaChatApi[accountIndex]->logout() : megaChatApi[accountIndex]->localLogout();
-    ASSERT_CHAT_TEST(waitForResponse(flagRequestLogout), "Expired timeout for chat logout");
-    ASSERT_CHAT_TEST(!lastErrorChat[accountIndex], "Error chat logout. Error: " + lastErrorMsgChat[accountIndex] + " (" + std::to_string(lastErrorChat[accountIndex]) + ")");
+    if (!closeSession)  // for closed session, karere automatically logs out itself
+    {
+        megaChatApi[accountIndex]->localLogout();
+        ASSERT_CHAT_TEST(waitForResponse(flagRequestLogout), "Expired timeout for chat logout");
+        ASSERT_CHAT_TEST(!lastErrorChat[accountIndex], "Error chat logout. Error: " + lastErrorMsgChat[accountIndex] + " (" + std::to_string(lastErrorChat[accountIndex]) + ")");
+    }
     MegaApi::addLoggerObject(logger);   // need to restore customized logger
 
 }


### PR DESCRIPTION
When the SDK is logged out or an ESID is received for any type of SDK request, automatically set the status of karere to "invalid session id", which results in a logout() from karere.