### PR TITLE
 Move management of MegaChatRoomListener to MegaChatRoomHandler 

### DIFF
--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -662,9 +662,9 @@ void MegaChatApi::addChatRoomListener(MegaChatHandle chatid, MegaChatRoomListene
     pImpl->addChatRoomListener(chatid, listener);
 }
 
-void MegaChatApi::removeChatRoomListener(MegaChatRoomListener *listener)
+void MegaChatApi::removeChatRoomListener(MegaChatHandle chatid, MegaChatRoomListener *listener)
 {
-    pImpl->removeChatRoomListener(listener);
+    pImpl->removeChatRoomListener(chatid, listener);
 }
 
 void MegaChatApi::addChatRequestListener(MegaChatRequestListener *listener)

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2992,7 +2992,7 @@ public:
      *
      * @param listener Object that is unregistered
      */
-    void removeChatRoomListener(MegaChatRoomListener *listener);
+    void removeChatRoomListener(MegaChatHandle chatid, MegaChatRoomListener *listener);
 
     /**
      * @brief Register a listener to receive all events about requests

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1188,7 +1188,16 @@ MegaChatRoomHandler *MegaChatApiImpl::getChatRoomHandler(MegaChatHandle chatid)
 
 void MegaChatApiImpl::removeChatRoomHandler(MegaChatHandle chatid)
 {
-    chatRoomHandler.erase(chatid);
+    map<MegaChatHandle, MegaChatRoomHandler*>::iterator it = chatRoomHandler.find(chatid);
+    if (it == chatRoomHandler.end())
+    {
+        API_LOG_WARNING("removeChatRoomHandler: chatroom handler not found (chatid: %s)", karere::Id(chatid).toString().c_str());
+        return;
+    }
+
+    MegaChatRoomHandler *roomHandler = chatRoomHandler[chatid];
+    chatRoomHandler.erase(it);
+    delete roomHandler;
 }
 
 ChatRoom *MegaChatApiImpl::findChatRoom(MegaChatHandle chatid)

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -2038,10 +2038,8 @@ bool MegaChatApiImpl::openChatRoom(MegaChatHandle chatid, MegaChatRoomListener *
     ChatRoom *chatroom = findChatRoom(chatid);
     if (chatroom)
     {
-        MegaChatRoomHandler *roomHandler = getChatRoomHandler(chatid);
-        roomHandler->addChatRoomListener(listener);
         addChatRoomListener(chatid, listener);
-        chatroom->setAppChatHandler(roomHandler);
+        chatroom->setAppChatHandler(getChatRoomHandler(chatid));
     }
 
     sdkMutex.unlock();

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1382,56 +1382,6 @@ void MegaChatApiImpl::fireOnChatLocalVideoData(MegaChatHandle chatid, int width,
 
 #endif  // webrtc
 
-void MegaChatApiImpl::fireOnChatRoomUpdate(MegaChatRoom *chat)
-{
-    for(set<MegaChatRoomListener *>::iterator it = roomListeners.begin(); it != roomListeners.end() ; it++)
-    {
-        (*it)->onChatRoomUpdate(chatApi, chat);
-    }
-
-    delete chat;
-}
-
-void MegaChatApiImpl::fireOnMessageLoaded(MegaChatMessage *msg)
-{
-    for(set<MegaChatRoomListener *>::iterator it = roomListeners.begin(); it != roomListeners.end() ; it++)
-    {
-        (*it)->onMessageLoaded(chatApi, msg);
-    }
-
-    delete msg;
-}
-
-void MegaChatApiImpl::fireOnMessageReceived(MegaChatMessage *msg)
-{
-    for(set<MegaChatRoomListener *>::iterator it = roomListeners.begin(); it != roomListeners.end() ; it++)
-    {
-        (*it)->onMessageReceived(chatApi, msg);
-    }
-
-    delete msg;
-}
-
-void MegaChatApiImpl::fireOnMessageUpdate(MegaChatMessage *msg)
-{
-    for(set<MegaChatRoomListener *>::iterator it = roomListeners.begin(); it != roomListeners.end() ; it++)
-    {
-        (*it)->onMessageUpdate(chatApi, msg);
-    }
-
-    delete msg;
-}
-
-void MegaChatApiImpl::fireOnHistoryReloaded(MegaChatRoom *chat)
-{
-    for(set<MegaChatRoomListener *>::iterator it = roomListeners.begin(); it != roomListeners.end() ; it++)
-    {
-        (*it)->onHistoryReloaded(chatApi, chat);
-    }
-
-    delete chat;
-}
-
 void MegaChatApiImpl::fireOnChatListItemUpdate(MegaChatListItem *item)
 {
     for(set<MegaChatListener *>::iterator it = listeners.begin(); it != listeners.end() ; it++)
@@ -2079,8 +2029,10 @@ bool MegaChatApiImpl::openChatRoom(MegaChatHandle chatid, MegaChatRoomListener *
     ChatRoom *chatroom = findChatRoom(chatid);
     if (chatroom)
     {
+        MegaChatRoomHandler *roomHandler = getChatRoomHandler(chatid);
+        roomHandler->addChatRoomListener(listener);
         addChatRoomListener(chatid, listener);
-        chatroom->setAppChatHandler(getChatRoomHandler(chatid));
+        chatroom->setAppChatHandler(roomHandler);
     }
 
     sdkMutex.unlock();
@@ -2095,8 +2047,10 @@ void MegaChatApiImpl::closeChatRoom(MegaChatHandle chatid, MegaChatRoomListener 
     if (chatroom)
     {
         chatroom->removeAppChatHandler();
+
+        MegaChatRoomHandler *roomHandler = getChatRoomHandler(chatid);
+        roomHandler->removeChatRoomListener(listener);
         removeChatRoomHandler(chatid);
-        removeChatRoomListener(listener);
     }
 
     sdkMutex.unlock();
@@ -2830,7 +2784,8 @@ void MegaChatApiImpl::addChatRoomListener(MegaChatHandle chatid, MegaChatRoomLis
     }
 
     sdkMutex.lock();
-    roomListeners.insert(listener);
+    MegaChatRoomHandler *roomHandler = getChatRoomHandler(chatid);
+    roomHandler->addChatRoomListener(listener);
     sdkMutex.unlock();
 }
 
@@ -2912,7 +2867,7 @@ void MegaChatApiImpl::removeChatListener(MegaChatListener *listener)
     sdkMutex.unlock();
 }
 
-void MegaChatApiImpl::removeChatRoomListener(MegaChatRoomListener *listener)
+void MegaChatApiImpl::removeChatRoomListener(MegaChatHandle chatid, MegaChatRoomListener *listener)
 {
     if (!listener)
     {
@@ -2920,7 +2875,8 @@ void MegaChatApiImpl::removeChatRoomListener(MegaChatRoomListener *listener)
     }
 
     sdkMutex.lock();
-    roomListeners.erase(listener);
+    MegaChatRoomHandler *roomHandler = getChatRoomHandler(chatid);
+    roomHandler->removeChatRoomListener(listener);
     sdkMutex.unlock();
 }
 
@@ -3853,13 +3809,72 @@ MegaChatRoomHandler::MegaChatRoomHandler(MegaChatApiImpl *chatApi, MegaChatHandl
     this->mChat = NULL;
 }
 
+void MegaChatRoomHandler::addChatRoomListener(MegaChatRoomListener *listener)
+{
+    roomListeners.insert(listener);
+}
+
+void MegaChatRoomHandler::removeChatRoomListener(MegaChatRoomListener *listener)
+{
+    roomListeners.erase(listener);
+}
+
+void MegaChatRoomHandler::fireOnChatRoomUpdate(MegaChatRoom *chat)
+{
+    for(set<MegaChatRoomListener *>::iterator it = roomListeners.begin(); it != roomListeners.end() ; it++)
+    {
+        (*it)->onChatRoomUpdate((MegaChatApi*)chatApi, chat);
+    }
+
+    delete chat;
+}
+
+void MegaChatRoomHandler::fireOnMessageLoaded(MegaChatMessage *msg)
+{
+    for(set<MegaChatRoomListener *>::iterator it = roomListeners.begin(); it != roomListeners.end() ; it++)
+    {
+        (*it)->onMessageLoaded((MegaChatApi*)chatApi, msg);
+    }
+
+    delete msg;
+}
+
+void MegaChatRoomHandler::fireOnMessageReceived(MegaChatMessage *msg)
+{
+    for(set<MegaChatRoomListener *>::iterator it = roomListeners.begin(); it != roomListeners.end() ; it++)
+    {
+        (*it)->onMessageReceived((MegaChatApi*)chatApi, msg);
+    }
+
+    delete msg;
+}
+
+void MegaChatRoomHandler::fireOnMessageUpdate(MegaChatMessage *msg)
+{
+    for(set<MegaChatRoomListener *>::iterator it = roomListeners.begin(); it != roomListeners.end() ; it++)
+    {
+        (*it)->onMessageUpdate((MegaChatApi*)chatApi, msg);
+    }
+
+    delete msg;
+}
+
+void MegaChatRoomHandler::fireOnHistoryReloaded(MegaChatRoom *chat)
+{
+    for(set<MegaChatRoomListener *>::iterator it = roomListeners.begin(); it != roomListeners.end() ; it++)
+    {
+        (*it)->onHistoryReloaded((MegaChatApi*)chatApi, chat);
+    }
+
+    delete chat;
+}
 
 void MegaChatRoomHandler::onUserTyping(karere::Id user)
 {
     MegaChatRoomPrivate *chat = (MegaChatRoomPrivate *) chatApi->getChatRoom(chatid);
     chat->setUserTyping(user.val);
 
-    chatApi->fireOnChatRoomUpdate(chat);
+    fireOnChatRoomUpdate(chat);
 }
 
 void MegaChatRoomHandler::onLastTextMessageUpdated(const chatd::LastTextMsg& msg)
@@ -3883,7 +3898,7 @@ void MegaChatRoomHandler::onLastMessageTsUpdated(uint32_t ts)
 void MegaChatRoomHandler::onHistoryReloaded()
 {
     MegaChatRoomPrivate *chat = (MegaChatRoomPrivate *) chatApi->getChatRoom(chatid);
-    chatApi->fireOnHistoryReloaded(chat);
+    fireOnHistoryReloaded(chat);
 }
 
 bool MegaChatRoomHandler::isRevoked(MegaChatHandle h)
@@ -3973,7 +3988,7 @@ void MegaChatRoomHandler::onMemberNameChanged(uint64_t userid, const std::string
     MegaChatRoomPrivate *chat = (MegaChatRoomPrivate *) chatApi->getChatRoom(chatid);
     chat->setMembersUpdated();
 
-    chatApi->fireOnChatRoomUpdate(chat);
+    fireOnChatRoomUpdate(chat);
 }
 
 void MegaChatRoomHandler::onTitleChanged(const string &title)
@@ -3981,7 +3996,7 @@ void MegaChatRoomHandler::onTitleChanged(const string &title)
     MegaChatRoomPrivate *chat = (MegaChatRoomPrivate *) chatApi->getChatRoom(chatid);
     chat->setTitle(title);
 
-    chatApi->fireOnChatRoomUpdate(chat);
+    fireOnChatRoomUpdate(chat);
 }
 
 void MegaChatRoomHandler::onUnreadCountChanged(int count)
@@ -3989,7 +4004,7 @@ void MegaChatRoomHandler::onUnreadCountChanged(int count)
     MegaChatRoomPrivate *chat = (MegaChatRoomPrivate *) chatApi->getChatRoom(chatid);
     chat->setUnreadCount(count);
 
-    chatApi->fireOnChatRoomUpdate(chat);
+    fireOnChatRoomUpdate(chat);
 }
 
 void MegaChatRoomHandler::init(Chat &chat, DbInterface *&)
@@ -4015,7 +4030,7 @@ void MegaChatRoomHandler::onRecvNewMessage(Idx idx, Message &msg, Message::Statu
     MegaChatMessagePrivate *message = new MegaChatMessagePrivate(msg, status, idx);
     set <MegaChatHandle> *msgToUpdate = handleNewMessage(message);
 
-    chatApi->fireOnMessageReceived(message);
+    fireOnMessageReceived(message);
 
     if (msgToUpdate)
     {
@@ -4025,7 +4040,7 @@ void MegaChatRoomHandler::onRecvNewMessage(Idx idx, Message &msg, Message::Statu
             if (msg)
             {
                 msg->setAccess();
-                chatApi->fireOnMessageUpdate(msg);
+                fireOnMessageUpdate(msg);
             }
         }
         delete msgToUpdate;
@@ -4037,19 +4052,19 @@ void MegaChatRoomHandler::onRecvHistoryMessage(Idx idx, Message &msg, Message::S
     MegaChatMessagePrivate *message = new MegaChatMessagePrivate(msg, status, idx);
     handleHistoryMessage(message);
 
-    chatApi->fireOnMessageLoaded(message);
+    fireOnMessageLoaded(message);
 }
 
 void MegaChatRoomHandler::onHistoryDone(chatd::HistSource /*source*/)
 {
-    chatApi->fireOnMessageLoaded(NULL);
+    fireOnMessageLoaded(NULL);
 }
 
 void MegaChatRoomHandler::onUnsentMsgLoaded(chatd::Message &msg)
 {
     Message::Status status = (Message::Status) MegaChatMessage::STATUS_SENDING;
     MegaChatMessagePrivate *message = new MegaChatMessagePrivate(msg, status, MEGACHAT_INVALID_INDEX);
-    chatApi->fireOnMessageLoaded(message);
+    fireOnMessageLoaded(message);
 }
 
 void MegaChatRoomHandler::onUnsentEditLoaded(chatd::Message &msg, bool oriMsgIsSending)
