### PR TITLE
Do not decide locally to move message to manual-sending

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2030,37 +2030,6 @@ void Chat::flushOutputQueue(bool fromStart)
 
     while (mNextUnsent != mSending.end())
     {
-        ManualSendReason reason = kManualSendInvalidReason;
-
-        if (mOwnPrivilege < PRIV_FULL)
-        {
-            reason = kManualSendNoWriteAccess;
-        }
-        else if (manualResendWhenUserJoins() && !mNextUnsent->isEdit() && (mNextUnsent->recipients != mUsers))
-        {
-            reason = kManualSendUsersChanged;
-        }
-        else if ((time(NULL) - mNextUnsent->msg->ts) > CHATD_MAX_EDIT_AGE)
-        {
-            reason = kManualSendTooOld;
-        }
-
-        if (reason != kManualSendInvalidReason)
-        {
-            auto start = mNextUnsent;
-            mNextUnsent = mSending.end();
-            // Too old message or edit, or group composition has changed, or no write access.
-            // Move it and all following items as well
-            for (auto it = start; it != mSending.end();)
-            {
-                auto erased = it;
-                it++;
-                moveItemToManualSending(erased, reason);
-            }
-            CALL_CRYPTO(resetSendKey);
-            return;
-        }
-
         //kickstart encryption
         //return true if we encrypted and sent at least one message
         if (!msgEncryptAndSend(mNextUnsent++))


### PR DESCRIPTION
The message could be already confirmed by server. It's better to send it
and receive the `REJECT` than to move it to the manual-sending-queue
directly, because if the server confirmed the message, we may end up
with the message in the history and the same message in the manual-
sending-queue.
By resending the message, if already confirmed, we will receive a `MSGID` and we can discard the message in the sending status safely.