### PR TITLE
Avoid notifications of message that haven't been loaded by the app

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1940,10 +1940,14 @@ void Chat::onMsgUpdated(Message* cipherMsg)
             histmsg.type = msg->type;
             histmsg.userid = msg->userid;
 
-            if (idx >= mNextHistFetchIdx)
+            if (idx > mNextHistFetchIdx)
             {
                 // msg.ts is zero - chatd doesn't send the original timestamp
                 CALL_LISTENER(onMessageEdited, histmsg, idx);
+            }
+            else
+            {
+                CHATID_LOG_DEBUG("onMessageEdited() skipped for not-loaded-yet message");
             }
 
             if (msg->userid != client().userId() && // is not our own message


### PR DESCRIPTION
When the last message in history is the one that is updated, it's still notified even if not loaded yet. This commit aims to fix that