### PR TITLE
Send a new JOIN to chatd upon re-join

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2556,6 +2556,13 @@ bool GroupChatRoom::syncWithApi(const mega::MegaTextChat& chat)
     {
         if (mOwnPriv != chatd::PRIV_NOTPRESENT)
         {
+            // if already connected, need to send a new JOIN to chatd
+            if (parent.client.connected())
+            {
+                KR_LOG_DEBUG("Connecting existing room to chatd after re-join...");
+                mChat->connect();
+            }
+
             KR_LOG_DEBUG("Chatroom[%s]: API event: We were reinvited",  Id(mChatid).toString().c_str());
             notifyRejoinedChat();
         }


### PR DESCRIPTION
When client is connected to chatd and the user is removed from a
groupchat, the opened connection will only provide updates on the
existing history (and allow to set the seen-pointer). However, if the
user re-joins (we know that because of the API actionpacket), we need to
send a new JOINRANGEHIST to chatd in order to start receiving new
history.