### PR TITLE
Allow to connect as the user is away from app

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -704,7 +704,7 @@ void Client::dumpContactList(::mega::MegaUserList& clist)
     KR_LOG_DEBUG("== Contactlist end ==");
 }
 
-promise::Promise<void> Client::connect(Presence pres)
+promise::Promise<void> Client::connect(Presence pres, bool isInBackground)
 {
 // only the first connect() needs to wait for the mSessionReadyPromise.
 // Any subsequent connect()-s (preceded by disconnect()) can initiate
@@ -713,6 +713,9 @@ promise::Promise<void> Client::connect(Presence pres)
         return mConnectPromise;
     else if (mConnState == kConnected)
         return promise::_Void();
+
+    if (isInBackground)
+        notifyUserIdle();
 
     assert(mConnState == kDisconnected);
     auto sessDone = mSessionReadyPromise.done();

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -341,7 +341,7 @@ promise::Promise<void> Client::initWithNewSession(const char* sid, const std::st
     .then([this, scsn, contactList, chatList]()
     {
         loadContactListFromApi(*contactList);
-        chatd.reset(new chatd::Client(&api, mMyHandle));
+        chatd.reset(new chatd::Client(&api, mMyHandle, isInBackground));
         assert(chats->empty());
         chats->onChatsUpdate(*chatList);
         commit(scsn);
@@ -426,7 +426,7 @@ void Client::initWithDbSession(const char* sid)
         loadOwnKeysFromDb();
         contactList->loadFromDb();
         mContactsLoaded = true;
-        chatd.reset(new chatd::Client(&api, mMyHandle));
+        chatd.reset(new chatd::Client(&api, mMyHandle, isInBackground));
         chats->loadFromDb();
     }
     catch(std::runtime_error& e)
@@ -714,8 +714,7 @@ promise::Promise<void> Client::connect(Presence pres, bool isInBackground)
     else if (mConnState == kConnected)
         return promise::_Void();
 
-    if (isInBackground)
-        notifyUserIdle();
+    this->isInBackground = isInBackground;
 
     assert(mConnState == kDisconnected);
     auto sessDone = mSessionReadyPromise.done();

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -725,8 +725,11 @@ public:
      * i.e. it will be preserved even if the client disconnects. To disable
      * setting such a forced presence and assume whatever presence was last used,
      * and/or use only dynamic presence, set this param to \c Presence::kClear
+     * @param isInBackground In case the app requests to connect from a service in
+     * background, it should not send KEEPALIVE, but KEEPALIVEAWAY. Hence, it will
+     * avoid to tell chatd that the client is active.
      */
-    promise::Promise<void> connect(Presence pres=Presence::kClear);
+    promise::Promise<void> connect(Presence pres=Presence::kClear, bool isInBackground = false);
 
     /** @brief Disconnects the client from chatd and presenced */
     promise::Promise<void> disconnect();

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -621,6 +621,7 @@ public:
 
     SqliteDb db;
     std::unique_ptr<chatd::Client> chatd;
+    bool isInBackground = false;
     MyMegaApi api;
     rtcModule::IRtcModule* rtc = nullptr;
     unsigned mReconnectConnStateHandler = 0;

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -95,8 +95,8 @@ namespace chatd
 ws_base_s Client::sWebsocketContext;
 bool Client::sWebsockCtxInitialized = false;
 
-Client::Client(MyMegaApi *api, Id userId)
-:mUserId(userId), mApi(api)
+Client::Client(MyMegaApi *api, Id userId, bool isInBackground)
+    :mUserId(userId), mApi(api), mKeepaliveType(isInBackground ? OP_KEEPALIVEAWAY : OP_KEEPALIVE)
 {
     if (!sWebsockCtxInitialized)
     {

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -1032,7 +1032,7 @@ public:
     MyMegaApi *mApi;
     uint8_t mKeepaliveType = OP_KEEPALIVE;
     karere::Id userId() const { return mUserId; }
-    Client(MyMegaApi *api, karere::Id userId);
+    Client(MyMegaApi *api, karere::Id userId, bool isInBackground);
     ~Client(){}
     Chat& chats(karere::Id chatid) const
     {

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -118,6 +118,11 @@ void MegaChatApi::connect(MegaChatRequestListener *listener)
     pImpl->connect(listener);
 }
 
+void MegaChatApi::connectInBackground(MegaChatRequestListener *listener)
+{
+    pImpl->connectInBackground(listener);
+}
+
 void MegaChatApi::disconnect(MegaChatRequestListener *listener)
 {
     pImpl->disconnect(listener);

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -1274,6 +1274,29 @@ public:
     void connect(MegaChatRequestListener *listener = NULL);
 
     /**
+     * @brief Establish the connection with chat-related servers (chatd, presenced and Gelb).
+     *
+     * This function is intended to be used instead of MegaChatApi::connect when the connection
+     * is done by a service in background, which is launched without user-interaction. It avoids
+     * to notify to the server that this client is active, but actually the user is away.
+     *
+     * This function must be called only after calling:
+     *  - MegaChatApi::init to initialize the chat engine
+     *  - MegaApi::login to login in MEGA
+     *  - MegaApi::fetchNodes to retrieve current state of the account
+     *
+     * At that point, the initialization state should be MegaChatApi::INIT_ONLINE_SESSION.
+     * The online status after connecting will be whatever was last used.
+     *
+     * The associated request type with this request is MegaChatRequest::TYPE_CONNECT
+     * Valid data in the MegaChatRequest object received on callbacks:
+     * - MegaChatRequest::getFlag - Returns true.
+     *
+     * @param listener MegaChatRequestListener to track this request
+     */
+    void connectInBackground(MegaChatRequestListener *listener = NULL);
+
+    /**
      * @brief Disconnect from chat-related servers (chatd, presenced and Gelb).
      *
      * The associated request type with this request is MegaChatRequest::TYPE_DISCONNECT

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -205,7 +205,9 @@ void MegaChatApiImpl::sendPendingRequests()
         {
         case MegaChatRequest::TYPE_CONNECT:
         {
-            mClient->connect(karere::Presence::kInvalid)
+            bool isInBackground = request->getFlag();
+
+            mClient->connect(karere::Presence::kInvalid, isInBackground)
             .then([request, this]()
             {
                 MegaChatErrorPrivate *megaChatError = new MegaChatErrorPrivate(MegaChatError::ERROR_OK);
@@ -1368,6 +1370,14 @@ void MegaChatApiImpl::fireOnChatConnectionStateUpdate(MegaChatHandle chatid, int
 void MegaChatApiImpl::connect(MegaChatRequestListener *listener)
 {
     MegaChatRequestPrivate *request = new MegaChatRequestPrivate(MegaChatRequest::TYPE_CONNECT, listener);
+    requestQueue.push(request);
+    waiter->notify();
+}
+
+void MegaChatApiImpl::connectInBackground(MegaChatRequestListener *listener)
+{
+    MegaChatRequestPrivate *request = new MegaChatRequestPrivate(MegaChatRequest::TYPE_CONNECT, listener);
+    request->setFlag(true);
     requestQueue.push(request);
     waiter->notify();
 }

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -779,6 +779,7 @@ public:
 
     // General chat methods
     void connect(MegaChatRequestListener *listener = NULL);
+    void connectInBackground(MegaChatRequestListener *listener = NULL);
     void disconnect(MegaChatRequestListener *listener = NULL);
     int getConnectionState();
     int getChatConnectionState(MegaChatHandle chatid);


### PR DESCRIPTION
Android provides background services that require to be connected to
chatd, but sending KEEPALIVEAWAY in order to tell chatd the user is
actually away