### PR TITLE
Update keyid of unconfirmed messages upon key's confirmation

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2452,8 +2452,9 @@ void Chat::onMsgUpdated(Message* cipherMsg)
 
             case SVCRYPTO_ENOKEY:
                 //we have a normal situation where a message was sent just before a user joined, so it will be undecryptable
-                assert(mClient.chats(mChatId).isGroup());
                 CHATID_LOG_WARNING("No key to decrypt message %s, possibly message was sent just before user joined", ID_CSTR(cipherMsg->id()));
+                assert(mClient.chats(mChatId).isGroup());
+                assert(message->keyid < 0xffff0001);   // a confirmed keyid should never be the transactional keyxid
                 cipherMsg->setEncrypted(Message::kEncryptedNoKey);
                 break;
 
@@ -2894,8 +2895,9 @@ bool Chat::msgIncomingAfterAdd(bool isNew, bool isLocal, Message& msg, Idx idx)
 
             case SVCRYPTO_ENOKEY:
                 //we have a normal situation where a message was sent just before a user joined, so it will be undecryptable
-                assert(mClient.chats(mChatId).isGroup());
                 CHATID_LOG_WARNING("No key to decrypt message %s, possibly message was sent just before user joined", ID_CSTR(message->id()));
+                assert(mClient.chats(mChatId).isGroup());
+                assert(message->keyid < 0xffff0001);   // a confirmed keyid should never be the transactional keyxid
                 message->setEncrypted(Message::kEncryptedNoKey);
                 break;
 

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -9,7 +9,7 @@
 enum
 {
     CHATD_KEYID_INVALID = 0,                // used when no keyid is set
-    CHATD_KEYID_UNCONFIRMED = 0xffffffff    // used when a new keyid has been requested. Should be kept as constant as possible and in the range of 0xffff0001 to 0xffffffff
+    CHATD_KEYID_UNCONFIRMED = 0xfffffffe    // used when a new keyid has been requested. Should be kept as constant as possible and in the range of 0xffff0001 to 0xffffffff
 };
 
 namespace chatd


### PR DESCRIPTION
It may happen that a `NEWKEY keyxid`+[`NEWMSG msgxid keyxid`]* is received and confirmed by server, but the client only receive the key's confirmation (`NEWKEYID`, but not the `NEWMSGID`). Hence, upon reconnection, MEGAchat will resend the `NEWMSG msgxid keyxid` without a `NEWKEY`, which is not acceptable for chatd.
This branch attempts to fix the aforementioned scenario by updating the `keyxid` of unconfirmed messages and immediately set the `keyid` (both in sending item and in DB).