### PR TITLE
Improve behavior when system has a call collision

### DIFF
--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -575,6 +575,11 @@ MegaChatCall *MegaChatApi::getChatCallByChatId(MegaChatHandle chatId)
     return pImpl->getChatCallByChatId(chatId);
 }
 
+int MegaChatApi::getCallsNumber()
+{
+    return pImpl->getCallsNumber();
+}
+
 void MegaChatApi::addChatCallListener(MegaChatCallListener *listener)
 {
     pImpl->addChatCallListener(listener);

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -575,9 +575,9 @@ MegaChatCall *MegaChatApi::getChatCallByChatId(MegaChatHandle chatId)
     return pImpl->getChatCallByChatId(chatId);
 }
 
-int MegaChatApi::getCallsNumber()
+int MegaChatApi::getNumCalls()
 {
-    return pImpl->getCallsNumber();
+    return pImpl->getNumCalls();
 }
 
 void MegaChatApi::addChatCallListener(MegaChatCallListener *listener)

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2841,6 +2841,12 @@ public:
      */
     MegaChatCall *getChatCallByChatId(MegaChatHandle chatId);
 
+    /**
+     * @brief Returns number of calls that there are at the system
+     * @return number of calls in the system
+     */
+    int getCallsNumber();
+
 #endif
 
     // Listeners

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2845,7 +2845,7 @@ public:
      * @brief Returns number of calls that there are at the system
      * @return number of calls in the system
      */
-    int getCallsNumber();
+    int getNumCalls();
 
 #endif
 

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -2569,7 +2569,7 @@ MegaChatCall *MegaChatApiImpl::getChatCallByChatId(MegaChatHandle chatId)
 
 }
 
-int MegaChatApiImpl::getCallsNumber()
+int MegaChatApiImpl::getNumCalls()
 {
     int callsNumber = 0;
     sdkMutex.lock();

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -2569,6 +2569,16 @@ MegaChatCall *MegaChatApiImpl::getChatCallByChatId(MegaChatHandle chatId)
 
 }
 
