### PR TITLE
Protect access to `mUserLoggers` upon usage

### DIFF
--- a/src/base/logger.cpp
+++ b/src/base/logger.cpp
@@ -181,6 +181,7 @@ void Logger::logv(const char* prefix, krLogLevel level, unsigned flags, const ch
  */
 void Logger::logString(krLogLevel level, const char* msg, unsigned flags, size_t len)
 {
+    LockGuard lock(mMutex);
     if (len == (size_t)-1)
         len = strlen(msg);
 


### PR DESCRIPTION
The list of registered loggers is static and its accesses must be
thread-safe. A `LockGuard` is used to guarantize the concurrent access
to the list of loggers upon addition/removal, but not for the `log()`
itself, which iterates through every registered logger.