### PR TITLE
Fix creation of backrefs

### DIFF
--- a/src/chatd.h
+++ b/src/chatd.h
@@ -1024,7 +1024,7 @@ protected:
     void moveItemToManualSending(OutputQueue::iterator it, ManualSendReason reason);
     void handleTruncate(const Message& msg, Idx idx);
     void deleteMessagesBefore(Idx idx);
-    void createMsgBackRefs(Message& msg);
+    void createMsgBackRefs(OutputQueue::iterator msgit);
     void verifyMsgOrder(const Message& msg, Idx idx);
     /**
      * @brief Initiates replaying of callbacks about unsent messages and unsent


### PR DESCRIPTION
Messages used to be encrypted only once when they were added to the send
queue (and stored encrypted as blobs in the db), so the assumption was
that all messages in the send queue precede the one for which back
references are created. Now messages from the send queue are encrypted
just prior to sending, and if a send queue flush is retried, the
assumption that encrypted message is the last one is no longer true.