### PR TITLE
Resolve promise after cancel timeout

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3112,12 +3112,12 @@ void Chat::setOnlineState(ChatState state)
 
         if (!mClient.karereClient->mSyncPromise.done())
         {
-            mClient.karereClient->mSyncPromise.resolve();
             if (mClient.karereClient->mSyncTimer)
             {
                 cancelTimeout(mClient.karereClient->mSyncTimer, mClient.karereClient->appCtx);
                 mClient.karereClient->mSyncTimer = 0;
             }
+            mClient.karereClient->mSyncPromise.resolve();
         }
     }
 }


### PR DESCRIPTION
Just in case the resolution of the promise executes callbacks and, in
the meantime, the timer expires.