### PR TITLE
DNS cache for presenced and chatd

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -540,8 +540,8 @@ Promise<void> Connection::reconnect()
                     mLoginPromise.reject(errStr, statusDNS, kErrorTypeGeneric);
                 }
             }
-
-            if (cachedIPs)
+            else if (cachedIPs) // if wsResolveDNS() failed immediately, very likely there's
+            // no network connetion, so it's futile to attempt to connect
             {
                 doConnect();
             }

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -527,12 +527,7 @@ Promise<void> Connection::reconnect()
                     return;
                 }
 
-                string ipv4, ipv6;
-                mDNScache.get(mUrl.host, ipv4, ipv6);
-                bool match = ((std::find(ipsv4.begin(), ipsv4.end(), ipv4) != ipsv4.end())
-                        && (std::find(ipsv6.begin(), ipsv6.end(), ipv6) != ipsv6.end()));
-
-                if (match)
+                if (mDNScache.isMatch(mUrl.host, ipsv4, ipsv6))
                 {
                     CHATDS_LOG_DEBUG("DNS resolve matches cached IPs.");
                 }

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -330,12 +330,14 @@ void Chat::login()
 }
 
 Connection::Connection(Client& client, int shardNo)
-: mChatdClient(client), mShardNo(shardNo)
+: mChatdClient(client), mShardNo(shardNo),
+  mDNScache(mChatdClient.karereClient->websocketIO->mDnsCache)
 {}
 
 void Connection::wsConnectCb()
 {
-    CHATDS_LOG_DEBUG("Chatd connected");
+    CHATDS_LOG_DEBUG("Chatd connected to %s", mTargetIp.c_str());
+    mDNScache.connectDone(mUrl.host, mTargetIp);
     mState = kStateConnected;
     assert(!mConnectPromise.done());
     mConnectPromise.resolve();
@@ -352,7 +354,7 @@ void Connection::wsCloseCb(int errcode, int errtype, const char *preason, size_t
 
 void Connection::onSocketClose(int errcode, int errtype, const std::string& reason)
 {
-    CHATDS_LOG_WARNING("Socket close. Reason: %s", reason.c_str());
+    CHATDS_LOG_WARNING("Socket close on IP %s. Reason: %s", mTargetIp.c_str(), reason.c_str());
     mHeartbeatEnabled = false;
     auto oldState = mState;
     mState = kStateDisconnected;
@@ -373,6 +375,7 @@ void Connection::onSocketClose(int errcode, int errtype, const std::string& reas
         return;
 
     usingipv6 = !usingipv6;
+    mTargetIp.clear();
 
     if (oldState < kStateConnected) //tell retry controller that the connect attempt failed
     {
@@ -466,6 +469,9 @@ Promise<void> Connection::reconnect()
             mConnectPromise = Promise<void>();
             mLoginPromise = Promise<void>();
 
+            string ipv4, ipv6;
+            bool cachedIPs = mDNScache.get(mUrl.host, ipv4, ipv6);
+
             mState = kStateResolving;
             CHATDS_LOG_DEBUG("Resolving hostname %s...", mUrl.host.c_str());
 
@@ -476,85 +482,68 @@ Promise<void> Connection::reconnect()
                     chat.setOnlineState(kChatStateConnecting);
             }
 
-            int status = wsResolveDNS(mChatdClient.karereClient->websocketIO, mUrl.host.c_str(),
-                         [wptr, this](int status, std::string ipv4, std::string ipv6)
+            int statusDNS = wsResolveDNS(mChatdClient.karereClient->websocketIO, mUrl.host.c_str(),
+                         [wptr, cachedIPs, this](int statusDNS, std::string ipv4, std::string ipv6)
             {
                 if (wptr.deleted())
                 {
                     CHATDS_LOG_DEBUG("DNS resolution completed, but chatd client was deleted.");
                     return;
                 }
-                if (mState != kStateResolving)
-                {
-                    CHATDS_LOG_DEBUG("Unexpected connection state %s while resolving DNS.", connStateToStr(mState));
-                    return;
-                }
 
-                if (status < 0)
+                if (statusDNS < 0)
                 {
-                   CHATDS_LOG_DEBUG("Async DNS error in chatd. Error code: %d", status);
+                   CHATDS_LOG_DEBUG("Async DNS error in chatd. Error code: %d", statusDNS);
                    string errStr = "Async DNS error in chatd for shard "+std::to_string(mShardNo);
                    if (!mConnectPromise.done())
                    {
-                       mConnectPromise.reject(errStr, status, kErrorTypeGeneric);
+                       mConnectPromise.reject(errStr, statusDNS, kErrorTypeGeneric);
                    }
                    if (!mLoginPromise.done())
                    {
-                       mLoginPromise.reject(errStr, status, kErrorTypeGeneric);
+                       mLoginPromise.reject(errStr, statusDNS, kErrorTypeGeneric);
                    }
                    return;
                 }
 
-                mState = kStateConnecting;
-                string ip = (usingipv6 && ipv6.size()) ? ipv6 : ipv4;
-                CHATDS_LOG_DEBUG("Connecting to chatd using the IP: %s", ip.c_str());
+                // update DNS cache
+                bool match = mDNScache.set(mUrl.host, ipv4, ipv6);
 
-                bool rt = wsConnect(mChatdClient.karereClient->websocketIO, ip.c_str(),
-                          mUrl.host.c_str(),
-                          mUrl.port,
-                          mUrl.path.c_str(),
-                          mUrl.isSecure);
-                if (!rt)
+                if (!cachedIPs) // connect required DNS lookup
                 {
-                    string otherip;
-                    if (ip == ipv6 && ipv4.size())
-                    {
-                        otherip = ipv4;
-                    }
-                    else if (ip == ipv4 && ipv6.size())
-                    {
-                        otherip = ipv6;
-                    }
-
-                    if (otherip.size())
-                    {
-                        CHATDS_LOG_DEBUG("Connection to chatd failed. Retrying using the IP: %s", otherip.c_str());
-                        if (wsConnect(mChatdClient.karereClient->websocketIO, otherip.c_str(),
-                                                  mUrl.host.c_str(),
-                                                  mUrl.port,
-                                                  mUrl.path.c_str(),
-                                                  mUrl.isSecure))
-                        {
-                            return;
-                        }
-                    }
-
-                    onSocketClose(0, 0, "Websocket error on wsConnect (chatd)");
+                    CHATDS_LOG_DEBUG("Hostname resolved by first time. Connecting...");
+                    doConnect();
+                    return;
+                }
+                if (match)
+                {
+                    CHATDS_LOG_DEBUG("DNS resolve matches cached IPs.");
+                }
+                else
+                {
+                    CHATDS_LOG_WARNING("DNS resolve doesn't match cached IPs. Forcing reconnect...");
+                    onSocketClose(0, 0, "DNS resolve doesn't match cached IPs (chatd)");
                 }
             });
 
-            if (status < 0)
+            // immediate error at wsResolveDNS()
+            if (statusDNS < 0)
             {
-                CHATDS_LOG_DEBUG("Sync DNS error in chatd. Error code: %d", status);
+                CHATDS_LOG_DEBUG("Sync DNS error in chatd. Error code: %d", statusDNS);
                 string errStr = "Sync DNS error in chatd for shard "+std::to_string(mShardNo);
                 if (!mConnectPromise.done())
                 {
-                    mConnectPromise.reject(errStr, status, kErrorTypeGeneric);
+                    mConnectPromise.reject(errStr, statusDNS, kErrorTypeGeneric);
                 }
                 if (!mLoginPromise.done())
                 {
-                    mLoginPromise.reject(errStr, status, kErrorTypeGeneric);
+                    mLoginPromise.reject(errStr, statusDNS, kErrorTypeGeneric);
                 }
+            }
+
+            if (cachedIPs)
+            {
+                doConnect();
             }
 
             return mConnectPromise
@@ -584,6 +573,55 @@ void Connection::disconnect()
     }
 
     onSocketClose(0, 0, "terminating");
+}
+
+void Connection::doConnect()
+{
+    string ipv4, ipv6;
+    bool cachedIPs = mDNScache.get(mUrl.host, ipv4, ipv6);
+    assert(cachedIPs);
+    mTargetIp = (usingipv6 && ipv6.size()) ? ipv6 : ipv4;
+
+    mState = kStateConnecting;
+    CHATDS_LOG_DEBUG("Connecting to chatd using the IP: %s", mTargetIp.c_str());
+
+    bool rt = wsConnect(mChatdClient.karereClient->websocketIO, mTargetIp.c_str(),
+              mUrl.host.c_str(),
+              mUrl.port,
+              mUrl.path.c_str(),
+              mUrl.isSecure);
+
+    if (!rt)    // immediate failure --> try the other IP family (if available)
+    {
+        CHATDS_LOG_DEBUG("Connection to chatd failed using the IP: %s", mTargetIp.c_str());
+
+        string oldTargetIp = mTargetIp;
+        mTargetIp.clear();
+        if (oldTargetIp == ipv6 && ipv4.size())
+        {
+            mTargetIp = ipv4;
+        }
+        else if (oldTargetIp == ipv4 && ipv6.size())
+        {
+            mTargetIp = ipv6;
+        }
+
+        if (mTargetIp.size())
+        {
+            CHATDS_LOG_DEBUG("Retrying using the IP: %s", mTargetIp.c_str());
+            if (wsConnect(mChatdClient.karereClient->websocketIO, mTargetIp.c_str(),
+                                      mUrl.host.c_str(),
+                                      mUrl.port,
+                                      mUrl.path.c_str(),
+                                      mUrl.isSecure))
+            {
+                return;
+            }
+            CHATDS_LOG_DEBUG("Connection to chatd failed using the IP: %s", mTargetIp.c_str());
+        }
+
+        onSocketClose(0, 0, "Websocket error on wsConnect (chatd)");
+    }
 }
 
 promise::Promise<void> Connection::retryPendingConnection()

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -347,12 +347,14 @@ public:
          };
 
 protected:
-    bool usingipv6 = false;
     Client& mChatdClient;
     int mShardNo;
     std::set<karere::Id> mChatIds;
     State mState = kStateNew;
     karere::Url mUrl;
+    bool usingipv6 = false; // ip version to try first (both are tried)
+    std::string mTargetIp;
+    DNScache &mDNScache;
     bool mHeartbeatEnabled = false;
     time_t mTsLastRecv = 0;
     megaHandle mEchoTimer = 0;
@@ -373,6 +375,7 @@ protected:
     void onSocketClose(int ercode, int errtype, const std::string& reason);
     promise::Promise<void> reconnect();
     void disconnect();
+    void doConnect();
     void notifyLoggedIn();
 // Destroys the buffer content
     bool sendBuf(Buffer&& buf);

--- a/src/net/libwebsocketsIO.cpp
+++ b/src/net/libwebsocketsIO.cpp
@@ -57,36 +57,31 @@ void LibwebsocketsIO::addevents(::mega::Waiter* waiter, int)
 
 static void onDnsResolved(uv_getaddrinfo_t *req, int status, struct addrinfo *res)
 {
-    string ipv4, ipv6;
-    std::function<void (int, string, string)>* func = (std::function<void (int, string, string)>*)req->data;
+    vector<string> ipsv4, ipsv6;
+    std::function<void (int, vector<string>&, vector<string>&)>* func = (std::function<void (int, vector<string>&, vector<string>&)>*)req->data;
     struct addrinfo *hp = res;
     while (hp)
     {
         char straddr[INET6_ADDRSTRLEN];
         straddr[0] = 0;
 
-        if (!ipv4.size() && hp->ai_family == AF_INET)
+        if (hp->ai_family == AF_INET)
         {
             sockaddr_in *addr = (sockaddr_in *)hp->ai_addr;
             inet_ntop(hp->ai_family, &addr->sin_addr, straddr, sizeof(straddr));
             if (straddr[0])
             {
-                ipv4 = straddr;
+                ipsv4.push_back(straddr);
             }
         }
-        else if (!ipv6.size() && hp->ai_family == AF_INET6)
+        else if (hp->ai_family == AF_INET6)
         {
             sockaddr_in6 *addr = (sockaddr_in6 *)hp->ai_addr;
             inet_ntop(hp->ai_family, &addr->sin6_addr, straddr, sizeof(straddr));
             if (straddr[0])
             {
-                ipv6 = string("[") + straddr + "]";
+                ipsv6.push_back(string("[") + straddr + "]");
             }
-        }
-
-        if (ipv4.size() && ipv6.size())
-        {
-            break;
         }
 
         hp = hp->ai_next;
@@ -97,16 +92,16 @@ static void onDnsResolved(uv_getaddrinfo_t *req, int status, struct addrinfo *re
         WEBSOCKETS_LOG_ERROR("Failed to resolve DNS. Reason: %s (%d)", uv_strerror(status), status);
     }
 
-    (*func)(status, ipv4, ipv6);
+    (*func)(status, ipsv4, ipsv6);
     uv_freeaddrinfo(res);
     delete func;
     delete req;
 }
 
-bool LibwebsocketsIO::wsResolveDNS(const char *hostname, std::function<void (int, string, string)> f)
+bool LibwebsocketsIO::wsResolveDNS(const char *hostname, std::function<void (int, vector<string>&, vector<string>&)> f)
 {
     uv_getaddrinfo_t *h = new uv_getaddrinfo_t();
-    h->data = new std::function<void (int, string, string)>(f);
+    h->data = new std::function<void (int, vector<string>&, vector<string>&)>(f);
     return uv_getaddrinfo(eventloop, h, onDnsResolved, hostname, NULL, NULL);
 }
 

--- a/src/net/libwebsocketsIO.h
+++ b/src/net/libwebsocketsIO.h
@@ -21,7 +21,7 @@ public:
     virtual void addevents(::mega::Waiter*, int);
     
 protected:
-    virtual bool wsResolveDNS(const char *hostname, std::function<void(int, std::string, std::string)> f);
+    virtual bool wsResolveDNS(const char *hostname, std::function<void(int, std::vector<std::string>&, std::vector<std::string>&)> f);
     virtual WebsocketsClientImpl *wsConnect(const char *ip, const char *host,
                                            int port, const char *path, bool ssl,
                                            WebsocketsClient *client);

--- a/src/net/libwsIO.cpp
+++ b/src/net/libwsIO.cpp
@@ -47,7 +47,7 @@ void LibwsIO::addevents(::mega::Waiter* waiter, int)
 
 }
 
-bool LibwsIO::wsResolveDNS(const char *hostname, std::function<void (int, std::string, std::string)> f)
+bool LibwsIO::wsResolveDNS(const char *hostname, std::function<void (int, std::vector<std::string>&, std::vector<std::string>&)> f)
 {
     mApi.call(&::mega::MegaApi::queryDNS, hostname)
     .then([f](ReqResult result)

--- a/src/net/libwsIO.h
+++ b/src/net/libwsIO.h
@@ -18,7 +18,7 @@ public:
 
 protected:
     ws_base_s wscontext;
-    virtual bool wsResolveDNS(const char *hostname, std::function<void(int, std::string, std::string)> f);
+    virtual bool wsResolveDNS(const char *hostname, std::function<void(int, std::vector<std::string>&, std::vector<std::string>&)> f);
     virtual WebsocketsClientImpl *wsConnect(const char *ip, const char *host,
                                            int port, const char *path, bool ssl,
                                            WebsocketsClient *client);

--- a/src/net/websocketsIO.cpp
+++ b/src/net/websocketsIO.cpp
@@ -229,7 +229,7 @@ void DNScache::connectDone(std::string &url, std::string &ip)
         {
             it->second.connectIpv4Ts = time(NULL);
         }
-        else (ip == it->second.ipv6)
+        else if (ip == it->second.ipv6)
         {
             it->second.connectIpv6Ts = time(NULL);
         }

--- a/src/net/websocketsIO.cpp
+++ b/src/net/websocketsIO.cpp
@@ -178,3 +178,60 @@ void WebsocketsClient::wsCloseCbPrivate(int errcode, int errtype, const char *pr
 
     wsCloseCb(errcode, errtype, preason, reason_len);
 }
+
+bool DNScache::set(std::string &url, std::string &ipv4, std::string &ipv6)
+{
+    auto it = mRecords.find(url);
+    bool exists = (it != mRecords.end());
+
+    bool match = (exists
+                  && (ipv4 == it->second.ipv4)
+                  && (ipv6 == it->second.ipv6));
+
+    if (!match)
+    {
+        DNSrecord record;
+        record.ipv4 = ipv4;
+        record.ipv6 = ipv6;
+        record.resolveTs = time(NULL);
+
+        mRecords[url] = record;
+    }
+
+    return match;
+}
+
+void DNScache::clear(std::string &url)
+{
+    mRecords.erase(url);
+}
+
+bool DNScache::get(std::string &url, std::string &ipv4, std::string &ipv6)
+{
+    auto it = mRecords.find(url);
+    if (it == mRecords.end())
+    {
+        return false;
+    }
+
+    ipv4 = it->second.ipv4;
+    ipv6 = it->second.ipv6;
+
+    return true;
+}
+
+void DNScache::connectDone(std::string &url, std::string &ip)
+{
+    auto it = mRecords.find(url);
+    if (it != mRecords.end())
+    {
+        if (ip == it->second.ipv4)
+        {
+            it->second.connectIpv4Ts = time(NULL);
+        }
+        else (ip == it->second.ipv6)
+        {
+            it->second.connectIpv6Ts = time(NULL);
+        }
+    }
+}

--- a/src/net/websocketsIO.cpp
+++ b/src/net/websocketsIO.cpp
@@ -87,7 +87,7 @@ WebsocketsClient::~WebsocketsClient()
     ctx = NULL;
 }
 
-bool WebsocketsClient::wsResolveDNS(WebsocketsIO *websocketIO, const char *hostname, std::function<void (int, std::string, std::string)> f)
+bool WebsocketsClient::wsResolveDNS(WebsocketsIO *websocketIO, const char *hostname, std::function<void (int, std::vector<std::string>&, std::vector<std::string>&)> f)
 {
     return websocketIO->wsResolveDNS(hostname, f);
 }

--- a/src/net/websocketsIO.cpp
+++ b/src/net/websocketsIO.cpp
@@ -179,7 +179,7 @@ void WebsocketsClient::wsCloseCbPrivate(int errcode, int errtype, const char *pr
     wsCloseCb(errcode, errtype, preason, reason_len);
 }
 
-bool DNScache::set(std::string &url, std::string &ipv4, std::string &ipv6)
+bool DNScache::set(const std::string &url, const std::string &ipv4, const std::string &ipv6)
 {
     auto it = mRecords.find(url);
     bool exists = (it != mRecords.end());
@@ -201,12 +201,12 @@ bool DNScache::set(std::string &url, std::string &ipv4, std::string &ipv6)
     return match;
 }
 
-void DNScache::clear(std::string &url)
+void DNScache::clear(const std::string &url)
 {
     mRecords.erase(url);
 }
 
-bool DNScache::get(std::string &url, std::string &ipv4, std::string &ipv6)
+bool DNScache::get(const std::string &url, std::string &ipv4, std::string &ipv6)
 {
     auto it = mRecords.find(url);
     if (it == mRecords.end())
@@ -220,7 +220,7 @@ bool DNScache::get(std::string &url, std::string &ipv4, std::string &ipv6)
     return true;
 }
 
-void DNScache::connectDone(std::string &url, std::string &ip)
+void DNScache::connectDone(const std::string &url, const std::string &ip)
 {
     auto it = mRecords.find(url);
     if (it != mRecords.end())
@@ -236,7 +236,7 @@ void DNScache::connectDone(std::string &url, std::string &ip)
     }
 }
 
-time_t DNScache::age(std::string &url)
+time_t DNScache::age(const std::string &url)
 {
     auto it = mRecords.find(url);
     if (it != mRecords.end())

--- a/src/net/websocketsIO.cpp
+++ b/src/net/websocketsIO.cpp
@@ -235,3 +235,14 @@ void DNScache::connectDone(std::string &url, std::string &ip)
         }
     }
 }
