### PR TITLE
Fix error at message order verification

### DIFF
--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -480,7 +480,7 @@ public:
     uint16_t updated;
     uint32_t keyid;
     unsigned char type;
-    BackRefId backRefId;
+    BackRefId backRefId = 0;
     std::vector<BackRefId> backRefs;
     mutable void* userp;
     mutable uint8_t userFlags = 0;


### PR DESCRIPTION
Management messages don't have a `backRefId`, but it was not
initialized. Hence, it was used to verify the order and it generates
errors when it should not.