### PR TITLE
Fix a crash due to illegal access to user-attribute cache

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -418,7 +418,8 @@ promise::Promise<void> Client::initWithNewSession(const char* sid, const std::st
     mMyIdentity = (static_cast<uint64_t>(rand()) << 32) | time(NULL);
     db.query("insert or replace into vars(name,value) values('clientid_seed', ?)", mMyIdentity);
 
-    mUserAttrCache.reset(new UserAttrCache(*this));
+    mUserAttrCache.reset(new UserAttrCache(*this));    
+    api.sdk.addGlobalListener(this);
 
     auto wptr = weakHandle();
     return loadOwnKeysFromApi()
@@ -535,7 +536,8 @@ void Client::initWithDbSession(const char* sid)
         }
         assert(db);
         assert(!mSid.empty());
-        mUserAttrCache.reset(new UserAttrCache(*this));
+        mUserAttrCache.reset(new UserAttrCache(*this));        
+        api.sdk.addGlobalListener(this);
 
         mMyHandle = getMyHandleFromDb();
         assert(mMyHandle);
@@ -586,8 +588,6 @@ Client::InitState Client::init(const char* sid)
         KR_LOG_ERROR("init: karere is already initialized. Current state: %s", initStateStr());
         return kInitErrAlready;
     }
-
-    api.sdk.addGlobalListener(this);
 
     if (sid)
     {


### PR DESCRIPTION
When MEGAchat is initialized without `sid`, the instantiation of the
user-attribute cache (`mUserAttrCache`) is delayed until the completion
of fetchnodes. However, the registration of the `MegaGlobalListener` may
result on calls to `onUsersUpdate()` earlier than the initialization is
done, resulting on segmentation fault.