+
+time_t DNScache::age(std::string &url)
+{
+    auto it = mRecords.find(url);
+    if (it != mRecords.end())
+    {
+        return it->second.resolveTs;
+    }
+
+    return 0;
+}

--- a/src/net/websocketsIO.h
+++ b/src/net/websocketsIO.h
@@ -21,12 +21,15 @@ class DNScache
 {
 public:
     DNScache() {}
-    bool set(const std::string &url, const std::string &ipv4, const std::string &ipv6);   // true if changed
+    // returns false if ipv4 and ipv6 for the given url already match the ones in cache, true if not (so they are updated)
+    bool set(const std::string &url, const std::string &ipv4, const std::string &ipv6);
     void clear(const std::string &url);
+    // returns true if hit in cache, false if there's no record for the given url
     bool get(const std::string &url, std::string &ipv4, std::string &ipv6);
     void connectDone(const std::string &url, const std::string &ip);
     time_t age(const std::string &url);
-
+    bool isMatch(const std::string &url, const std::vector<std::string> &ipsv4, const std::vector<std::string> &ipsv6);
+    bool isMatch(const std::string &url, const std::string &ipv4, const std::string &ipv6);
 private:
     struct DNSrecord
     {

--- a/src/net/websocketsIO.h
+++ b/src/net/websocketsIO.h
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <functional>
+#include <vector>
 #include <mega/waiter.h>
 #include <mega/thread.h>
 #include "base/logger.h"
@@ -55,7 +56,7 @@ protected:
     
     // This function is protected to prevent a wrong direct usage
     // It must be only used from WebsocketClient
-    virtual bool wsResolveDNS(const char *hostname, std::function<void(int status, std::string ipv4, std::string ipv6)> f) = 0;
+    virtual bool wsResolveDNS(const char *hostname, std::function<void(int status, std::vector<std::string> &ipsv4, std::vector<std::string> &ipsv6)> f) = 0;
     virtual WebsocketsClientImpl *wsConnect(const char *ip, const char *host,
                                            int port, const char *path, bool ssl,
                                            WebsocketsClient *client) = 0;
@@ -74,7 +75,7 @@ private:
 public:
     WebsocketsClient();
     virtual ~WebsocketsClient();
-    bool wsResolveDNS(WebsocketsIO *websocketIO, const char *hostname, std::function<void(int, std::string, std::string)> f);
+    bool wsResolveDNS(WebsocketsIO *websocketIO, const char *hostname, std::function<void(int, std::vector<std::string>&, std::vector<std::string>&)> f);
     bool wsConnect(WebsocketsIO *websocketIO, const char *ip,
                    const char *host, int port, const char *path, bool ssl);
     bool wsSendMessage(char *msg, size_t len);  // returns true on success, false if error

--- a/src/net/websocketsIO.h
+++ b/src/net/websocketsIO.h
@@ -24,15 +24,16 @@ public:
     void clear(std::string &url);
     bool get(std::string &url, std::string &ipv4, std::string &ipv6);
     void connectDone(std::string &url, std::string &ip);
+    time_t age(std::string &url);
 
 private:
     struct DNSrecord
     {
         std::string ipv4;
         std::string ipv6;
-        time_t resolveTs = 0;
-        time_t connectIpv4Ts = 0;
-        time_t connectIpv6Ts = 0;
+        time_t resolveTs = 0;       // can be used to invalidate IP addresses by age
+        time_t connectIpv4Ts = 0;   // can be used for heuristics based on last successful connection
+        time_t connectIpv6Ts = 0;   // can be used for heuristics based on last successful connection
     };
 
     std::map<std::string, DNSrecord> mRecords;

--- a/src/net/websocketsIO.h
+++ b/src/net/websocketsIO.h
@@ -21,11 +21,11 @@ class DNScache
 {
 public:
     DNScache() {}
-    bool set(std::string &url, std::string &ipv4, std::string &ipv6);   // true if changed
-    void clear(std::string &url);
-    bool get(std::string &url, std::string &ipv4, std::string &ipv6);
-    void connectDone(std::string &url, std::string &ip);
-    time_t age(std::string &url);
+    bool set(const std::string &url, const std::string &ipv4, const std::string &ipv6);   // true if changed
+    void clear(const std::string &url);
+    bool get(const std::string &url, std::string &ipv4, std::string &ipv6);
+    void connectDone(const std::string &url, const std::string &ip);
+    time_t age(const std::string &url);
 
 private:
     struct DNSrecord

--- a/src/net/websocketsIO.h
+++ b/src/net/websocketsIO.h
@@ -16,12 +16,36 @@
 class WebsocketsClient;
 class WebsocketsClientImpl;
 
+class DNScache
+{
+public:
+    DNScache() {}
+    bool set(std::string &url, std::string &ipv4, std::string &ipv6);   // true if changed
+    void clear(std::string &url);
+    bool get(std::string &url, std::string &ipv4, std::string &ipv6);
+    void connectDone(std::string &url, std::string &ip);
+
+private:
+    struct DNSrecord
+    {
+        std::string ipv4;
+        std::string ipv6;
+        time_t resolveTs = 0;
+        time_t connectIpv4Ts = 0;
+        time_t connectIpv6Ts = 0;
+    };
+
+    std::map<std::string, DNSrecord> mRecords;
+};
+
 // Generic websockets network layer
 class WebsocketsIO : public mega::EventTrigger
 {
 public:
     WebsocketsIO(::mega::Mutex *mutex, ::mega::MegaApi *megaApi, void *ctx);
     virtual ~WebsocketsIO();
+
+    DNScache mDnsCache;
     
 protected:
     ::mega::Mutex *mutex;

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -259,13 +259,7 @@ Client::reconnect(const std::string& url)
                     return;
                 }
 
-
-                string ipv4, ipv6;
-                mDNScache.get(mUrl.host, ipv4, ipv6);
-                bool match = ((std::find(ipsv4.begin(), ipsv4.end(), ipv4) != ipsv4.end())
-                        && (std::find(ipsv6.begin(), ipsv6.end(), ipv6) != ipsv6.end()));
-
-                if (match)
+                if (mDNScache.isMatch(mUrl.host, ipsv4, ipsv6))
                 {
                     PRESENCED_LOG_DEBUG("DNS resolve matches cached IPs.");
                 }

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -280,8 +280,8 @@ Client::reconnect(const std::string& url)
                     mLoginPromise.reject(errStr, statusDNS, kErrorTypeGeneric);
                 }
             }
-
-            if (cachedIPs)
+            else if (cachedIPs) // if wsResolveDNS() failed immediately, very likely there's
+            // no network connetion, so it's futile to attempt to connect
             {
                 doConnect();
             }

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -60,7 +60,7 @@ void Client::pushPeers()
 void Client::wsConnectCb()
 {
     PRESENCED_LOG_DEBUG("Presenced connected to %s", mTargetIp.c_str());
-    karereClient->websocketIO->mDnsCache.connectDone(mUrl.host, mTargetIp);
+    mDNScache.connectDone(mUrl.host, mTargetIp);
     setConnState(kConnected);
     assert(!mConnectPromise.done());
     mConnectPromise.resolve();
@@ -217,7 +217,7 @@ Client::reconnect(const std::string& url)
             mLoginPromise = Promise<void>();
 
             string ipv4, ipv6;
-            bool cachedIPs = karereClient->websocketIO->mDnsCache.get(mUrl.host, ipv4, ipv6);
+            bool cachedIPs = mDNScache.get(mUrl.host, ipv4, ipv6);
 
             setConnState(kResolving);
             PRESENCED_LOG_DEBUG("Resolving hostname %s...", mUrl.host.c_str());
@@ -247,7 +247,7 @@ Client::reconnect(const std::string& url)
                 }
 
                 // update DNS cache
-                bool match = karereClient->websocketIO->mDnsCache.set(mUrl.host, ipv4, ipv6);
+                bool match = mDNScache.set(mUrl.host, ipv4, ipv6);
 
                 if (!cachedIPs) // connect required DNS lookup
                 {
@@ -370,7 +370,7 @@ void Client::disconnect()
 void Client::doConnect()
 {
     string ipv4, ipv6;
-    bool cachedIPs = karereClient->websocketIO->mDnsCache.get(mUrl.host, ipv4, ipv6);
+    bool cachedIPs = mDNScache.get(mUrl.host, ipv4, ipv6);
     assert(cachedIPs);
     mTargetIp = (usingipv6 && ipv6.size()) ? ipv6 : ipv4;
 

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -29,7 +29,8 @@ namespace presenced
 {
 
 Client::Client(MyMegaApi *api, karere::Client *client, Listener& listener, uint8_t caps)
-: mListener(&listener), karereClient(client), mApi(api), mCapabilities(caps), usingipv6(false)
+: mListener(&listener), karereClient(client), mApi(api), mCapabilities(caps), usingipv6(false),
+  mDNScache(karereClient->websocketIO->mDnsCache)
 {}
 
 promise::Promise<void>
@@ -196,6 +197,8 @@ Client::reconnect(const std::string& url)
             if (!mUrl.isValid())
                 return promise::Error("No valid URL provided and current URL is not valid");
         }
+
+        setConnState(kResolving);
 
         auto wptr = weakHandle();
         return retry("presenced", [this](int no, DeleteTrackable::Handle wptr)

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -260,7 +260,8 @@ protected:
     promise::Promise<void> mConnectPromise;
     promise::Promise<void> mLoginPromise;
     uint8_t mCapabilities;
-    bool usingipv6;
+    bool usingipv6; // ip version to try first (both are tried)
+    std::string mTargetIp;
     karere::Id mMyHandle;
     Config mConfig;
     bool mLastSentUserActive = false;
@@ -312,6 +313,7 @@ public:
     connect(const std::string& url, karere::Id myHandle, IdRefMap&& peers,
         const Config& Config);
     void disconnect();
+    void doConnect();
     promise::Promise<void> retryPendingConnection();
     /** @brief Performs server ping and check for network inactivity.
      * Must be called externally in order to have all clients

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -254,14 +254,15 @@ protected:
     ConnState mConnState = kConnNew;
     Listener* mListener;
     karere::Client *karereClient;
-    karere::Url mUrl;
     MyMegaApi *mApi;
     bool mHeartbeatEnabled = false;
     promise::Promise<void> mConnectPromise;
     promise::Promise<void> mLoginPromise;
     uint8_t mCapabilities;
+    karere::Url mUrl;
     bool usingipv6; // ip version to try first (both are tried)
     std::string mTargetIp;
+    DNScache &mDNScache;
     karere::Id mMyHandle;
     Config mConfig;
     bool mLastSentUserActive = false;


### PR DESCRIPTION
In order to speed up the connection establishment to chatd/presenced, this branch adds a in-memory cache for resolved hostnames.

Any reconnection attempt automatically uses cached IPs and perform a DNS lookup in parallel. When the DNS is resolved, if the IPs don't match, it forces a reconnect directly (even if connected). 