### PR TITLE
Join also chatrooms when connection is already logged in

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -222,7 +222,7 @@ void Chat::connect(const std::string& url)
             CHATID_LOG_ERROR("Error connecting to server: %s", err.what());
         });
     }
-    else if (mConnection.isConnected())
+    else if (mConnection.isConnected() || mConnection.isLoggedIn())
     {
         login();
     }
@@ -643,7 +643,7 @@ void Chat::join()
 {
 //We don't have any local history, otherwise joinRangeHist() would be called instead of this
 //Reset handshake state, as we may be reconnecting
-    assert(mConnection.isConnected());
+    assert(mConnection.isConnected() || mConnection.isLoggedIn());
     mUserDump.clear();
     setOnlineState(kChatStateJoining);
     mServerFetchState = kHistNotFetching;


### PR DESCRIPTION
I will consider if it's worthy to remove the logged in state of `Connection` and manage such state at the `chat::Client` level.