+int MegaChatApiImpl::getCallsNumber()
+{
+    int callsNumber = 0;
+    sdkMutex.lock();
+    callsNumber = callHandlers.size();
+    sdkMutex.unlock();
+
+    return callsNumber;
+}
+
 void MegaChatApiImpl::addChatCallListener(MegaChatCallListener *listener)
 {
     if (!listener)

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -2768,12 +2768,6 @@ void MegaChatApiImpl::onIncomingContactRequest(const MegaContactRequest &req)
 
 rtcModule::ICallHandler *MegaChatApiImpl::onIncomingCall(rtcModule::ICall& call)
 {
-    if (findChatCallHandler(call.chat().chatId()))
-    {
-        assert(false);
-        API_LOG_ERROR("Incoming call for a chatid which already has a call");
-    }
-
     MegaChatCallHandler *chatCallHandler = new MegaChatCallHandler(this);
     chatCallHandler->setCall(&call);
     MegaChatHandle chatid = call.chat().chatId();
@@ -5301,7 +5295,12 @@ void MegaChatCallHandler::onDestroy(rtcModule::TermCode reason, bool byPeer, con
     assert(chatCall != NULL);
     if (chatCall != NULL)
     {
-        megaChatApi->removeChatCallHandler(chatCall->getChatid());
+        MegaChatHandle chatid = chatCall->getChatid();
+
+        if (megaChatApi->findChatCallHandler(chatid) == this)
+        {
+            megaChatApi->removeChatCallHandler(chatCall->getChatid());
+        }
     }
     else
     {

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -937,7 +937,7 @@ public:
     void loadAudioVideoDeviceList(MegaChatRequestListener *listener = NULL);
     MegaChatCall *getChatCall(MegaChatHandle callId);
     MegaChatCall *getChatCallByChatId(MegaChatHandle chatId);
-    int getCallsNumber();
+    int getNumCalls();
 #endif
 
 //    MegaChatCallPrivate *getChatCallByPeer(const char* jid);

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -937,8 +937,7 @@ public:
     void loadAudioVideoDeviceList(MegaChatRequestListener *listener = NULL);
     MegaChatCall *getChatCall(MegaChatHandle callId);
     MegaChatCall *getChatCallByChatId(MegaChatHandle chatId);
-
-
+    int getCallsNumber();
 #endif
 
 //    MegaChatCallPrivate *getChatCallByPeer(const char* jid);

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -293,29 +293,22 @@ void RtcModule::msgCallRequest(RtMessage& packet)
         if (iteratorCall != mCalls.end())
         {
             Call *existingCall = iteratorCall->second.get();
-            if (existingCall->state() >= Call::kStateJoining)
+            if (existingCall->state() >= Call::kStateJoining || existingCall->isJoiner())
             {
                 cmdEndpoint(RTCMD_CALL_REQ_DECLINE, packet, packet.callid, TermCode::kBusy);
                 return;
             }
-            else if (existingCall->isJoiner())
-            {
-                cmdEndpoint(RTCMD_CALL_REQ_DECLINE, packet, packet.callid, TermCode::kBusy);
-                return;
-            }
-            else if (mClient.myHandle() < packet.userid)
-            {
-                // hang up existing call and answer automatically incoming call
-                avFlags = existingCall->sentAv();
-                answerAutomatic = true;
-                existingCall->hangup();
-                mCalls.erase(chatId);
-            }
-            else
+            else if (mClient.myHandle() > packet.userid)
             {
                 RTCM_LOG_DEBUG("msgCallRequest: Waiting for the other peer hangup its incoming call and answer our call");
                 return;
             }
+
+            // hang up existing call and answer automatically incoming call
+            avFlags = existingCall->sentAv();
+            answerAutomatic = true;
+            existingCall->hangup();
+            mCalls.erase(chatId);
         }
     }
 

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -1184,6 +1184,16 @@ void Call::hangup(TermCode reason)
 }
 Call::~Call()
 {
+    if (mState != Call::kStateDestroyed)
+    {
+        stopIncallPingTimer();
+        mLocalPlayer.reset();
+        setState(Call::kStateDestroyed);
+        FIRE_EVENT(CALL, onDestroy, TermCode::kErrInternal, false, "Callback from Call::dtor");// jscs:ignore disallowImplicitTypeConversion
+        mManager.removeCall(*this);
+        SUB_LOG_DEBUG("Forced call to onDestroy from call dtor");
+    }
+
     SUB_LOG_DEBUG("Destroyed");
 }
 void Call::onUserOffline(Id userid, uint32_t clientid)

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -1850,9 +1850,11 @@ void Session::submitStats(TermCode termCode, const std::string& errInfo)
         info.caid = mCall.mManager.mOwnAnonId;
         info.aaid = mPeerAnonId;
     }
+      // Send stats is disable temporarily
+//    std::string stats = mStatRecorder->getStats(info);
+//    mCall.mManager.mClient.api.sdk.sendChatStats(stats.c_str());
+
     return;
-    std::string stats = mStatRecorder->getStats(info);
-    mCall.mManager.mClient.api.sdk.sendChatStats(stats.c_str());
 }
 
 // we actually verify the whole SDP, not just the fingerprints

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -282,7 +282,10 @@ void RtcModule::msgCallRequest(RtMessage& packet)
     AvFlags avFlags(false, false);
     bool answerAutomatic = false;
 
