### PR TITLE
Avoid to change the state of connection in offline mode

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -227,7 +227,7 @@ void Chat::connect()
             mConnection.reconnect()
             .fail([this](const promise::Error& err)
             {
-                CHATID_LOG_ERROR("Error connecting to server: %s", err.what());
+                CHATID_LOG_ERROR("Chat::connect(): Error connecting to server after getting URL: %s", err.what());
             });
         });
 
@@ -237,7 +237,7 @@ void Chat::connect()
         mConnection.reconnect()
         .fail([this](const promise::Error& err)
         {
-            CHATID_LOG_ERROR("Error connecting to server: %s", err.what());
+            CHATID_LOG_ERROR("Chat::connect(): connection state: disconnected. Error connecting to server: %s", err.what());
         });
 
     }
@@ -337,6 +337,9 @@ bool Connection::sendKeepalive(uint8_t opcode)
 
 void Connection::sendEcho()
 {
+    if (!mUrl.isValid())    // the connection is not ready yet (i.e. initialization in offline-mode)
+        return;
+
     if (mEchoTimer) // one is already sent
         return;
 


### PR DESCRIPTION
When the app starts in offline mode, connections to chatd are kept in
state `kStateNew`. That state must be preserved until the app requests
to connect, when MEGAchat retrieves the URLs of shards.
The `ECHO` mechanism, if used during offline mode, would set the state
to `kStateDisconnected`, preventing to get the URL.