### PR TITLE
Skip presence's notification at termination

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1088,6 +1088,11 @@ void Contact::updatePresence(Presence pres)
 // presenced handlers
 void Client::onPresenceChange(Id userid, Presence pres)
 {
+    if (mInitState == kInitTerminated)
+    {
+        return;
+    }
+
     if (userid == mMyHandle)
     {
         mOwnPresence = pres;


### PR DESCRIPTION
During termination (logout), karere `disconnect()`, which results on a
notification of the online presence right before the logout finishes.
The app attempts to access to the `mClient` at the
`onChatOnlineStatusUpdate()` callback, but due to the thread's
switching, it's too late and the `mClient` is already invalid.
This fix solves the issue by not notifying the invalid presence as
result of disconnect during termination.