@@ -4061,7 +4076,7 @@ void MegaChatRoomHandler::onUnsentEditLoaded(chatd::Message &msg, bool oriMsgIsS
     }
     MegaChatMessagePrivate *message = new MegaChatMessagePrivate(msg, Message::kSending, index);
     message->setContentChanged();
-    chatApi->fireOnMessageLoaded(message);
+    fireOnMessageLoaded(message);
 }
 
 void MegaChatRoomHandler::onMessageConfirmed(Id msgxid, const Message &msg, Idx idx)
@@ -4072,7 +4087,7 @@ void MegaChatRoomHandler::onMessageConfirmed(Id msgxid, const Message &msg, Idx 
 
     std::set <MegaChatHandle> *msgToUpdate = handleNewMessage(message);
 
-    chatApi->fireOnMessageUpdate(message);
+    fireOnMessageUpdate(message);
 
     if (msgToUpdate)
     {
@@ -4082,7 +4097,7 @@ void MegaChatRoomHandler::onMessageConfirmed(Id msgxid, const Message &msg, Idx 
             if (msg)
             {
                 msg->setAccess();
-                chatApi->fireOnMessageUpdate(msg);
+                fireOnMessageUpdate(msg);
             }
         }
         delete msgToUpdate;
@@ -4094,14 +4109,14 @@ void MegaChatRoomHandler::onMessageRejected(const Message &msg, uint8_t reason)
     MegaChatMessagePrivate *message = new MegaChatMessagePrivate(msg, Message::kServerRejected, MEGACHAT_INVALID_INDEX);
     message->setStatus(MegaChatMessage::STATUS_SERVER_REJECTED);
     message->setCode(reason);
-    chatApi->fireOnMessageUpdate(message);
+    fireOnMessageUpdate(message);
 }
 
 void MegaChatRoomHandler::onMessageStatusChange(Idx idx, Message::Status newStatus, const Message &msg)
 {
     MegaChatMessagePrivate *message = new MegaChatMessagePrivate(msg, newStatus, idx);
     message->setStatus(newStatus);
-    chatApi->fireOnMessageUpdate(message);
+    fireOnMessageUpdate(message);
 }
 
 void MegaChatRoomHandler::onMessageEdited(const Message &msg, chatd::Idx idx)
@@ -4109,7 +4124,7 @@ void MegaChatRoomHandler::onMessageEdited(const Message &msg, chatd::Idx idx)
     Message::Status status = mChat->getMsgStatus(msg, idx);
     MegaChatMessagePrivate *message = new MegaChatMessagePrivate(msg, status, idx);
     message->setContentChanged();
-    chatApi->fireOnMessageUpdate(message);
+    fireOnMessageUpdate(message);
 }
 
 void MegaChatRoomHandler::onEditRejected(const Message &msg, ManualSendReason reason)
