### PR TITLE
Check video flags at StreamPlayer to avoid notify video frames when video is disabled

### DIFF
--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -660,6 +660,8 @@ void Call::getLocalStream(AvFlags av, std::string& errors)
     {
         mLocalPlayer->attachVideo(mLocalStream->video());
     }
+
+    mLocalPlayer->enableVideo(av.video());
 }
 
 void Call::msgCallTerminate(RtMessage& packet)
@@ -1344,6 +1346,7 @@ AvFlags Call::muteUnmute(AvFlags av)
     auto oldAv = mLocalStream->effectiveAv();
     mLocalStream->setAv(av);
     av = mLocalStream->effectiveAv();
+    mLocalPlayer->enableVideo(av.video());
     if (oldAv != av)
     {
         for (auto& item: mSessions)
@@ -1569,6 +1572,7 @@ void Session::onAddStream(artc::tspMediaStream stream)
         FIRE_EVENT(SESS, onVideoRecv);
     });
     mRemotePlayer->attachToStream(stream);
+    mRemotePlayer->enableVideo(mPeerAv.video());
 }
 void Session::onRemoveStream(artc::tspMediaStream stream)
 {
@@ -2043,6 +2047,8 @@ void Session::msgMute(RtMessage& packet)
 {
     auto oldAv = mPeerAv;
     mPeerAv.set(packet.payload.read<uint8_t>(8));
+    mRemotePlayer->enableVideo(mPeerAv.video());
+
     FIRE_EVENT(SESS, onPeerMute, mPeerAv, oldAv);
 }
 


### PR DESCRIPTION
Check video flags at StreamPlayer to avoid notify video frames when video is disabled. If webrtc update the protocol to disable audio/video flow in a session, this commit has to be removed