### PR TITLE
Fixes for sending queue

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1287,14 +1287,7 @@ void Chat::createMsgBackRefs(Message& msg)
 Chat::SendingItem* Chat::postMsgToSending(uint8_t opcode, Message* msg)
 {
     mSending.emplace_back(opcode, msg, mUsers);
-
-    auto& item = mSending.back();
-    CALL_DB(saveMsgToSending, item);
-    if (opcode == OP_MSGUPD)    // comfirmed messages always use the original key for edits
-    {
-        CALL_DB(confirmKeyOfSendingItem, item.rowid, msg->keyid);
-    }
-
+    CALL_DB(saveMsgToSending, mSending.back());
     if (mNextUnsent == mSending.end())
     {
         mNextUnsent--;

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -498,9 +498,9 @@ void Chat::logSend(const Command& cmd)
         }
         case OP_NEWKEY:
         {
-            //auto& keycmd = static_cast<const KeyCommand&>(cmd);
-            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send NEWKEY\n",
-                        ID_CSTR(mChatId));
+            auto& keycmd = static_cast<const KeyCommand&>(cmd);
+            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send NEWKEY - keyxid: %u\n",
+                        ID_CSTR(mChatId), keycmd.keyId());
             break;
         }
         default:
@@ -966,18 +966,18 @@ void Connection::execCommand(const StaticBuffer& buf)
                 READ_CHATID(0);
                 READ_32(keyxid, 8);
                 READ_32(keyid, 12);
-                CHATD_LOG_DEBUG("%s: recv KEYID %u", ID_CSTR(chatid), keyid);
+                CHATD_LOG_DEBUG("%s: recv KEYID: %u -> %u", ID_CSTR(chatid), keyxid, keyid);
                 mClient.chats(chatid).keyConfirm(keyxid, keyid);
                 break;
             }
             case OP_NEWKEY:
             {
                 READ_CHATID(0);
-                pos += 4; //skip dummy 32bit keyid
+                READ_32(keyid, 8);
                 READ_32(totalLen, 12);
                 const char* keys = buf.readPtr(pos, totalLen);
                 pos+=totalLen;
-                CHATD_LOG_DEBUG("%s: recv NEWKEY", ID_CSTR(chatid));
+                CHATD_LOG_DEBUG("%s: recv NEWKEY %u", ID_CSTR(chatid), keyid);
                 mClient.chats(chatid).onNewKeys(StaticBuffer(keys, totalLen));
                 break;
             }

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1800,8 +1800,16 @@ Idx Chat::msgConfirm(Id msgxid, Id msgid)
         return CHATD_IDX_INVALID;
 
     CHATID_LOG_DEBUG("recv NEWMSGID: '%s' -> '%s'", ID_CSTR(msgxid), ID_CSTR(msgid));
-    //put into history
+
+    // update msgxid to msgid
     msg->setId(msgid, false);