@@ -4125,7 +4140,7 @@ void MegaChatRoomHandler::onEditRejected(const Message &msg, ManualSendReason re
         API_LOG_WARNING("Edit message rejected, reason: %d", reason);
         message->setCode(reason);
     }
-    chatApi->fireOnMessageUpdate(message);
+    fireOnMessageUpdate(message);
 }
 
 void MegaChatRoomHandler::onOnlineStateChange(ChatState state)
@@ -4153,7 +4168,7 @@ void MegaChatRoomHandler::onUserJoin(Id userid, Priv privilege)
         {
             chatroom->setMembersUpdated();
         }
-        chatApi->fireOnChatRoomUpdate(chatroom);
+        fireOnChatRoomUpdate(chatroom);
     }
 }
 
@@ -4166,7 +4181,7 @@ void MegaChatRoomHandler::onUserLeave(Id userid)
 
         MegaChatRoomPrivate *chatroom = new MegaChatRoomPrivate(*mRoom);
         chatroom->setMembersUpdated();
-        chatApi->fireOnChatRoomUpdate(chatroom);
+        fireOnChatRoomUpdate(chatroom);
     }
 }
 
@@ -4175,7 +4190,7 @@ void MegaChatRoomHandler::onRejoinedChat()
     if (mRoom)
     {
         MegaChatRoomPrivate *chatroom = new MegaChatRoomPrivate(*mRoom);
-        chatApi->fireOnChatRoomUpdate(chatroom);
+        fireOnChatRoomUpdate(chatroom);
     }
 }
 
