### PR TITLE
Add mediainfo to attachment messages

### DIFF
--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -5895,16 +5895,10 @@ const char *JSonUtils::generateAttachNodeJSon(MegaNodeList *nodes)
             jsonNode.AddMember(rapidjson::Value("hash"), fpValue, jSonAttachmentNodes.GetAllocator());
         }
 
-        // fa -> image thumbail
-        if (megaNode->hasThumbnail() || megaNode->hasPreview())
+        // fa -> image thumbnail/preview/mediainfo
+        const char *fa = megaNode->getFileAttrString();
+        if (fa)
         {
-            const char *fa = megaNode->getFileAttrString();
-            if (!fa)
-            {
-                API_LOG_ERROR("Failed to get the fileattribute string of node %d", megaNode->getHandle());
-                return NULL;
-            }
-
             std::string faString(fa);
             delete [] fa;
 


### PR DESCRIPTION
For video files, the preview/thumbnail are set by the app and may not be
already set at the time node is checked to prepare the attachment.
However, the mediainfo (that is used to show the duration of the video)
in already available, so better to always attach the `fileattrstring`
when available.