### PR TITLE
 Avoid to start ECHO if already in foreground 

### DIFF
--- a/bindings/java/nz/mega/sdk/MegaChatApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaChatApiJava.java
@@ -766,6 +766,15 @@ public class MegaChatApiJava {
     }
 
     /**
+     * Returns the background status established in MEGAchat
+     *
+     * @return True if background status was set.
+     */
+    public boolean getBackgroundStatus(){
+        return megaChatApi.getBackgroundStatus();
+    }
+
+    /**
      * Returns the current firstname of the user
      *
      * This function is useful to get the firstname of users who participated in a groupchat with

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -167,10 +167,11 @@ void Client::cancelTimers()
 
 void Client::notifyUserActive()
 {
-    sendEcho();
-
     if (mKeepaliveType == OP_KEEPALIVE)
         return;
+
+    sendEcho();
+
     mKeepaliveType = OP_KEEPALIVE;
     sendKeepalive();
 }

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -195,6 +195,11 @@ bool Client::areAllChatsLoggedIn()
         }
     }
 
+    if (allConnected)
+    {
+        CHATD_LOG_DEBUG("We are now logged in to all chats");
+    }
+
     return allConnected;
 }
 
@@ -405,7 +410,7 @@ Promise<void> Connection::reconnect()
             mLoginPromise = Promise<void>();
 
             mState = kStateResolving;
-            CHATDS_LOG_DEBUG("Resolving hostname...");
+            CHATDS_LOG_DEBUG("Resolving hostname %s...", mUrl.host.c_str());
 
             for (auto& chatid: mChatIds)
             {
@@ -1953,7 +1958,7 @@ void Chat::onLastSeen(Id msgid)
     {
         if (mLastSeenIdx == CHATD_IDX_INVALID)  // don't have a previous idx yet --> initialization
         {
-            CHATID_LOG_DEBUG("setMessageSeen: Setting last seen msgid to %s", ID_CSTR(mLastSeenId));
+            CHATID_LOG_DEBUG("setMessageSeen: Setting last seen msgid to %s", ID_CSTR(msgid));
             mLastSeenId = msgid;
             CALL_DB(setLastSeen, msgid);
 

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -1118,6 +1118,7 @@ public:
     IRtcHandler* mRtcHandler = nullptr;
     karere::Id userId() const { return mUserId; }
     void setKeepaliveType(bool isInBackground);
+    uint8_t keepaliveType() { return mKeepaliveType; }
     Client(karere::Client *client, karere::Id userId);
     ~Client();
     std::shared_ptr<Chat> chatFromId(karere::Id chatid) const

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -6,7 +6,11 @@
 #include <buffer.h>
 #include "karereId.h"
 
-enum { CHATD_KEYID_INVALID = 0, CHATD_KEYID_UNCONFIRMED = 0xffffffff };
+enum
+{
+    CHATD_KEYID_INVALID = 0,                // used when no keyid is set
+    CHATD_KEYID_UNCONFIRMED = 0xffffffff    // used when a new keyid has been requested. Should be kept as constant as possible and in the range of 0xffff0001 to 0xffffffff
+};
 
 namespace chatd
 {
@@ -178,7 +182,7 @@ enum Opcode
       * S->C: Key notification. Payload format is (userid.8 keyid.4 keylen.2 key)*
       * Receive: <chatid> <keyid> <payload>
       *
-      * Keep <keyxid> as constant as possible (e.g. 0xffffffff).
+      * Keep <keyxid> as constant as possible. Valid range: [0xFFFF0001 - 0xFFFFFFFF]
       * Note that ( chatid, userid, keyid ) is unique. Neither ( chatid, keyid ) nor
       * ( userid, keyid ) are unique!
       */

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -285,7 +285,7 @@ void MegaChatApi::setBackgroundStatus(bool background, MegaChatRequestListener *
 
 bool MegaChatApi::getBackgroundStatus()
 {
-    pImpl->getBackgroundStatus();
+    return pImpl->getBackgroundStatus();
 }
 
 void MegaChatApi::getUserFirstname(MegaChatHandle userhandle, MegaChatRequestListener *listener)

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -283,6 +283,11 @@ void MegaChatApi::setBackgroundStatus(bool background, MegaChatRequestListener *
     pImpl->setBackgroundStatus(background, listener);
 }
 
+bool MegaChatApi::getBackgroundStatus()
+{
+    pImpl->getBackgroundStatus();
+}
+
 void MegaChatApi::getUserFirstname(MegaChatHandle userhandle, MegaChatRequestListener *listener)
 {
     pImpl->getUserFirstname(userhandle, listener);

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -1979,6 +1979,13 @@ public:
     void setBackgroundStatus(bool background, MegaChatRequestListener *listener = NULL);
 
     /**
+     * @brief Returns the background status established in MEGAchat
+     *
+     * @return True if background status was set.
+     */
+    bool getBackgroundStatus();
+
+    /**
      * @brief Returns the current firstname of the user
      *
      * This function is useful to get the firstname of users who participated in a groupchat with

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1754,6 +1754,19 @@ void MegaChatApiImpl::setBackgroundStatus(bool background, MegaChatRequestListen
     waiter->notify();
 }
 
+bool MegaChatApiImpl::getBackgroundStatus()
+{
+    bool status = false;
+
+    sdkMutex.lock();
+
+    status = mClient ? mClient->chatd->keepaliveType() : false;
+
+    sdkMutex.unlock();
+
+    return status;
+}
+
 void MegaChatApiImpl::getUserFirstname(MegaChatHandle userhandle, MegaChatRequestListener *listener)
 {
     MegaChatRequestPrivate *request = new MegaChatRequestPrivate(MegaChatRequest::TYPE_GET_FIRSTNAME, listener);

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -904,6 +904,7 @@ public:
 
     int getUserOnlineStatus(MegaChatHandle userhandle);
     void setBackgroundStatus(bool background, MegaChatRequestListener *listener = NULL);
+    bool getBackgroundStatus();
 
     void getUserFirstname(MegaChatHandle userhandle, MegaChatRequestListener *listener = NULL);
     void getUserLastname(MegaChatHandle userhandle, MegaChatRequestListener *listener = NULL);

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -212,7 +212,8 @@ Client::reconnect(const std::string& url)
             mLoginPromise = Promise<void>();
 
             setConnState(kResolving);
-            PRESENCED_LOG_DEBUG("Resolving hostname...");
+            PRESENCED_LOG_DEBUG("Resolving hostname %s...", mUrl.host.c_str());
+
             int status = wsResolveDNS(karereClient->websocketIO, mUrl.host.c_str(),
                          [wptr, this](int status, std::string ipv4, std::string ipv6)
             {


### PR DESCRIPTION
Android app requests `MEGAchat::setBackgroundStatus(false) repeatedly while it's in foreground (every 3 secs), which may trigger a reconnect once and again when it's not needed.