### PR TITLE
Check cache version during decryption process

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1530,8 +1530,7 @@ void Chat::onEndCall(karere::Id userid, uint32_t clientid)
 
 void Chat::initChat()
 {
-    mBackwardList.clear();
-    mForwardList.clear();
+    clear();
     mIdToIndexMap.clear();
 
     mForwardStart = CHATD_IDX_RANGE_MIDDLE;
@@ -2320,7 +2319,7 @@ void Chat::onMsgUpdated(Message* cipherMsg)
             mSending.erase(erased);
         }
     }
-    mCrypto->msgDecrypt(cipherMsg)
+    mCrypto->msgDecrypt(cipherMsg, &mCacheVersion)
     .then([this](Message* msg)
     {
         assert(!msg->isEncrypted());
@@ -2630,7 +2629,7 @@ bool Chat::msgIncomingAfterAdd(bool isNew, bool isLocal, Message& msg, Idx idx)
         }
     }
     CHATD_LOG_CRYPTO_CALL("Calling ICrypto::decrypt()");
-    auto pms = mCrypto->msgDecrypt(&msg);
+    auto pms = mCrypto->msgDecrypt(&msg, &mCacheVersion);
     if (pms.succeeded())
     {
         assert(!msg.isEncrypted());

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -548,6 +548,7 @@ protected:
     Idx mForwardStart;
     std::vector<std::unique_ptr<Message>> mForwardList;
     std::vector<std::unique_ptr<Message>> mBackwardList;
+    unsigned int mCacheVersion = 0;
     OutputQueue mSending;
     OutputQueue::iterator mNextUnsent;
     bool mIsFirstJoin = true;
@@ -631,6 +632,7 @@ protected:
     Message* newest() const { return (!mForwardList.empty())? mForwardList.back().get() : mBackwardList.front().get(); }
     void clear()
     {
+        mCacheVersion++;
         mBackwardList.clear();
         mForwardList.clear();
     }

--- a/src/chatdICrypto.h
+++ b/src/chatdICrypto.h
@@ -67,9 +67,10 @@ public:
  * @brief Called by the client for received messages to decrypt them.
  * The crypto module \b must also set the type of the message, so that the client
  * knows whether to pass it to the application (i.e. contains an actual message)
- * or should not (i.e. contains a crypto system packet)
+ * or should not (i.e. contains a crypto system packet). In some cases, decryption process can
+ * be asynchronous, if chacheVersion changes during decryption process, the message is skipped
  */
-    virtual promise::Promise<Message*> msgDecrypt(Message* src) = 0;
+    virtual promise::Promise<Message*> msgDecrypt(Message* src, unsigned int *cacheVersion) = 0;
 
 /**
  * @brief The chatroom connection (to the chatd server shard) state state has changed.

--- a/src/strongvelope/strongvelope.cpp
+++ b/src/strongvelope/strongvelope.cpp
@@ -801,7 +801,7 @@ promise::Promise<Message*> ProtocolHandler::handleManagementMessage(
 //is decrypted.
 Promise<Message*> ProtocolHandler::msgDecrypt(Message* message, unsigned int *cacheVersion)
 {
-    assert(cacheVersion == NULL);
+    assert(cacheVersion != NULL);
     try
     {
         if (message->empty())

--- a/src/strongvelope/strongvelope.h
+++ b/src/strongvelope/strongvelope.h
@@ -328,7 +328,7 @@ public:
     uint32_t currentKeyId() const { return mCurrentKeyId; }
     promise::Promise<std::pair<chatd::MsgCommand*, chatd::KeyCommand*>>
     msgEncrypt(chatd::Message *message, chatd::MsgCommand* msgCmd);
-    virtual promise::Promise<chatd::Message*> msgDecrypt(chatd::Message* message);
+    virtual promise::Promise<chatd::Message*> msgDecrypt(chatd::Message* message, unsigned int *cacheVersion);
     virtual void onKeyReceived(uint32_t keyid, karere::Id sender,
         karere::Id receiver, const char* data, uint16_t dataLen);
     virtual void onKeyConfirmed(uint32_t keyxid, uint32_t keyid);


### PR DESCRIPTION
Solve problem when cache is removed and there are messages in decryption procedure. 
We have added a cache version that it is incremented when cache is re-created 
At decryption, we check if cache version has changed during procedure