### PR TITLE
Fix front camera selection for iOS

### DIFF
--- a/src/rtcModule/webrtcAdapter.cpp
+++ b/src/rtcModule/webrtcAdapter.cpp
@@ -127,9 +127,8 @@ void DeviceManager::enumInputDevices()
         char id[kSize] = {0};
         if (info->GetDeviceName(i, name, kSize, id, kSize) != -1)
         {
-            std::string sName = name;
-            std::transform(sName.begin(), sName.end(), sName.begin(), ::tolower);
-            if (sName.find("front") == std::string::npos)
+            std::string sId = id;
+            if (sId.find(":1") == std::string::npos)
             {
                 devices.push_back(cricket::Device(name, id));
             }


### PR DESCRIPTION
- Selects the default front camera by id (com.apple.avfoundation.avcapturedevice.built-in_video:1)
- Solves a bug in some languages that didn't include "front" in the description of the front camera