### PR TITLE
Protect MegaChatApi against client being terminated

### DIFF
--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -1552,6 +1552,9 @@ public:
      *
      * If \c MegaChatApi::init() has not been called yet, this function returns INIT_NOT_DONE
      *
+     * If the chat-engine is being terminated because the session is expired, it returns 10.
+     * If the chat-engine is being logged out, it returns 4.
+     *
      * @return The current initialization state
      */
     int getInitState();

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1187,7 +1187,7 @@ ChatRoom *MegaChatApiImpl::findChatRoom(MegaChatHandle chatid)
 
     sdkMutex.lock();
 
-    if (mClient)
+    if (mClient && !terminating)
     {
         ChatRoomList::iterator it = mClient->chats->find(chatid);
         if (it != mClient->chats->end())
@@ -1207,7 +1207,7 @@ karere::ChatRoom *MegaChatApiImpl::findChatRoomByUser(MegaChatHandle userhandle)
 
     sdkMutex.lock();
 
-    if (mClient)
+    if (mClient && !terminating)
     {
         ContactList::iterator it = mClient->contactList->find(userhandle);
         if (it != mClient->contactList->end())
@@ -1588,7 +1588,7 @@ MegaChatPresenceConfig *MegaChatApiImpl::getPresenceConfig()
 
     sdkMutex.lock();
 
-    if (mClient)
+    if (mClient && !terminating)
     {
         const ::presenced::Config &cfg = mClient->presenced().config();
         if (cfg.presence().isValid())
@@ -1641,7 +1641,7 @@ int MegaChatApiImpl::getUserOnlineStatus(MegaChatHandle userhandle)
 
     sdkMutex.lock();
 
-    if (mClient)
+    if (mClient && !terminating)
     {
         ContactList::iterator it = mClient->contactList->find(userhandle);
         if (it != mClient->contactList->end())
@@ -1780,7 +1780,7 @@ MegaChatRoomList *MegaChatApiImpl::getChatRooms()
 
     sdkMutex.lock();
 
-    if (mClient)
+    if (mClient && !terminating)
     {
         ChatRoomList::iterator it;
         for (it = mClient->chats->begin(); it != mClient->chats->end(); it++)
@@ -1834,7 +1834,7 @@ MegaChatListItemList *MegaChatApiImpl::getChatListItems()
 
     sdkMutex.lock();
 
-    if (mClient)
+    if (mClient && !terminating)
     {
         ChatRoomList::iterator it;
         for (it = mClient->chats->begin(); it != mClient->chats->end(); it++)
@@ -1871,7 +1871,7 @@ int MegaChatApiImpl::getUnreadChats()
 
     sdkMutex.lock();
 
-    if (mClient)
+    if (mClient && !terminating)
     {
         ChatRoomList::iterator it;
         for (it = mClient->chats->begin(); it != mClient->chats->end(); it++)
@@ -1895,7 +1895,7 @@ MegaChatListItemList *MegaChatApiImpl::getActiveChatListItems()
 
     sdkMutex.lock();
 
-    if (mClient)
+    if (mClient && !terminating)
     {
         ChatRoomList::iterator it;
         for (it = mClient->chats->begin(); it != mClient->chats->end(); it++)
@@ -1918,7 +1918,7 @@ MegaChatListItemList *MegaChatApiImpl::getInactiveChatListItems()
 
     sdkMutex.lock();
 
-    if (mClient)
+    if (mClient && !terminating)
     {
         ChatRoomList::iterator it;
         for (it = mClient->chats->begin(); it != mClient->chats->end(); it++)
@@ -1941,7 +1941,7 @@ MegaChatListItemList *MegaChatApiImpl::getUnreadChatListItems()
 
     sdkMutex.lock();
 
-    if (mClient)
+    if (mClient && !terminating)
     {
         ChatRoomList::iterator it;
         for (it = mClient->chats->begin(); it != mClient->chats->end(); it++)
@@ -2473,7 +2473,7 @@ void MegaChatApiImpl::saveCurrentState()
 {
     sdkMutex.lock();
 
-    if (mClient)
+    if (mClient && !terminating)
     {
         mClient->saveDb();
     }


### PR DESCRIPTION
If the session expires, the app may access MEGAchat while the client is being destroyed. This commit aims to protect against those cases.