### PR TITLE
Send CALLDATA with end-call always that is necessary

### DIFF
--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -1039,6 +1039,15 @@ Promise<void> Call::destroy(TermCode code, bool weTerminate, const string& msg)
     setState(Call::kStateTerminating);
     clearCallOutTimer();
 
+    if (mPredestroyState != Call::kStateRingIn && code != TermCode::kBusy)
+    {
+        sendCallData(kCallDataEnd);
+    }
+    else
+    {
+        SUB_LOG_WARNING("Not posting termination CALLDATA because term code is Busy and call state is ringing");
+    }
+
     Promise<void> pms((promise::Empty())); //non-initialized promise
     if (weTerminate)
     {
@@ -1075,15 +1084,6 @@ Promise<void> Call::destroy(TermCode code, bool weTerminate, const string& msg)
     {
         if (wptr.deleted())
             return;
-
-        if (mPredestroyState != Call::kStateRingIn && code != TermCode::kBusy)
-        {
-            sendCallData(kCallDataEnd);
-        }
-        else
-        {
-            SUB_LOG_WARNING("Not posting termination CALLDATA because term code is Busy and call state is ringing");
-        }
 
         assert(mSessions.empty());
         stopIncallPingTimer();

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -1383,8 +1383,7 @@ bool Call::sendCallData(int state)
 
 uint8_t Call::convertTermCodeToCallDataCode()
 {
-    uint8_t code;
-    switch (mTermCode)
+    uint8_t codeToChatd;
     switch (mTermCode & TermCode::kInvalid)
     {
         case kUserHangup:
@@ -1394,22 +1393,22 @@ uint8_t Call::convertTermCodeToCallDataCode()
                 case kStateRingIn:
                     assert(false);  // it should be kCallRejected
                 case kStateReqSent:
-                    code = kCallDataReasonCancelled;
+                    codeToChatd = kCallDataReasonCancelled;
                     break;
 
                 case kStateInProgress:
-                    code = kCallDataReasonEnded;
+                    codeToChatd = kCallDataReasonEnded;
                     break;
 
                 default:
-                    code = kCallDataReasonFailed;
+                    codeToChatd = kCallDataReasonFailed;
                     break;
             }
             break;
         }
 
         case kCallRejected:
-            code = kCallDataReasonRejected;
+            codeToChatd = kCallDataReasonRejected;
             break;
 
         case kAnsElsewhere:
@@ -1419,16 +1418,16 @@ uint8_t Call::convertTermCodeToCallDataCode()
 
         case kAnswerTimeout:
         case kRingOutTimeout:
-            code = kCallDataReasonNoAnswer;
+            codeToChatd = kCallDataReasonNoAnswer;
             break;
 
         case kAppTerminating:
-            code = (mPredestroyState == kStateInProgress) ? kCallDataReasonEnded : kCallDataReasonFailed;
+            codeToChatd = (mPredestroyState == kStateInProgress) ? kCallDataReasonEnded : kCallDataReasonFailed;
             break;
 
         case kBusy:
             assert(!isJoiner());
-            code = kCallDataReasonRejected;
+            codeToChatd = kCallDataReasonRejected;
             break;
 
         default:
@@ -1437,11 +1436,10 @@ uint8_t Call::convertTermCodeToCallDataCode()
                 SUB_LOG_ERROR("convertTermCodeToCallDataCode: Don't know how to translate term code %s, returning FAILED",
                               termCodeToStr(mTermCode));
             }
-            code = kCallDataReasonFailed;
+            codeToChatd = kCallDataReasonFailed;
             break;
     }
 
-    return code;
 }
 
 bool Call::answer(AvFlags av)

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -1045,7 +1045,7 @@ Promise<void> Call::destroy(TermCode code, bool weTerminate, const string& msg)
     }
     else
     {
-        SUB_LOG_WARNING("Not posting termination CALLDATA because term code is Busy and call state is ringing");
+        SUB_LOG_WARNING("Not posting termination CALLDATA because term code is Busy or call state is ringing");
     }
 
     Promise<void> pms((promise::Empty())); //non-initialized promise
@@ -1089,7 +1089,7 @@ Promise<void> Call::destroy(TermCode code, bool weTerminate, const string& msg)
         stopIncallPingTimer();
         mLocalPlayer.reset();
         setState(Call::kStateDestroyed);
-        FIRE_EVENT(CALL, onDestroy, static_cast<TermCode>(code & TermCode::kInvalid),
+        FIRE_EVENT(CALL, onDestroy, static_cast<TermCode>(code & ~TermCode::kPeer),
             !!(code & 0x80), msg);// jscs:ignore disallowImplicitTypeConversion
         mManager.removeCall(*this);
     });
@@ -1384,7 +1384,7 @@ bool Call::sendCallData(int state)
 uint8_t Call::convertTermCodeToCallDataCode()
 {
     uint8_t codeToChatd;
-    switch (mTermCode & TermCode::kInvalid)
+    switch (mTermCode & ~TermCode::kPeer)
     {
         case kUserHangup:
         {

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -1440,6 +1440,7 @@ uint8_t Call::convertTermCodeToCallDataCode()
             break;
     }
 
+    return codeToChatd;
 }
 
 bool Call::answer(AvFlags av)

--- a/src/rtcModule/webrtc.h
+++ b/src/rtcModule/webrtc.h
@@ -121,7 +121,7 @@ enum TermCode: uint8_t
 
 static inline bool isTermError(TermCode code)
 {
-    int errorCode = code & TermCode::kInvalid;
+    int errorCode = code & ~TermCode::kPeer;
     return (errorCode >= TermCode::kErrorFirst) && (errorCode <= TermCode::kErrorLast);
 }
 

--- a/src/rtcModule/webrtc.h
+++ b/src/rtcModule/webrtc.h
@@ -121,7 +121,7 @@ enum TermCode: uint8_t
 
 static inline bool isTermError(TermCode code)
 {
-    int errorCode = code & 0x7f;
+    int errorCode = code & TermCode::kInvalid;
     return (errorCode >= TermCode::kErrorFirst) && (errorCode <= TermCode::kErrorLast);
 }
 


### PR DESCRIPTION
Adjust native behaviour to webClient behaviour. This change had been apply to gropuCall branch but it has been moved to this branch before merging groupCall functionality because it was necessary to get compatibility between clients