### PR TITLE
Protect MyListener

### DIFF
--- a/src/sdkApi.h
+++ b/src/sdkApi.h
@@ -46,6 +46,9 @@ public:
     ApiPromise mPromise;
     virtual void onRequestFinish(mega::MegaApi* api, mega::MegaRequest *request, mega::MegaError* e)
     {
+        if (wptr.deleted())
+            return;
+
         std::shared_ptr<::mega::MegaRequest> req(request->copy());
         int errCode = e->getErrorCode();
         karere::marshallCall([this, req, errCode]()


### PR DESCRIPTION
If MegaChatApi has been deleted and the app logs out from MegaApi, but
there are pending requests to MegaApi, MegaApi will call
onRequestFinish() with EACCESS for each pending request, which will
attempt to queue the marshallCall on a deleted MegaChatApi (aka. `appCtx`).