### PR TITLE
WIP: Improve detection of dead socket [obsolete]

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -194,7 +194,10 @@ void Client::heartbeat()
     }
 
     mPresencedClient.heartbeat();
-    //TODO: implement in chatd as well
+    if (chatd)
+    {
+        chatd->heartbeat();
+    }
 }
 
 Client::~Client()

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -900,7 +900,7 @@ void Connection::execCommand(const StaticBuffer& buf)
         {
             case OP_KEEPALIVE:
             {
-                CHATD_LOG_DEBUG("%s: recv KEEPALIVE - shard %d", ID_CSTR(chatid), mShardNo);
+                CHATD_LOG_DEBUG("shard %d: recv KEEPALIVE", mShardNo);
                 sendKeepalive(mClient.mKeepaliveType);
                 break;
             }

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -314,7 +314,7 @@ class Connection: public karere::DeleteTrackable, public WebsocketsClient
 {
 public:
     enum State { kStateNew, kStateFetchingUrl, kStateDisconnected, kStateResolving, kStateConnecting, kStateConnected, kStateLoggedIn };
-    enum { kIdleTimeout = 10 };
+    enum { kIdleTimeout = 64 }; // chatd closes connection after 48-64s of not receiving a response
 
 protected:
     Client& mClient;
@@ -354,7 +354,7 @@ protected:
     void hist(karere::Id chatid, long count);
     bool sendCommand(Command&& cmd); // used internally only for OP_HELLO
     void execCommand(const StaticBuffer& buf);
-    bool sendKeepalive(uint8_t opcode);
+    void sendKeepalive(uint8_t opcode);
     friend class Client;
     friend class Chat;
 public:

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -276,7 +276,18 @@ enum Opcode
       * send KEEPALIVEAWAY
       */
     OP_KEEPALIVEAWAY = 30,
-    OP_LAST = OP_KEEPALIVEAWAY
+
+    /**
+      * @brief <randomToken>
+      *
+      * C->S: send an echo packet with 1byte payload. Server will respond with the
+      * same byte in return.
+      *
+      * This command helps to detect a broken socket when it silently dies.
+      */
+    OP_ECHO = 32,
+
+    OP_LAST = OP_ECHO
 };
 
 // privilege levels

--- a/src/net/libwebsocketsIO.cpp
+++ b/src/net/libwebsocketsIO.cpp
@@ -29,16 +29,9 @@ LibwebsocketsIO::LibwebsocketsIO(::mega::Mutex *mutex, ::mega::Waiter* waiter, v
     info.options |= LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
     info.options |= LWS_SERVER_OPTION_DISABLE_OS_CA_CERTS;
     info.options |= LWS_SERVER_OPTION_LIBUV;
-    info.ka_time = 10;
-    info.ka_probes = 1;
-    info.ka_interval = 1;
-//    info.ws_ping_pong_interval = 5;
-
-    lws_set_log_level(LLL_ERR | LLL_INFO | LLL_USER | LLL_WARN | LLL_COUNT
-                      | LLL_CLIENT | LLL_HEADER | LLL_NOTICE
-                      | LLL_LATENCY, NULL);
     
-//    lws_set_log_level(LLL_ERR | LLL_WARN, NULL);
+    lws_set_log_level(LLL_ERR | LLL_WARN, NULL);
+
     wscontext = lws_create_context(&info);
 
     ::mega::LibuvWaiter *libuvWaiter = dynamic_cast<::mega::LibuvWaiter *>(waiter);

--- a/src/net/libwebsocketsIO.cpp
+++ b/src/net/libwebsocketsIO.cpp
@@ -29,8 +29,16 @@ LibwebsocketsIO::LibwebsocketsIO(::mega::Mutex *mutex, ::mega::Waiter* waiter, v
     info.options |= LWS_SERVER_OPTION_DO_SSL_GLOBAL_INIT;
     info.options |= LWS_SERVER_OPTION_DISABLE_OS_CA_CERTS;
     info.options |= LWS_SERVER_OPTION_LIBUV;
+    info.ka_time = 10;
+    info.ka_probes = 1;
+    info.ka_interval = 1;
+//    info.ws_ping_pong_interval = 5;
+
+    lws_set_log_level(LLL_ERR | LLL_INFO | LLL_USER | LLL_WARN | LLL_COUNT
+                      | LLL_CLIENT | LLL_HEADER | LLL_NOTICE
+                      | LLL_LATENCY, NULL);
     
-    lws_set_log_level(LLL_ERR | LLL_WARN, NULL);
+//    lws_set_log_level(LLL_ERR | LLL_WARN, NULL);
     wscontext = lws_create_context(&info);
 
     ::mega::LibuvWaiter *libuvWaiter = dynamic_cast<::mega::LibuvWaiter *>(waiter);

--- a/src/net/libwebsocketsIO.cpp
+++ b/src/net/libwebsocketsIO.cpp
@@ -283,7 +283,7 @@ static bool check_public_key(X509_STORE_CTX* ctx)
 int LibwebsocketsClient::wsCallback(struct lws *wsi, enum lws_callback_reasons reason,
                                     void *user, void *data, size_t len)
 {
-    WEBSOCKETS_LOG_DEBUG("wsCallback() received: %d", reason);
+//    WEBSOCKETS_LOG_DEBUG("wsCallback() received: %d", reason);
 
     switch (reason)
     {

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -70,7 +70,7 @@ inline const char* Presence::toString(Code pres)
 
 namespace presenced
 {
-enum { kIdleTimeout = 10 };
+enum { kIdleTimeout = 25 };
 enum: karere::Presence::Code
 {
     kPresFlagsMask = 0xf0,

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -70,7 +70,7 @@ inline const char* Presence::toString(Code pres)
 
 namespace presenced
 {
-enum { kIdleTimeout = 5, kKeepaliveSendInterval = 25, kKeepaliveReplyTimeout = 10 };
+enum { kIdleTimeout = 10 };
 enum: karere::Presence::Code
 {
     kPresFlagsMask = 0xf0,

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -70,7 +70,7 @@ inline const char* Presence::toString(Code pres)
 
 namespace presenced
 {
-enum { kKeepaliveSendInterval = 25, kKeepaliveReplyTimeout = 15 };
+enum { kIdleTimeout = 5, kKeepaliveSendInterval = 25, kKeepaliveReplyTimeout = 10 };
 enum: karere::Presence::Code
 {
     kPresFlagsMask = 0xf0,
@@ -262,9 +262,8 @@ protected:
     Config mConfig;
     bool mLastSentUserActive = false;
     time_t mTsLastUserActivity = 0;
-    time_t mTsLastPingSent = 0;
+    bool mKeepaliveSent = false;
     time_t mTsLastRecv = 0;
-    time_t mTsLastSend = 0;
     bool mPrefsAckWait = false;
     IdRefMap mCurrentPeers;
     void initWebsocketCtx();
@@ -292,7 +291,7 @@ protected:
     void pushPeers();
     void configChanged();
     std::string prefsString() const;
-    bool sendKeepalive(time_t now=0);
+    bool sendKeepalive();
     
 public:
     Client(MyMegaApi *api, karere::Client *client, Listener& listener, uint8_t caps);


### PR DESCRIPTION
Revamping of the logic under `KEEPALIVE`s for both presenced and chatd.
Pending to adjust idle time to (chatd) retry connection / (presenced) send a keepalive.