### PR TITLE
Enforce critical section for logger

### DIFF
--- a/src/base/logger.cpp
+++ b/src/base/logger.cpp
@@ -46,6 +46,7 @@ static size_t myStrncpy(char* dest, const char* src, size_t maxCount);
 
 void Logger::logToConsole(bool enable)
 {
+    LockGuard lock(mMutex);
     if (enable)
     {
         if (mConsoleLogger)
@@ -62,6 +63,7 @@ void Logger::logToConsole(bool enable)
 
 void Logger::logToConsoleUseColors(bool useColors)
 {
+    LockGuard lock(mMutex);
     if (mConsoleLogger)
     {
         mConsoleLogger->setUseColors(useColors);
@@ -70,6 +72,7 @@ void Logger::logToConsoleUseColors(bool useColors)
 
 void Logger::logToFile(const char* fileName, size_t rotateSizeKb)
 {
+    LockGuard lock(mMutex);
     if (!fileName) //disable
     {
         mFileLogger.reset();
@@ -81,6 +84,7 @@ void Logger::logToFile(const char* fileName, size_t rotateSizeKb)
 
 void Logger::setAutoFlush(bool enable)
 {
+    LockGuard lock(mMutex);
     if (enable)
         mFlags &= ~krLogNoAutoFlush;
     else

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -96,7 +96,7 @@ public:
     volatile unsigned flags() const { return mFlags;}
     void setFlags(unsigned flags)
     {
-        std::lock_guard<std::recursive_mutex> lock(mMutex);
+        LockGuard lock(mMutex);
         mFlags = flags;
     }
     KarereLogChannel logChannels[krLogChannelCount];


### PR DESCRIPTION
There are crashes reported by iOS team at the `Logger::logString()`,
which we recently found it was not protected against access from
different threads. Now it's protected, but there are other unprotected
accesses that this commit aims to solve.