### PR TITLE
Correct conversión to std::string from end Call termCode

### DIFF
--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -5236,7 +5236,7 @@ MegaChatListItemPrivate::MegaChatListItemPrivate(ChatRoom &chatroom)
                 {
                     this->lastMsg = std::to_string(callEndedInfo->duration);
                     this->lastMsg.push_back(0x01);
-                    this->lastMsg += std::to_string(callEndedInfo->termCode);
+                    this->lastMsg += std::to_string(static_cast<uint32_t>(callEndedInfo->termCode));
                     for (unsigned int i = 0; i < callEndedInfo->participants.size(); i++)
                     {
                         this->lastMsg.push_back(0x01);


### PR DESCRIPTION
Convert uint8_t to uint32_t for correct conversion to std::string