### PR TITLE
Clean up obsolete code

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1116,8 +1116,7 @@ void Connection::execCommand(const StaticBuffer& buf)
                 }
                 else
                 {
-                    chat.rejectGeneric(op);
-                    //TODO: Implement
+                    chat.rejectGeneric(op, reason);
                 }
                 break;
             }
@@ -2280,22 +2279,9 @@ void Chat::rejectMsgupd(Id id, uint8_t serverReason)
     }
 }
 
-template<bool mustBeInSending>
-void Chat::rejectGeneric(uint8_t opcode)
+void Chat::rejectGeneric(uint8_t /*opcode*/, uint8_t /*reason*/)
 {
-    if (!mustBeInSending)
-        return;
-
-    if (mSending.empty())
-    {
-        throw std::runtime_error("rejectGeneric(mustBeInSending): Send queue is empty");
-    }
-    if (mSending.front().opcode() != opcode)
-    {
-        throw std::runtime_error("rejectGeneric(mustBeInSending): Rejected command is not at the front of the send queue");
-    }
-    CALL_DB(deleteItemFromSending, mSending.front().rowid);
-    mSending.pop_front();
+    //TODO: Implement
 }
 
 void Chat::onMsgUpdated(Message* cipherMsg)

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -1027,8 +1027,7 @@ protected:
     void onJoinRejected();
     void keyConfirm(KeyId keyxid, KeyId keyid);
     void rejectMsgupd(karere::Id id, uint8_t serverReason);
-    template <bool mustBeInSending=false>
-    void rejectGeneric(uint8_t opcode);
+    void rejectGeneric(uint8_t opcode, uint8_t reason);
     void moveItemToManualSending(OutputQueue::iterator it, ManualSendReason reason);
     void handleTruncate(const Message& msg, Idx idx);
     void deleteMessagesBefore(Idx idx);


### PR DESCRIPTION
Rejection of messages are handled at other level nowadays. This obsolete
function does nothing due to the value of `mustBeInSending`. In the
coming weeks we may need to implement a reject for differnt op-codes.