### PR TITLE
Fix connection state

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -241,7 +241,7 @@ void Chat::connect()
         });
 
     }
-    else if (mConnection.isConnected() || mConnection.isLoggedIn())
+    else if (mConnection.isConnected())
     {
         login();
     }
@@ -254,6 +254,12 @@ void Chat::disconnect()
 
 void Chat::login()
 {
+    assert(mConnection.isConnected());
+    mUserDump.clear();
+    setOnlineState(kChatStateJoining);
+    // In both cases (join/joinrangehist), don't block history messages being sent to app
+    mServerOldHistCbEnabled = false;
+
     ChatDbInfo info;
     mDbInterface->getHistoryInfo(info);
     mOldestKnownMsgId = info.oldestDbId;
@@ -308,11 +314,12 @@ void Connection::onSocketClose(int errcode, int errtype, const std::string& reas
 
     usingipv6 = !usingipv6;
 
-    if (oldState < kStateLoggedIn) //tell retry controller that the connect attempt failed
+    if (oldState < kStateConnected) //tell retry controller that the connect attempt failed
     {
-        CHATDS_LOG_DEBUG("Socket close and state is not kStateLoggedIn (but %s), start retry controller", connStateToStr(oldState));
+        CHATDS_LOG_DEBUG("Socket close and state is not kStateConnected (but %s), start retry controller", connStateToStr(oldState));
 
         assert(!mLoginPromise.succeeded());
+        assert(!mConnectPromise.succeeded());
         if (!mConnectPromise.done())
         {
             mConnectPromise.reject(reason, errcode, errtype);
@@ -405,7 +412,6 @@ Promise<void> Connection::reconnect()
                 if (!chat.isDisabled())
                     chat.setOnlineState(kChatStateConnecting);                
             }
-
 
             int status = wsResolveDNS(mChatdClient.karereClient->websocketIO, mUrl.host.c_str(),
                          [wptr, this](int status, std::string ipv4, std::string ipv6)
@@ -593,7 +599,7 @@ void Client::heartbeat()
 
 bool Connection::sendBuf(Buffer&& buf)
 {
-    if (!isLoggedIn() && !isConnected())
+    if (!isConnected())
         return false;
     
     bool rc = wsSendMessage(buf.buf(), buf.dataSize());
@@ -768,15 +774,9 @@ promise::Promise<void> Connection::rejoinExistingChats()
 // send JOIN
 void Chat::join()
 {
-//We don't have any local history, otherwise joinRangeHist() would be called instead of this
-//Reset handshake state, as we may be reconnecting
-    assert(mConnection.isConnected() || mConnection.isLoggedIn());
-    mUserDump.clear();
-    setOnlineState(kChatStateJoining);
+    //We don't have any local history, otherwise joinRangeHist() would be called instead of this
+    //Reset handshake state, as we may be reconnecting
     mServerFetchState = kHistNotFetching;
-    //we don't have local history, so mHistSendSource may be None or Server.
-    //In both cases this will not block history messages being sent to app
-    mServerOldHistCbEnabled = false;
     sendCommand(Command(OP_JOIN) + mChatId + mClient.mUserId + (int8_t)PRIV_NOCHANGE);
     requestHistoryFromServer(-initialHistoryFetchCount);
 }
@@ -880,8 +880,8 @@ HistSource Chat::getHistoryFromDbOrServer(unsigned count)
         }
         else
         {
-            if (!mConnection.isLoggedIn())
-                return kHistSourceServerOffline;
+            if (mOnlineState != kChatStateOnline)
+                return kHistSourceNotLoggedIn;
 
             auto wptr = weakHandle();
             marshallCall([wptr, this, count]()
@@ -2113,7 +2113,7 @@ void Chat::flushOutputQueue(bool fromStart)
 //the crypto module would get out of sync with the I/O sequence, which means
 //that it must have been reset/freshly initialized, and we have to skip
 //the NEWKEYID responses for the keys we flush from the output queue
-    if(mEncryptionHalted || !mConnection.isLoggedIn())
+    if (mEncryptionHalted || (mOnlineState != kChatStateOnline))
         return;
 
     if (fromStart)
@@ -2166,11 +2166,7 @@ void Chat::removeManualSend(uint64_t rowid)
 // after a reconnect, we tell the chatd the oldest and newest buffered message
 void Chat::joinRangeHist(const ChatDbInfo& dbInfo)
 {
-    assert(mConnection.isConnected() || mConnection.isLoggedIn());
     assert(dbInfo.oldestDbId && dbInfo.newestDbId);
-    mUserDump.clear();
-    setOnlineState(kChatStateJoining);
-    mServerOldHistCbEnabled = false;
     mServerFetchState = kHistFetchingNewFromServer;
     CHATID_LOG_DEBUG("Sending JOINRANGEHIST based on app db: %s - %s",
             dbInfo.oldestDbId.toString().c_str(), dbInfo.newestDbId.toString().c_str());
@@ -3055,9 +3051,12 @@ void Connection::notifyLoggedIn()
 {
     if (mLoginPromise.done())
         return;
-    mState = kStateLoggedIn;
+
     assert(mConnectPromise.succeeded());
-    mLoginPromise.resolve();
+    if (mChatdClient.areAllChatsLoggedIn())
+    {
+        mLoginPromise.resolve();
+    }
 }
 
 void Chat::onJoinComplete()

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -62,7 +62,7 @@ enum HistSource
     kHistSourceRam = 1, //< History is being retrieved from the history buffer in RAM
     kHistSourceDb = 2, //<History is being retrieved from the local DB
     kHistSourceServer = 3, //< History is being retrieved from the server
-    kHistSourceServerOffline = 4 //< History has to be fetched from server, but we are offline
+    kHistSourceNotLoggedIn = 4 //< History has to be fetched from server, but we are not logged in yet
 };
 /** Timeout to send SEEN (Milliseconds)**/
 enum { kSeenTimeout = 200 };
@@ -339,7 +339,7 @@ class Client;
 class Connection: public karere::DeleteTrackable, public WebsocketsClient
 {
 public:
-    enum State { kStateNew, kStateFetchingUrl, kStateDisconnected, kStateResolving, kStateConnecting, kStateConnected, kStateLoggedIn };
+    enum State { kStateNew, kStateFetchingUrl, kStateDisconnected, kStateResolving, kStateConnecting, kStateConnected};
     enum {
         kIdleTimeout = 64,  // chatd closes connection after 48-64s of not receiving a response
         kEchoTimeout = 1    // echo to check connection is alive when back to foreground
@@ -363,10 +363,6 @@ protected:
     bool isConnected() const
     {
         return mState == kStateConnected;
-    }
-    bool isLoggedIn() const
-    {
-        return mState == kStateLoggedIn;
     }
     
     virtual void wsConnectCb();
@@ -1175,7 +1171,6 @@ static inline const char* connStateToStr(Connection::State state)
     case Connection::State::kStateDisconnected: return "Disconnected";
     case Connection::State::kStateConnecting: return "Connecting";
     case Connection::State::kStateConnected: return "Connected";
-    case Connection::State::kStateLoggedIn: return "Logged-in";
     case Connection::State::kStateNew: return "New";
     case Connection::State::kStateFetchingUrl: return "Fetching URL";
     default: return "(invalid)";

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -655,7 +655,13 @@ static inline std::string& operator+(std::string&& str, karere::Id id)
 }
 
 enum ChatState
-{kChatStateOffline = 0, kChatStateConnecting, kChatStateJoining, kChatStateOnline};
+{
+    kChatStateOffline = 0,
+    kChatStateConnecting,       // connecting to chatd (resolve DNS, open socket...)
+    kChatStateJoining,          // connection to chatd is established, logging in
+    kChatStateOnline            // login completed (HISTDONE received for JOIN/JOINRANGEHIST)
+};
+
 static inline const char* chatStateToStr(unsigned state)
 {
     static const char* chatStates[] =

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2433,7 +2433,7 @@ public:
      * @param count The number of requested messages to load.
      *
      * @return Return the source of the messages that is going to be fetched. The possible values are:
-     *   - MegaChatApi::SOURCE_ERROR = -1: history has to be fetched from server, but we are offline
+     *   - MegaChatApi::SOURCE_ERROR = -1: history has to be fetched from server, but we are not logged in yet
      *   - MegaChatApi::SOURCE_NONE = 0: there's no more history available (not even int the server)
      *   - MegaChatApi::SOURCE_LOCAL: messages will be fetched locally (RAM or DB)
      *   - MegaChatApi::SOURCE_REMOTE: messages will be requested to the server. Expect some delay

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -231,12 +231,12 @@ void MegaChatApiImpl::sendPendingRequests()
         case MegaChatRequest::TYPE_RETRY_PENDING_CONNECTIONS:
         {
             mClient->retryPendingConnections()
-                    .then([this, request]()
+            .then([this, request]()
             {
                 MegaChatErrorPrivate *megaChatError = new MegaChatErrorPrivate(MegaChatError::ERROR_OK);
                 fireOnChatRequestFinish(request, megaChatError);
             })
-                    .fail([this, request](const promise::Error& e)
+            .fail([this, request](const promise::Error& e)
             {
                 MegaChatErrorPrivate *megaChatError = new MegaChatErrorPrivate(e.msg(), e.code(), e.type());
                 fireOnChatRequestFinish(request, megaChatError);
@@ -2170,7 +2170,7 @@ int MegaChatApiImpl::loadMessages(MegaChatHandle chatid, int count)
         case kHistSourceRam:
         case kHistSourceDb:     ret = MegaChatApi::SOURCE_LOCAL; break;
         case kHistSourceServer: ret = MegaChatApi::SOURCE_REMOTE; break;
-        case kHistSourceServerOffline: ret = MegaChatApi::SOURCE_ERROR; break;
+        case kHistSourceNotLoggedIn: ret = MegaChatApi::SOURCE_ERROR; break;
         default:
             API_LOG_ERROR("Unknown source of messages at loadMessages()");
             break;


### PR DESCRIPTION
The connection used to allow a logged-in state, established when the first chat completes its login. It's semantically wrong, since the connection is shared by multiple chats and it may happen that not all of
them are already logged in.
This commit resolves the `Connection::mLoginPromise` only when all chats are logged in and removes the (incorrect) state `Connection::State::kStateLoggedIn`.