+
+    // set final keyid
+    assert(mCrypto->currentKeyId() != CHATD_KEYID_INVALID);
+    assert(mCrypto->currentKeyId() != CHATD_KEYID_UNCONFIRMED);
+    msg->keyid = mCrypto->currentKeyId();
+
+    // add message to history
     push_forward(msg);
     auto idx = mIdToIndexMap[msgid] = highnum();
     CALL_DB(addMsgToHistory, *msg, idx);

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -478,22 +478,22 @@ void Chat::logSend(const Command& cmd)
         case OP_NEWMSG:
         {
             auto& msgcmd = static_cast<const MsgCommand&>(cmd);
-            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send NEWMSG - msgxid: %s, keyid: %u\n",
-                ID_CSTR(mChatId), ID_CSTR(msgcmd.msgid()), msgcmd.keyId());
+            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send NEWMSG - msgxid: %s, keyid: %u, ts: %u\n",
+                ID_CSTR(mChatId), ID_CSTR(msgcmd.msgid()), msgcmd.keyId(), msgcmd.ts());
             break;
         }
         case OP_MSGUPD:
         {
             auto& msgcmd = static_cast<const MsgCommand&>(cmd);
-            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send MSGUPD - msgid: %s, keyid: %u\n",
-                ID_CSTR(mChatId), ID_CSTR(msgcmd.msgid()), msgcmd.keyId());
+            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send MSGUPD - msgid: %s, keyid: %u, ts: %u, tsdelta: %uh\n",
+                ID_CSTR(mChatId), ID_CSTR(msgcmd.msgid()), msgcmd.keyId(), msgcmd.ts(), msgcmd.updated());
             break;
         }
         case OP_MSGUPDX:
         {
             auto& msgcmd = static_cast<const MsgCommand&>(cmd);
-            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send MSGUPDX - msgxid: %s, keyid: %u, tsdelta: %hu\n",
-                ID_CSTR(mChatId), ID_CSTR(msgcmd.msgid()), msgcmd.keyId(), msgcmd.updated());
+            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send MSGUPDX - msgxid: %s, keyid: %u, ts: %u, tsdelta: %uh\n",
+                ID_CSTR(mChatId), ID_CSTR(msgcmd.msgid()), msgcmd.keyId(), msgcmd.ts());
             break;
         }
         case OP_NEWKEY:

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1752,14 +1752,14 @@ Message* Chat::msgRemoveFromSending(Id msgxid, Id msgid)
         return nullptr;
 
     auto& item = mSending.front();
-    if (item.opcode() != OP_NEWMSG)
+    if (item.opcode() == OP_MSGUPDX)
     {
-//        CHATID_LOG_DEBUG("msgConfirm: sendQueue doesnt start with NEWMSG, but with %s", Command::opcodeToStr(item.opcode()));
+        CHATID_LOG_DEBUG("msgConfirm: sendQueue doesnt start with NEWMSG OR MSGUPD, but with MSGUPDX");
         return nullptr;
     }