@@ -4185,7 +4200,7 @@ void MegaChatRoomHandler::onExcludedFromChat()
     {
         MegaChatRoomPrivate *chatroom = new MegaChatRoomPrivate(*mRoom);
         chatroom->setClosed();
-        chatApi->fireOnChatRoomUpdate(chatroom);
+        fireOnChatRoomUpdate(chatroom);
     }
 }
 
@@ -4200,7 +4215,7 @@ void MegaChatRoomHandler::onUnreadChanged()
         {
             MegaChatRoomPrivate *chatroom = new MegaChatRoomPrivate(*mRoom);
             chatroom->setUnreadCount(mChat->unreadMsgCount());
-            chatApi->fireOnChatRoomUpdate(chatroom);
+            fireOnChatRoomUpdate(chatroom);
         }
     }
 }
@@ -4213,7 +4228,7 @@ void MegaChatRoomHandler::onManualSendRequired(chatd::Message *msg, uint64_t id,
     message->setStatus(MegaChatMessage::STATUS_SENDING_MANUAL);
     message->setRowId(id); // identifier for the manual-send queue, for removal from queue
     message->setCode(reason);
-    chatApi->fireOnMessageLoaded(message);
+    fireOnMessageLoaded(message);
 }
 
 

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -2055,8 +2055,7 @@ void MegaChatApiImpl::closeChatRoom(MegaChatHandle chatid, MegaChatRoomListener 
     {
         chatroom->removeAppChatHandler();
 
-        MegaChatRoomHandler *roomHandler = getChatRoomHandler(chatid);
-        roomHandler->removeChatRoomListener(listener);
+        removeChatRoomListener(chatid, listener);
         removeChatRoomHandler(chatid);
     }
 

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -352,6 +352,16 @@ class MegaChatRoomHandler :public karere::IApp::IChatHandler
 public:
     MegaChatRoomHandler(MegaChatApiImpl*, MegaChatHandle chatid);
 
+    void addChatRoomListener(MegaChatRoomListener *listener);
+    void removeChatRoomListener(MegaChatRoomListener *listener);
+
+    // MegaChatRoomListener callbacks
+    void fireOnChatRoomUpdate(MegaChatRoom *chat);
+    void fireOnMessageLoaded(MegaChatMessage *msg);
+    void fireOnMessageReceived(MegaChatMessage *msg);
+    void fireOnMessageUpdate(MegaChatMessage *msg);
+    void fireOnHistoryReloaded(MegaChatRoom *chat);
+
     // karere::IApp::IChatHandler implementation
 #ifndef KARERE_DISABLE_WEBRTC
     virtual rtcModule::ICallHandler* callHandler();
@@ -405,6 +415,8 @@ private:
 
     chatd::Chat *mChat;
     karere::ChatRoom *mRoom;
+
+    std::set<MegaChatRoomListener *> roomListeners;
 
     // nodes with granted/revoked access from loaded messsages
     std::map<MegaChatHandle, bool> attachmentsAccess;  // handle, access
@@ -748,7 +760,6 @@ private:
     EventQueue eventQueue;
 
     std::set<MegaChatListener *> listeners;
-    std::set<MegaChatRoomListener *> roomListeners;
     std::set<MegaChatRequestListener *> requestListeners;
 
     std::set<MegaChatPeerListItemHandler *> chatPeerListItemHandler;
@@ -811,7 +822,7 @@ public:
     void addChatRoomListener(MegaChatHandle chatid, MegaChatRoomListener *listener);
     void removeChatRequestListener(MegaChatRequestListener *listener);
     void removeChatListener(MegaChatListener *listener);
-    void removeChatRoomListener(MegaChatRoomListener *listener);
+    void removeChatRoomListener(MegaChatHandle chatid, MegaChatRoomListener *listener);
 #ifndef KARERE_DISABLE_WEBRTC
     void addChatCallListener(MegaChatCallListener *listener);
     void addChatLocalVideoListener(MegaChatVideoListener *listener);
@@ -835,13 +846,6 @@ public:
     void fireOnChatRemoteVideoData(MegaChatHandle chatid, int width, int height, char*buffer);
     void fireOnChatLocalVideoData(MegaChatHandle chatid, int width, int height, char*buffer);
 #endif
-
-    // MegaChatRoomListener callbacks
-    void fireOnChatRoomUpdate(MegaChatRoom *chat);
-    void fireOnMessageLoaded(MegaChatMessage *msg);
-    void fireOnMessageReceived(MegaChatMessage *msg);
-    void fireOnMessageUpdate(MegaChatMessage *msg);
-    void fireOnHistoryReloaded(MegaChatRoom *chat);
 
     // MegaChatListener callbacks (specific ones)
     void fireOnChatListItemUpdate(MegaChatListItem *item);


### PR DESCRIPTION
There was a bug managing listeners registered by the app, `MegaChatRoomListener`. All of them were called when a new event happened in any of the opened chatrooms. This commit associates the listeners to the corresponding handler in order to fix it.