### PR TITLE
Fix loading conversations in offline mode

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -851,9 +851,9 @@ HistSource Chat::getHistory(unsigned count)
         CALL_LISTENER(onHistoryDone, source);
         return source;
     }
-    if (nextSource == kHistSourceDb)
+    if (nextSource == kHistSourceDb || nextSource == kHistSourceServerOffline)
     {
-        CALL_LISTENER(onHistoryDone, kHistSourceDb);
+        CALL_LISTENER(onHistoryDone, nextSource);
     }
     return nextSource;
 }


### PR DESCRIPTION
Android reported a bug when app is started in offline mode and the
history of a chat is fetched. MEGAchat, once all the history is loaded
in RAM and retrieved by the app, it never calls `onHistoryDone()`
because of the unexpected `nextSource == kHistSourceServerOffline`, so
the app keeps waiting forever for the corresponding
`onMessageLoaded(NULL)`.