-    if (!mCalls.empty())
+    ChatRoom *chatRoom = mClient.chats->at(packet.chatid);
+    assert(chatRoom);
+
+    if (!mCalls.empty() && chatRoom && !chatRoom->isGroup())
     {
         // Two calls at same time in same chat
         karere::Id chatId = packet.chatid;

--- a/src/rtcModule/webrtc.h
+++ b/src/rtcModule/webrtc.h
@@ -262,6 +262,7 @@ public:
     uint32_t callerClient() const { return mCallerClient; }
     void changeHandler(ICallHandler* handler) { mHandler = handler; }
     TermCode termCode() const {return mTermCode; }
+    bool isJoiner() { return mIsJoiner; }
     virtual karere::AvFlags sentAv() const = 0;
     virtual void hangup(TermCode reason=TermCode::kInvalid) = 0;
     virtual bool answer(karere::AvFlags av) = 0;

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -3005,6 +3005,11 @@ void MegaChatApiTest::onChatCallUpdate(MegaChatApi *api, MegaChatCall *call)
             break;
 
         case MegaChatCall::CALL_STATUS_RING_IN:
+            if (api->getCallsNumber() > 1)
+            {
+                api->hangChatCall(call->getChatid());
+            }
+
             mCallReceived[apiIndex] = true;
             mIncomingCallId[apiIndex] = call->getId();
             mCallEmisorId[apiIndex] = call->getChatid();

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -2094,6 +2094,8 @@ void MegaChatApiTest::TEST_Calls(unsigned int a1, unsigned int a2)
 
     ASSERT_CHAT_TEST(megaChatApi[a2]->openChatRoom(chatid, chatroomListener), "Can't open chatRoom account 1");
     loadHistory(a2, chatid, chatroomListener);
+    megaChatApi[a2]->closeChatRoom(chatid, chatroomListener);
+    logout(a2);
 
     bool *audioVideoDeviceListLoaded = &requestFlagsChat[a1][MegaChatRequest::TYPE_LOAD_AUDIO_VIDEO_DEVICES]; *audioVideoDeviceListLoaded = false;
     megaChatApi[a1]->loadAudioVideoDeviceList();
@@ -2116,18 +2118,18 @@ void MegaChatApiTest::TEST_Calls(unsigned int a1, unsigned int a2)
     ASSERT_CHAT_TEST(waitForResponse(callAnswered), "Timeout expired for receiving a call");
     sleep(5);
     std::cerr << "Mute Call" << std::endl;
-    megaChatApi[a1]->disableAudio(chatid);
+    megaChatApi[a1]->disableAudio(mChatIdInProgressCall[a1]);
     sleep(5);
     std::cerr << "Disable Video" << std::endl;
-    megaChatApi[a1]->disableVideo(chatid);
+    megaChatApi[a1]->disableVideo(mChatIdInProgressCall[a1]);
     sleep(5);
     std::cerr << "Unmute Call" << std::endl;
-    megaChatApi[a1]->enableAudio(chatid);
+    megaChatApi[a1]->enableAudio(mChatIdInProgressCall[a1]);
     sleep(5);
     std::cerr << "Enable Video" << std::endl;
-    megaChatApi[a1]->enableVideo(chatid);
+    megaChatApi[a1]->enableVideo(mChatIdInProgressCall[a1]);
 
-    MegaChatCall *chatCall = megaChatApi[a1]->getChatCallByChatId(chatid);
+    MegaChatCall *chatCall = megaChatApi[a1]->getChatCallByChatId(mChatIdInProgressCall[a1]);
     ASSERT_CHAT_TEST(chatCall != NULL, "Invalid chat call at getChatCallByChatId");
 
     MegaChatCall *chatCall2 = megaChatApi[a1]->getChatCall(chatCall->getId());
@@ -2135,10 +2137,10 @@ void MegaChatApiTest::TEST_Calls(unsigned int a1, unsigned int a2)
 
 
     bool *callDestroyed= &mCallDestroyed[a1]; *callDestroyed = false;
-    sleep(10);
+    sleep(5);
     std::cerr << "Finish Call" << std::endl;
     sleep(2);
-    megaChatApi[a1]->hangChatCall(chatid);
+    megaChatApi[a1]->hangChatCall(mChatIdInProgressCall[a1]);
     std::cout << "Call finished." << std::endl;
 
     ASSERT_CHAT_TEST(waitForResponse(callDestroyed), "The call has to be finished");
@@ -2153,21 +2155,21 @@ void MegaChatApiTest::TEST_Calls(unsigned int a1, unsigned int a2)
 
     sleep(5);
     std::cerr << "Mute Call" << std::endl;
-    megaChatApi[a1]->disableAudio(chatid);
+    megaChatApi[a1]->disableAudio(mChatIdInProgressCall[a1]);
     sleep(5);
     std::cerr << "Disable Video" << std::endl;
-    megaChatApi[a1]->disableVideo(chatid);
+    megaChatApi[a1]->disableVideo(mChatIdInProgressCall[a1]);
     sleep(5);
     std::cerr << "Unmute Call" << std::endl;
-    megaChatApi[a1]->enableAudio(chatid);
+    megaChatApi[a1]->enableAudio(mChatIdInProgressCall[a1]);
     sleep(5);
     std::cerr << "Enable Video" << std::endl;
-    megaChatApi[a1]->enableVideo(chatid);
+    megaChatApi[a1]->enableVideo(mChatIdInProgressCall[a1]);
 
     sleep(10);
     std::cerr << "Finish Call" << std::endl;
     sleep(2);
-    megaChatApi[a1]->hangChatCall(chatid);
+    megaChatApi[a1]->hangChatCall(mChatIdInProgressCall[a1]);
     std::cout << "Call finished." << std::endl;
     sleep(5);
 
@@ -2191,7 +2193,7 @@ void MegaChatApiTest::TEST_Calls(unsigned int a1, unsigned int a2)
 //    megaChatApi[a1]->hangChatCall(chatid);
 
     megaChatApi[a1]->closeChatRoom(chatid, chatroomListener);
-    megaChatApi[a2]->closeChatRoom(chatid, chatroomListener);
+
 
     delete audioInDevices;
     audioInDevices = NULL;
@@ -2997,22 +2999,30 @@ void MegaChatApiTest::onChatCallUpdate(MegaChatApi *api, MegaChatCall *call)
         {
         case MegaChatCall::CALL_STATUS_IN_PROGRESS:
             mCallAnswered[apiIndex] = true;
+            mChatIdInProgressCall[apiIndex] = call->getChatid();
             break;
 
         case MegaChatCall::CALL_STATUS_REQUEST_SENT:
             mCallRequestSent[apiIndex] = true;
             mCallRequestSentId[apiIndex] = call->getId();
+            mCallId[apiIndex] = call->getChatid();
             break;
 
         case MegaChatCall::CALL_STATUS_RING_IN:
             if (api->getNumCalls() > 1)
             {
+                // Hangup in progress call and answer the new call
+//                api->hangChatCall(mCallId[apiIndex]);
+//                api->answerChatCall(call->getChatid());
+
+                // Hangup in coming call
                 api->hangChatCall(call->getChatid());
             }
 
             mCallReceived[apiIndex] = true;
             mIncomingCallId[apiIndex] = call->getId();
             mCallEmisorId[apiIndex] = call->getChatid();
+            mCallId[apiIndex] = call->getChatid();
             break;
 
         case MegaChatCall::CALL_STATUS_TERMINATING:

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -3005,7 +3005,7 @@ void MegaChatApiTest::onChatCallUpdate(MegaChatApi *api, MegaChatCall *call)
             break;
 
         case MegaChatCall::CALL_STATUS_RING_IN:
-            if (api->getCallsNumber() > 1)
+            if (api->getNumCalls() > 1)
             {
                 api->hangChatCall(call->getChatid());
             }

--- a/tests/sdk_test/sdk_test.h
+++ b/tests/sdk_test/sdk_test.h
@@ -287,6 +287,9 @@ private:
     bool mCallRequestSent[NUM_ACCOUNTS];
     megachat::MegaChatHandle mCallRequestSentId[NUM_ACCOUNTS];
     megachat::MegaChatHandle mIncomingCallId[NUM_ACCOUNTS];
+
+    megachat::MegaChatHandle mCallId[NUM_ACCOUNTS];
+    megachat::MegaChatHandle mChatIdInProgressCall[NUM_ACCOUNTS];
 #endif
 
     static const std::string DEFAULT_PATH;


### PR DESCRIPTION
- Solve a collision over same chat
- At test, reject incoming call when there is another call in-progress (it's possible uncomment a piece of code and hangup existing call and answer new call)