### PR TITLE
Persist new peers from chatd

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2230,7 +2230,7 @@ void GroupChatRoom::onUserJoin(Id userid, chatd::Priv privilege)
     else
     {
         auto wptr = weakHandle();
-        addMember(userid, privilege, false)
+        addMember(userid, privilege, true)
         .then([wptr, this]()
         {
             wptr.throwIfDeleted();


### PR DESCRIPTION
In case a new peer join is received first from chatd than from API, the new peer is notified but it was never saved to DB, since upon notificatio from API, the peer was already part of the groupchat. Once the app restarts, the peer was not anymore in the list of peers.