### PR TITLE
Remove unnecessary assertion

### DIFF
--- a/src/strongvelope/strongvelope.cpp
+++ b/src/strongvelope/strongvelope.cpp
@@ -1041,7 +1041,6 @@ ProtocolHandler::updateSenderKey()
     mParticipantsChanged = false;
 
     // Assemble the output for all recipients.
-    assert(mParticipants && !mParticipants->empty());
     return encryptKeyToAllParticipants(mCurrentKey)
     .then([this](std::pair<KeyCommand*, std::shared_ptr<SendKey>> result)
     {


### PR DESCRIPTION
A user who is alone in a chatroom can still send new messages and post
new keys