### PR TITLE
Fix notification of new chatroom

### DIFF
--- a/src/IGui.h
+++ b/src/IGui.h
@@ -360,7 +360,7 @@ public:
      * @brief Called by karere when we become participants in a 1on1 or a group chat.
      * @param room The chat room object.
      */
-    virtual void notifyInvited(const ChatRoom& room) {}
+    virtual void notifyInvited(ChatRoom& room) {}
 
     /** @brief Called when the karere::Client changes its initialization or termination state.
      * Look at karere::Client::InitState for the possible values of the client init

--- a/src/IGui.h
+++ b/src/IGui.h
@@ -356,11 +356,6 @@ public:
      */
     virtual rtcModule::ICallHandler* onIncomingCall(rtcModule::ICall& call, karere::AvFlags av) = 0;
 #endif
-    /**
-     * @brief Called by karere when we become participants in a 1on1 or a group chat.
-     * @param room The chat room object.
-     */
-    virtual void notifyInvited(ChatRoom& room) {}
 
     /** @brief Called when the karere::Client changes its initialization or termination state.
      * Look at karere::Client::InitState for the possible values of the client init

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1756,7 +1756,6 @@ void ChatRoomList::addMissingRoomsFromApi(const mega::MegaTextChatList& rooms, S
 
         ChatRoom* room = addRoom(apiRoom);
         chatids.insert(chatid);
-        client.app.notifyInvited(*room);
 
         if (client.connected())
         {

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2985,7 +2985,7 @@ uint8_t Chat::lastTextMessage(LastTextMsg*& msg)
         return LastTextMsgState::kFetching;
     }
 
-    if (mLastTextMsg.isValid()) // findlLastTextMsg() may have found it locally
+    if (mLastTextMsg.isValid()) // findLastTextMsg() may have found it locally
     {
         msg = &mLastTextMsg;
         return LastTextMsgState::kHave;

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -3013,13 +3013,6 @@ void MegaChatApiImpl::removeChatCallHandler(MegaChatHandle chatid)
 
 #endif
 
-void MegaChatApiImpl::notifyInvited(ChatRoom &room)
-{
-    MegaChatListItemPrivate *item = new MegaChatListItemPrivate(room);
-
-    fireOnChatListItemUpdate(item);
-}
-
 void MegaChatApiImpl::onInitStateChange(int newState)
 {
     API_LOG_DEBUG("Karere initialization state has changed: %d", newState);

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -3013,11 +3013,11 @@ void MegaChatApiImpl::removeChatCallHandler(MegaChatHandle chatid)
 
 #endif
 
-void MegaChatApiImpl::notifyInvited(const ChatRoom &room)
+void MegaChatApiImpl::notifyInvited(ChatRoom &room)
 {
-    MegaChatRoomPrivate *chat = new MegaChatRoomPrivate(room);
+    MegaChatListItemPrivate *item = new MegaChatListItemPrivate(room);
 
-    fireOnChatRoomUpdate(chat);
+    fireOnChatListItemUpdate(item);
 }
 
 void MegaChatApiImpl::onInitStateChange(int newState)

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -965,7 +965,7 @@ public:
 #ifndef KARERE_DISABLE_WEBRTC
     virtual rtcModule::ICallHandler *onIncomingCall(rtcModule::ICall& call, karere::AvFlags av);
 #endif
-    virtual void notifyInvited(const karere::ChatRoom& room);
+    virtual void notifyInvited(karere::ChatRoom& room);
     virtual void onInitStateChange(int newState);
 
     // rtcModule::IChatListHandler implementation

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -965,7 +965,6 @@ public:
 #ifndef KARERE_DISABLE_WEBRTC
     virtual rtcModule::ICallHandler *onIncomingCall(rtcModule::ICall& call, karere::AvFlags av);
 #endif
-    virtual void notifyInvited(karere::ChatRoom& room);
     virtual void onInitStateChange(int newState);
 
     // rtcModule::IChatListHandler implementation


### PR DESCRIPTION
The callback `notifyInvited()` provides the same information (actually
less detailed) than the corresponding `addGroupChatItem()` and
`addPeerChatItem()`. Keeping such callback will result on duplicated
callbacks for the same event.