### PR TITLE
Add support for reject of hist

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1193,6 +1193,10 @@ void Connection::execCommand(const StaticBuffer& buf)
                 {
                     chat.onKeyReject();
                 }
+                else if (op == OP_HIST)
+                {
+                    chat.onHistReject();
+                }
                 else
                 {
                     chat.rejectGeneric(op, reason);
@@ -2342,6 +2346,14 @@ void Chat::keyConfirm(KeyId keyxid, KeyId keyid)
 void Chat::onKeyReject()
 {
     mCrypto->onKeyRejected();
+}
+
+void Chat::onHistReject()
+{
+    CHATID_LOG_WARNING("HIST was rejected, setting chat offline and disabling it");
+    mServerFetchState = kHistNotFetching;
+    setOnlineState(kChatStateOffline);
+    disable(true);
 }
 
 void Chat::rejectMsgupd(Id id, uint8_t serverReason)

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2351,6 +2351,7 @@ void Chat::onKeyReject()
 void Chat::onHistReject()
 {
     CHATID_LOG_WARNING("HIST was rejected, setting chat offline and disabling it");
+    assert(false);  // chatd should not REJECT a HIST, it indicates a more critical issue
     mServerFetchState = kHistNotFetching;
     setOnlineState(kChatStateOffline);
     disable(true);

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -1061,6 +1061,7 @@ protected:
     void onJoinRejected();
     void keyConfirm(KeyId keyxid, KeyId keyid);
     void onKeyReject();
+    void onHistReject();
     void rejectMsgupd(karere::Id id, uint8_t serverReason);
     void rejectGeneric(uint8_t opcode, uint8_t reason);
     void moveItemToManualSending(OutputQueue::iterator it, ManualSendReason reason);


### PR DESCRIPTION
In case chatd rejects a `HIST` opcode, disable the chatroom