### PR TITLE
Adjust code for invalid presence

### DIFF
--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -1401,7 +1401,7 @@ public:
         STATUS_AWAY       = 2,      /// User is not available
         STATUS_ONLINE     = 3,      /// User is available
         STATUS_BUSY       = 4,      /// User don't expect notifications nor call requests
-        STATUS_INVALID    = 0xFF    /// Invalid value. Presence not received yet
+        STATUS_INVALID    = 15      /// Invalid value. Presence not received yet
     };
 
     enum


### PR DESCRIPTION
The presence status actually use the lower 4 bits of a single byte, but it may contain flags in the higher 4 bits. Hence, to get the status, a flag mask is applied to the presence's value, `~0xF0`. As a result, the invalid presence is `0x0F` instead of `0xFF`.