### PR TITLE
Clear history of cached chats if DB version is out of date

### DIFF
--- a/src/karereCommon.cpp
+++ b/src/karereCommon.cpp
@@ -16,7 +16,9 @@ namespace rtcModule {void globalCleanup(); }
 
 namespace karere
 {
-const char* gDbSchemaVersionSuffix = "2";
+const char* gDbSchemaVersionSuffix = "3";
+// 2 --> +3: invalidate cached chats to reload history (so call-history msgs are fetched)
+
 bool gCatchException = true;
 
 void globalInit(void(*postFunc)(void*, void*), uint32_t options, const char* logPath, size_t logSize)


### PR DESCRIPTION
This commit will clear any cached history for any chat, so it requires
to be freshly fetched from chatd. It will solve the issue of missing
management messages for the call-history while the client used protocol
version `/1`