### PR TITLE
Fix issue moving msgs to manual sending queue

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1545,12 +1545,7 @@ Chat::SendingItem* Chat::postMsgToSending(uint8_t opcode, Message* msg)
     {
         mNextUnsent--;
     }
-//The mSending queue should not change, as we never delete items upon sending, only upon confirmation
-#ifndef NDEBUG
-    auto save = &mSending.back();
-#endif
     flushOutputQueue();
-    assert(&mSending.back() == save);
     return &mSending.back();
 }
 
@@ -1923,7 +1918,7 @@ void Chat::flushOutputQueue(bool fromStart)
         {
             auto start = mNextUnsent;
             mNextUnsent = mSending.end();
-            // Too old message or edit, or group composition has changed.
+            // Too old message or edit, or group composition has changed, or no write access.
             // Move it and all following items as well
             for (auto it = start; it != mSending.end();)
             {

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1948,8 +1948,22 @@ void Chat::moveItemToManualSending(OutputQueue::iterator it, ManualSendReason re
 
 void Chat::removeManualSend(uint64_t rowid)
 {
-    if (!mDbInterface->deleteManualSendItem(rowid))
-        throw std::runtime_error("Unknown manual send id");
+    try
+    {
+        ManualSendReason reason;
+        Message *msg = getManualSending(rowid, reason);
+        if (msg->id() == mLastTextMsg.id())
+        {
+            findAndNotifyLastTextMsg();
+        }
+        delete msg;
+
+        mDbInterface->deleteManualSendItem(rowid);
+    }
+    catch(std::runtime_error& e)
+    {
+        CHATID_LOG_ERROR("removeManualSend: Unknown manual send id: %s", e.what());
+    }
 }
 
 // after a reconnect, we tell the chatd the oldest and newest buffered message

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2025,7 +2025,7 @@ Message* Chat::msgRemoveFromSending(Id msgxid, Id msgid)
 
     if (!msgid)
     {
-        moveItemToManualSending(mSending.begin(), (mOwnPrivilege == PRIV_RDONLY)
+        moveItemToManualSending(mSending.begin(), (mOwnPrivilege < PRIV_FULL)
             ? kManualSendNoWriteAccess
             : kManualSendGeneralReject); //deletes item
         return nullptr;

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1485,7 +1485,6 @@ void Chat::msgSubmit(Message* msg)
 {
     assert(msg->isSending());
     assert(msg->keyid == CHATD_KEYID_INVALID);
-    postMsgToSending(OP_NEWMSG, msg);
 
     // last text msg stuff
     if (msg->isText())
@@ -1493,6 +1492,8 @@ void Chat::msgSubmit(Message* msg)
         onLastTextMsgUpdated(*msg);
     }
     onMsgTimestamp(msg->ts);
+
+    postMsgToSending(OP_NEWMSG, msg);
 }
 
 void Chat::createMsgBackRefs(Message& msg)

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1904,12 +1904,20 @@ void Chat::flushOutputQueue(bool fromStart)
 
     while (mNextUnsent != mSending.end())
     {
-        ManualSendReason reason =
-             (manualResendWhenUserJoins() && !mNextUnsent->isEdit() && (mNextUnsent->recipients != mUsers))
-            ? kManualSendUsersChanged : kManualSendInvalidReason;
+        ManualSendReason reason = kManualSendInvalidReason;
 
-        if ((reason == kManualSendInvalidReason) && (time(NULL) - mNextUnsent->msg->ts > CHATD_MAX_EDIT_AGE))
+        if (mOwnPrivilege < PRIV_FULL)
+        {
+            reason = kManualSendNoWriteAccess;
+        }
+        else if (manualResendWhenUserJoins() && !mNextUnsent->isEdit() && (mNextUnsent->recipients != mUsers))
+        {
+            reason = kManualSendUsersChanged;
+        }
+        else if ((time(NULL) - mNextUnsent->msg->ts) > CHATD_MAX_EDIT_AGE)
+        {
             reason = kManualSendTooOld;
+        }
 
         if (reason != kManualSendInvalidReason)
         {

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -48,10 +48,10 @@ class ICrypto;
 enum ManualSendReason: uint8_t
 {
     kManualSendInvalidReason = 0,
-    kManualSendUsersChanged = 1, ///< Group chat participants have changed
-    kManualSendTooOld = 2, ///< Message is older than CHATD_MAX_EDIT_AGE seconds
-    kManualSendGeneralReject = 3, ///< chatd rejected the message, for unknown reason
-    kManualSendNoWriteAccess = 4,  ///< Read-only privilege or not belong to the chatroom
+    kManualSendUsersChanged = 1,    ///< Group chat participants have changed
+    kManualSendTooOld = 2,          ///< Message is older than CHATD_MAX_EDIT_AGE seconds
+    kManualSendGeneralReject = 3,   ///< chatd rejected the message, for unknown reason
+    kManualSendNoWriteAccess = 4,   ///< Read-only privilege or not belong to the chatroom
     kManualSendEditNoChange = 6     /// Edit message has same content than message in server
 };
 


### PR DESCRIPTION
A message can be deleted by `postMsgToSending()` in the event our user has no-write-access or the message is too old. In that case, the message is moved into the manual-sending-queue. The intermediate layer immediately deletes the object, which turns the pointer to the message into invalid (and cannot be used for last-
message-stuff).
Furthermore, the `mSending` queue *does* change, since we delete items upon sending
when we know we won't be able to send them, like no write access or message is too old, so the assertion is failed in those cases.