### PR TITLE
Fix out-of-range index upon PUSH

### DIFF
--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -939,7 +939,12 @@ void MegaChatApiImpl::sendPendingRequests()
                     Idx lastSeenIdx = chat.lastSeenIdx();
 
                     // first msg to consider: last-seen if loaded in memory. Otherwise, the oldest loaded msg
-                    Idx first = (lastSeenIdx != CHATD_IDX_INVALID) ? (lastSeenIdx + 1) : chat.lownum();
+                    Idx first = chat.lownum();
+                    if (lastSeenIdx != CHATD_IDX_INVALID        // message is known locally
+                            && chat.findOrNull(lastSeenIdx))    // message is loaded in RAM
+                    {
+                        first = lastSeenIdx + 1;
+                    }
                     Idx last = chat.highnum();
                     int maxCount = 6;   // do not notify more than 6 messages per chat
                     for (Idx i = last; (i >= first && maxCount > 0); i--)

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -502,7 +502,7 @@ const char* MegaChatApiTest::printChatListItemInfo(const MegaChatListItem *item)
     buffer << ", ownPriv: " << item->getOwnPrivilege();
     buffer << ", unread: " << item->getUnreadCount() << ", changes: " << item->getChanges();
     buffer << ", lastMsg: " << item->getLastMessage() << ", lastMsgType: " << item->getLastMessageType();
-    buffer << ", lastTs: " << item->getLastTimestamp() << endl;
+    buffer << ", lastTs: " << item->getLastTimestamp();
 
     return MegaApi::strdup(buffer.str().c_str());
 }


### PR DESCRIPTION
The last seen index may not be loaded in memory, hence accessing to it
will throw an exception.