### PR TITLE
Skip reconnect event from SDK while there is a call in progress

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -434,7 +434,13 @@ void Client::onEvent(::mega::MegaApi* api, ::mega::MegaEvent* event)
     case ::mega::MegaEvent::EVENT_DISCONNECT:
     {
         if (connState() == kConnecting || connState() == kConnected)
-        {
+        {            
+#ifndef KARERE_DISABLE_WEBRTC
+            if (rtc && rtc->isCallInProgress())
+            {
+                break;
+            }
+#endif
             auto wptr = weakHandle();
             marshallCall([wptr, this]()
             {


### PR DESCRIPTION
It may happen the SDK doesn't receive any data from server during 10 minutes, so for safety reasons it reconnects to API. That event is notified to MEGAchat, that may have its connections up and running and the user may have an ongoing call. In that case, we don't want to force a reconnect, since obviously the connection is alive due to the call.