-    if (item.msg->id() != msgxid)
+    if ((item.opcode() == OP_NEWMSG) && (item.msg->id() != msgxid))
     {
-//        CHATID_LOG_DEBUG("msgConfirm: sendQueue starts with NEWMSG, but the msgxid is different");
+        CHATID_LOG_DEBUG("msgConfirm: sendQueue starts with NEWMSG, but the msgxid is different");
         return nullptr;
     }
 

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1292,7 +1292,14 @@ void Chat::createMsgBackRefs(Message& msg)
 Chat::SendingItem* Chat::postMsgToSending(uint8_t opcode, Message* msg)
 {
     mSending.emplace_back(opcode, msg, mUsers);
-    CALL_DB(saveMsgToSending, mSending.back());
+
+    auto& item = mSending.back();
+    CALL_DB(saveMsgToSending, item);
+    if (opcode == OP_MSGUPD)    // comfirmed messages always use the original key for edits
+    {
+        CALL_DB(confirmKeyOfSendingItem, item.rowid, msg->keyid);
+    }
+
     if (mNextUnsent == mSending.end())
     {
         mNextUnsent--;

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1859,21 +1859,25 @@ void Chat::keyConfirm(KeyId keyxid, KeyId keyid)
 void Chat::rejectMsgupd(Id id, uint8_t serverReason)
 {
     if (mSending.empty())
+    {
         throw std::runtime_error("rejectMsgupd: Send queue is empty");
+    }
 
     auto& front = mSending.front();
     auto opcode = front.opcode();
     if (opcode != OP_MSGUPD && opcode != OP_MSGUPDX)
+    {
         throw std::runtime_error(std::string("rejectMsgupd: Front of send queue does not match - expected opcode MSGUPD or MSGUPDX, actual opcode: ")
         +Command::opcodeToStr(opcode));
+    }
 
     auto& msg = *front.msg;
     if (msg.id() != id)
     {
         std::string errorMsg = "rejectMsgupd: Message msgid/msgxid does not match the one at the front of send queue. Rejected: '";
-        errorMsg.append(msg.id().toString());
-        errorMsg.append("' Sent: '");
         errorMsg.append(id.toString());
+        errorMsg.append("' Sent: '");
+        errorMsg.append(msg.id().toString());
         errorMsg.append("'");
 
         throw std::runtime_error(errorMsg);

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1754,12 +1754,14 @@ Message* Chat::msgRemoveFromSending(Id msgxid, Id msgid)
     auto& item = mSending.front();
     if (item.opcode() == OP_MSGUPDX)
     {
-        CHATID_LOG_DEBUG("msgConfirm: sendQueue doesnt start with NEWMSG OR MSGUPD, but with MSGUPDX");
+        CHATID_LOG_DEBUG("msgConfirm: sendQueue doesnt start with NEWMSG or MSGUPD, but with MSGUPDX");
         return nullptr;
     }
-    if ((item.opcode() == OP_NEWMSG) && (item.msg->id() != msgxid))
+    Id msgxidOri = item.msg->id();
+    if ((item.opcode() == OP_NEWMSG) && (msgxidOri != msgxid))
     {
-        CHATID_LOG_DEBUG("msgConfirm: sendQueue starts with NEWMSG, but the msgxid is different");
+        CHATID_LOG_DEBUG("msgConfirm: sendQueue starts with NEWMSG, but the msgxid is different"
+                         " (sent msgxid: '%s', received '%s')", ID_CSTR(msgxidOri), ID_CSTR(msgxid));
         return nullptr;
     }
 

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -478,22 +478,22 @@ void Chat::logSend(const Command& cmd)
         case OP_NEWMSG:
         {
             auto& msgcmd = static_cast<const MsgCommand&>(cmd);
-            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send NEWMSG - msgxid: %s\n",
-                ID_CSTR(mChatId), ID_CSTR(msgcmd.msgid()));
+            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send NEWMSG - msgxid: %s, keyid: %u\n",
+                ID_CSTR(mChatId), ID_CSTR(msgcmd.msgid()), msgcmd.keyId());
             break;
         }
         case OP_MSGUPD:
         {
             auto& msgcmd = static_cast<const MsgCommand&>(cmd);
-            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send MSGUPD - msgid: %s\n",
-                ID_CSTR(mChatId), ID_CSTR(msgcmd.msgid()));
+            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send MSGUPD - msgid: %s, keyid: %u\n",
+                ID_CSTR(mChatId), ID_CSTR(msgcmd.msgid()), msgcmd.keyId());
             break;
         }
         case OP_MSGUPDX:
         {
             auto& msgcmd = static_cast<const MsgCommand&>(cmd);
-            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send MSGUPDX - msgxid: %s, tsdelta: %hu\n",
-                ID_CSTR(mChatId), ID_CSTR(msgcmd.msgid()), msgcmd.updated());
+            krLoggerLog(krLogChannel_chatd, krLogLevelDebug, "%s: send MSGUPDX - msgxid: %s, keyid: %u, tsdelta: %hu\n",
+                ID_CSTR(mChatId), ID_CSTR(msgcmd.msgid()), msgcmd.keyId(), msgcmd.updated());
             break;
         }
         case OP_NEWKEY:
@@ -848,7 +848,7 @@ void Connection::execCommand(const StaticBuffer& buf)
                 READ_32(msglen, 34);
                 const char* msgdata = buf.readPtr(pos, msglen);
                 pos += msglen;
