### PR TITLE
Ignore completion of requests for deleted MegaApi instances

### DIFF
--- a/src/base/promise.h
+++ b/src/base/promise.h
@@ -148,7 +148,7 @@ protected:
     int mCount;
 public:
     CallbackList():mCount(0){}
-    inline void checkCanAdd() const
+    inline void checkCanAdd(int cnt = 0) const
     {
         if (mCount>=L)
             throw std::runtime_error(kNoMoreCallbacksMsg);
@@ -162,8 +162,7 @@ public:
     template<class SP>
     inline void push(SP& cb)
     {
-        if (mCount >= L)
-            throw std::runtime_error(kNoMoreCallbacksMsg);
+        checkCanAdd();
         items[mCount++] = cb.release();
     }
 
@@ -186,8 +185,7 @@ public:
     inline void addListMoveItems(CallbackList& other)
     {
         int cnt = other.count();
-        if (mCount+cnt > L)
-            throw std::runtime_error(kNoMoreCallbacksMsg);
+        checkCanAdd(cnt);
         for (int i=0; i<cnt; i++)
             items[mCount++] = other.items[i];
         other.mCount = 0;

--- a/src/base/promise.h
+++ b/src/base/promise.h
@@ -150,7 +150,7 @@ public:
     CallbackList():mCount(0){}
     inline void checkCanAdd(int cnt = 0) const
     {
-        if (mCount>=L)
+        if (mCount + cnt >= L)
             throw std::runtime_error(kNoMoreCallbacksMsg);
     }
 /**

--- a/src/sdkApi.h
+++ b/src/sdkApi.h
@@ -8,6 +8,7 @@
 #include <megaapi.h>
 #include "base/promise.h"
 #include "base/gcmpp.h"
+#include <base/trackDelete.h>
 #include <logger.h>
 #include <string.h>
 #include "karereCommon.h" //for KR_LOG_DEBUG
@@ -38,9 +39,10 @@ public:
 class MyListener: public mega::MegaRequestListener
 {
     void *appCtx;
+    karere::DeleteTrackable::Handle wptr;
     
 public:
-    MyListener(void *ctx) : appCtx(ctx) { }
+    MyListener(void *ctx, karere::DeleteTrackable::Handle wptr) : appCtx(ctx), wptr(wptr) { }
     ApiPromise mPromise;
     virtual void onRequestFinish(mega::MegaApi* api, mega::MegaRequest *request, mega::MegaError* e)
     {
@@ -48,8 +50,12 @@ public:
         int errCode = e->getErrorCode();
         karere::marshallCall([this, req, errCode]()
         {
+            if (wptr.deleted())
+                return;
+
             if (mPromise.done())
                 return; //a timeout timer may resolve it before the actual callback
+
             if(errCode != mega::MegaError::API_OK)
             {
                 std::string errmsg = "Mega API error ";
@@ -69,9 +75,10 @@ public:
 class MyListenerNoResult: public ::mega::MegaRequestListener
 {
     void *appCtx;
+    karere::DeleteTrackable::Handle wptr;
 
 public:
-    MyListenerNoResult(void *ctx) : appCtx(ctx) { }
+    MyListenerNoResult(void *ctx, karere::DeleteTrackable::Handle wptr) : appCtx(ctx), wptr(wptr) { }
 
     promise::Promise<void> mPromise;
     virtual void onRequestFinish(mega::MegaApi* api, mega::MegaRequest *request, mega::MegaError* e)
@@ -79,8 +86,12 @@ public:
         int errCode = e->getErrorCode();
         karere::marshallCall([this, errCode]()
         {
+            if (wptr.deleted())
+                return;
+
             if (mPromise.done())
                 return; //a timeout timer may resolve it before the actual callback
+
             if(errCode != mega::MegaError::API_OK)
             {
                 std::string errmsg = "Mega API error ";
@@ -125,7 +136,7 @@ class MyMegaLogger: public ::mega::MegaLogger
     }
 };
 
-class MyMegaApi
+class MyMegaApi: public karere::DeleteTrackable
 {
 public:
     ::mega::MegaApi& sdk;
@@ -140,14 +151,14 @@ public:
     template <typename... Args, typename MSig=void(::mega::MegaApi::*)(Args..., ::mega::MegaRequestListener*)>
     ApiPromise call(MSig method, Args... args)
     {
-        auto listener = new MyListener(appCtx);
+        auto listener = new MyListener(appCtx, getDelTracker());
         (sdk.*method)(args..., listener);
         return listener->mPromise;
     }
     template <typename... Args, typename MSig=void(::mega::MegaApi::*)(Args..., ::mega::MegaRequestListener*)>
     promise::Promise<void> callIgnoreResult(MSig method, Args... args)
     {
-        auto listener = new MyListenerNoResult(appCtx);
+        auto listener = new MyListenerNoResult(appCtx, getDelTracker());
         (sdk.*method)(args..., listener);
         return listener->mPromise;
     }

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -1528,7 +1528,7 @@ void MegaChatApiTest::TEST_SwitchAccounts(unsigned int a1, unsigned int a2)
     delete [] session;
     session = NULL;
 
-    // LOgin over same index account but with other user
+    // Login over same index account but with other user
     session = login(a1, NULL, mAccounts[a2].getEmail().c_str(), mAccounts[a2].getPassword().c_str());
 
     delete [] session;


### PR DESCRIPTION
When a `MyMegaApi` is deleted, but there's a `MyListener` registered for a pending request, the `onRequestFinish()` will be executed anyway, resolving the associated promise. The resolution of the promise could create side-effects in other places. Better to do nothing if the instance of `MyMegaApi` has been deleted already.