### PR TITLE
Reconnect triggered by SDK

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -405,18 +405,21 @@ void Client::onEvent(::mega::MegaApi* api, ::mega::MegaEvent* event)
 
     case ::mega::MegaEvent::EVENT_DISCONNECT:
     {
-        auto wptr = weakHandle();
-        marshallCall([wptr, this]()
+        if (connState() == kConnecting || connState() == kConnected)
         {
-            if (wptr.deleted())
+            auto wptr = weakHandle();
+            marshallCall([wptr, this]()
             {
-                return;
-            }
+                if (wptr.deleted())
+                {
+                    return;
+                }
 
-            KR_LOG_WARNING("EVENT_DISCONNECT --> reconnect triggered by SDK");
-            retryPendingConnections();
+                KR_LOG_WARNING("EVENT_DISCONNECT --> reconnect triggered by SDK");
+                retryPendingConnections();
 
-        }, appCtx);
+            }, appCtx);
+        }
         break;
     }
 

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -498,11 +498,6 @@ bool MegaChatApiTest::waitForResponse(bool *responseReceived, unsigned int timeo
             {
                 for (int i = 0; i < NUM_ACCOUNTS; i++)
                 {
-                    if (megaChatApi[i] && megaChatApi[i]->getInitState() == MegaChatApi::INIT_ONLINE_SESSION)
-                    {
-                        megaChatApi[i]->retryPendingConnections();
-                    }
-
                     if (megaApi[i] && megaApi[i]->isLoggedIn())
                     {
                         megaApi[i]->retryPendingConnections();


### PR DESCRIPTION
When the SDK fully disconnects and resets its connections, MEGAchat
should follow it and reconnect creating new sockets (and resolving DNS)