-                CHATD_LOG_DEBUG("%s: recv %s - msgid: '%s', from user '%s' with keyid %x",
+                CHATD_LOG_DEBUG("%s: recv %s - msgid: '%s', from user '%s' with keyid %u",
                     ID_CSTR(chatid), Command::opcodeToStr(opcode), ID_CSTR(msgid),
                     ID_CSTR(userid), keyid);
 

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1860,14 +1860,24 @@ void Chat::rejectMsgupd(Id id, uint8_t serverReason)
 {
     if (mSending.empty())
         throw std::runtime_error("rejectMsgupd: Send queue is empty");
+
     auto& front = mSending.front();
     auto opcode = front.opcode();
     if (opcode != OP_MSGUPD && opcode != OP_MSGUPDX)
         throw std::runtime_error(std::string("rejectMsgupd: Front of send queue does not match - expected opcode MSGUPD or MSGUPDX, actual opcode: ")
         +Command::opcodeToStr(opcode));
+
     auto& msg = *front.msg;
     if (msg.id() != id)
-        throw std::runtime_error("rejectMsgupd: Message msgid/msgxid does not match the one at the front of send queue");
+    {
+        std::string errorMsg = "rejectMsgupd: Message msgid/msgxid does not match the one at the front of send queue. Rejected: '";
+        errorMsg.append(msg.id().toString());
+        errorMsg.append("' Sent: '");
+        errorMsg.append(id.toString());
+        errorMsg.append("'");
+
+        throw std::runtime_error(errorMsg);
+    }
 
     /* Server reason:
         0 - insufficient privs or not in chat

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -897,11 +897,6 @@ void Connection::execCommand(const StaticBuffer& buf)
             {
                 READ_ID(msgxid, 0);
                 READ_ID(msgid, 8);
-                if (!msgid)
-                {
-                    CHATD_LOG_ERROR("MSGID with zero message id received, ignoring");
-                    break;
-                }
                 CHATD_LOG_DEBUG("recv MSGID: '%s' -> '%s'", ID_CSTR(msgxid), ID_CSTR(msgid));
                 mClient.onMsgAlreadySent(msgxid, msgid);
                 break;

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -958,12 +958,12 @@ void Connection::execCommand(const StaticBuffer& buf)
                 chat.onHistDone();
                 break;
             }
-            case OP_KEYID:
+            case OP_NEWKEYID:
             {
                 READ_CHATID(0);
                 READ_32(keyxid, 8);
                 READ_32(keyid, 12);
-                CHATD_LOG_DEBUG("%s: recv KEYID: %u -> %u", ID_CSTR(chatid), keyxid, keyid);
+                CHATD_LOG_DEBUG("%s: recv NEWKEYID: %u -> %u", ID_CSTR(chatid), keyxid, keyid);
                 mClient.chats(chatid).keyConfirm(keyxid, keyid);
                 break;
             }
@@ -1635,7 +1635,7 @@ void Chat::flushOutputQueue(bool fromStart)
 //Indeed, if we flush the send queue from the start, this means that
 //the crypto module would get out of sync with the I/O sequence, which means
 //that it must have been reset/freshly initialized, and we have to skip
-//the KEYID responses for the keys we flush from the output queue
+//the NEWKEYID responses for the keys we flush from the output queue
     if(mEncryptionHalted || !mConnection.isLoggedIn())
         return;
 
@@ -2722,7 +2722,7 @@ const char* Command::opcodeToStr(uint8_t opcode)
         RET_ENUM_NAME(BROADCAST);
         RET_ENUM_NAME(HISTDONE);
         RET_ENUM_NAME(NEWKEY);
-        RET_ENUM_NAME(KEYID);
+        RET_ENUM_NAME(NEWKEYID);
         RET_ENUM_NAME(JOINRANGEHIST);
         RET_ENUM_NAME(MSGUPDX);
         RET_ENUM_NAME(MSGID);

--- a/src/chatdDb.h
+++ b/src/chatdDb.h
@@ -66,7 +66,7 @@ public:
         item.recipients.save(rcpts);
         mDb.query("insert into sending (chatid, opcode, ts, msgid, msg, type, updated, "
                          "recipients, backrefid, backrefs) values(?,?,?,?,?,?,?,?,?,?)",
-            (uint64_t)mMessages.chatId(), item.opcode(), (int)time(NULL), msg->id(),
+            (uint64_t)mMessages.chatId(), item.opcode(), msg->ts, msg->id(),
             *msg, msg->type, msg->updated, rcpts, msg->backRefId, msg->backrefBuf());
         item.rowid = sqlite3_last_insert_rowid(mDb);
     }

--- a/src/chatdICrypto.h
+++ b/src/chatdICrypto.h
@@ -94,6 +94,7 @@ public:
      */
     virtual void onKeyConfirmed(KeyId keyxid, KeyId keyid)  = 0;
 
+    virtual KeyId currentKeyId() const = 0;
 /**
  * @brief Invalidates the current send key, forcing a new send key to be generated
  * and posted on next message encrypt.

--- a/src/chatdICrypto.h
+++ b/src/chatdICrypto.h
@@ -61,34 +61,16 @@ public:
  * that message instead of the 0xffffffff keyid.
  */
     virtual promise::Promise<std::pair<MsgCommand*, KeyCommand*> >
-    msgEncrypt(Message* msg, MsgCommand* cmd)
-    {
-        promise::Promise<std::pair<MsgCommand*, KeyCommand*>> pms;
-        karere::setTimeout([pms, msg, cmd]() mutable
-        {
-            cmd->setMsg(msg->buf(), msg->dataSize());
-            cmd->setKeyId(1);
-            msg->keyid = 1;
-            pms.resolve(std::make_pair(cmd, (KeyCommand*)nullptr));
-        }, 2000, appCtx);
-        return pms;
-    }
+    msgEncrypt(Message* msg, MsgCommand* cmd) = 0;
+
 /**
  * @brief Called by the client for received messages to decrypt them.
  * The crypto module \b must also set the type of the message, so that the client
  * knows whether to pass it to the application (i.e. contains an actual message)
  * or should not (i.e. contains a crypto system packet)
  */
-    virtual promise::Promise<Message*> msgDecrypt(Message* src)
-    { //test implementation
-        promise::Promise<Message*> pms;
-        int delay = rand() % 400+20;
-        karere::setTimeout([src, pms]() mutable
-        {
-            pms.resolve(src);
-        }, delay, appCtx);
-        return pms;
-    }
+    virtual promise::Promise<Message*> msgDecrypt(Message* src) = 0;
+
 /**
  * @brief The chatroom connection (to the chatd server shard) state state has changed.
  */

--- a/src/chatdICrypto.h
+++ b/src/chatdICrypto.h
@@ -88,7 +88,12 @@ public:
  */
     virtual void onKeyReceived(KeyId keyid, karere::Id sender, karere::Id receiver,
         const char* keydata, uint16_t keylen) = 0;
+
+    /**
+     * @brief A new key sent to server has been confirmed by the server, and added to Chat.keys
+     */
     virtual void onKeyConfirmed(KeyId keyxid, KeyId keyid)  = 0;
+
 /**
  * @brief Invalidates the current send key, forcing a new send key to be generated
  * and posted on next message encrypt.

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -174,7 +174,7 @@ enum Opcode
       * Send: <chatid> <keyxid> <payload>
       *
       * S->C: Key notification. Payload format is (userid.8 keyid.4 keylen.2 key)*
-      * Receive: <chatid> <keyxid> <payload>
+      * Receive: <chatid> <keyid> <payload>
       *
       * Keep <keyxid> as constant as possible (e.g. 0xffffffff).
       * Note that ( chatid, userid, keyid ) is unique. Neither ( chatid, keyid ) nor

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -187,7 +187,7 @@ enum Opcode
       * S->C: Signal the final <keyid> for a newly allocated key.
       * Receive: <chatid> <keyxid> <keyid>
       */
-    OP_KEYID = 18,
+    OP_NEWKEYID = 18,
 
     /**
       * @brief

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -495,6 +495,7 @@ public:
     }
     uint32_t msglen() const { return read<uint32_t>(35); }
     uint16_t updated() const { return read<uint16_t>(29); }
+    uint32_t ts() const { return read<uint32_t>(25); }
     void clearMsg()
     {
         if (msglen() > 0)

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2292,7 +2292,7 @@ public:
      * When an already delivered message (MegaChatMessage::STATUS_DELIVERED) is edited, the status 
      * of the message will change from STATUS_SENDING directly to STATUS_DELIVERED again, without
      * the transition through STATUS_SERVER_RECEIVED. In other words, the protocol doesn't allow
-     * to know when an edit has been delived to the target user, but only when the edit has been
+     * to know when an edit has been delivered to the target user, but only when the edit has been
      * received by the server, so for convenience the status of the original message is kept.
      * @note if MegaChatApi::isMessageReceptionConfirmationActive returns false, messages may never
      * reach the status delivered, since the target user will not send the required acknowledge to the

--- a/src/strongvelope/strongvelope.cpp
+++ b/src/strongvelope/strongvelope.cpp
@@ -1023,7 +1023,7 @@ void ProtocolHandler::onKeyConfirmed(uint32_t keyxid, uint32_t keyid)
     if (!mCurrentKey || (mCurrentKeyId != CHATD_KEYID_UNCONFIRMED))
         throw std::runtime_error("strongvelope: setCurrentKeyId: Current send key is not unconfirmed");
     if (keyxid != CHATD_KEYID_UNCONFIRMED)
-        throw std::runtime_error("strongvelope: setCurrentKeyId: Usage error: trying to set keyid to the UNOCNFIRMED value");
+        throw std::runtime_error("strongvelope: setCurrentKeyId: Usage error: trying to set keyid to the UNCONFIRMED value");
 
     mUnconfirmedKeyCmd.reset();
     mCurrentKeyId = keyid;

--- a/src/strongvelope/strongvelope.cpp
+++ b/src/strongvelope/strongvelope.cpp
@@ -696,7 +696,7 @@ ProtocolHandler::msgEncrypt(Message* msg, MsgCommand* msgCmd)
     if ((msg->keyid == CHATD_KEYID_INVALID)
      || (msg->keyid == CHATD_KEYID_UNCONFIRMED)) //we have to use the current send key
     {
-        if (!mCurrentKey || mParticipantsChanged)
+        if (!mCurrentKey || mParticipantsChanged) // create a new key and prepare the KeyCommand
         {
             auto wptr = weakHandle();
             return updateSenderKey()

--- a/src/strongvelope/strongvelope.h
+++ b/src/strongvelope/strongvelope.h
@@ -327,6 +327,7 @@ protected:
         legacyExtractKeys(const std::shared_ptr<ParsedMessage>& parsedMsg);
 public:
 //chatd::ICrypto interface
+        uint32_t currentKeyId() const { return mCurrentKeyId; }
         promise::Promise<std::pair<chatd::MsgCommand*, chatd::KeyCommand*>>
             msgEncrypt(chatd::Message *message, chatd::MsgCommand* msgCmd);
         virtual promise::Promise<chatd::Message*> msgDecrypt(chatd::Message* message);

--- a/src/strongvelope/strongvelope.h
+++ b/src/strongvelope/strongvelope.h
@@ -25,8 +25,6 @@
 #define STRONGVELOPE_LOG_WARNING(fmtString,...) KARERE_LOG_WARNING(krLogChannel_strongvelope, "%s: " fmtString, chatid.toString().c_str(), ##__VA_ARGS__)
 #define STRONGVELOPE_LOG_ERROR(fmtString,...) KARERE_LOG_ERROR(krLogChannel_strongvelope, "%s: " fmtString, chatid.toString().c_str(), ##__VA_ARGS__)
 
-#define SVCRYPTO_ERRTYPE 0x3e9a5419 //should resemble megasvlp
-
 //NOTE: In C/C++ it should be avoided to have enum constant names with all capital
 //letters, because of possible conflicts with macros defined by other libs.
 //As enums can be naturally namespaced, their names are usually short


### PR DESCRIPTION
For new messages that are sent along with new keys, the `keyid` is set to
`CHATD_KEYID_INVALID` and it's never updated to its final `keyid`. Fixed!

Additionally, allow first message in sending queue to be the edition of an already confirmed message, not restrict it to a new message.

Also, reuse the `ts` of a `NEWMSG` for the `MSGUPDX`, which was updated (only in cache)