### PR TITLE
Check if last message needs update upon removal of manual-sending msg

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2083,7 +2083,10 @@ void Chat::removeManualSend(uint64_t rowid)
     {
         ManualSendReason reason;
         Message *msg = getManualSending(rowid, reason);
-        if (msg->id() == mLastTextMsg.id())
+        bool updateLastMsg = (mLastTextMsg.idx() == CHATD_IDX_INVALID) // if not confirmed yet...
+                ? (msg->id() == mLastTextMsg.xid()) // ...and it's the msgxid about to be removed
+                : (msg->id() == mLastTextMsg.id()); // or was confirmed and the msgid is about to be removed (a pending edit)
+        if (updateLastMsg)
         {
             findAndNotifyLastTextMsg();
         }


### PR DESCRIPTION
The last message can be a message in sending status or already confirmed
by server. The check used to assume the last-message was always
confirmed, which is wrong and triggers an assertion.