### PR TITLE
Remove unnecessary last characters at rich link

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3791,7 +3791,7 @@ bool Message::hasUrl(const string &text, string &url)
         }
         else
         {
-            if (partialString.size() > 0)
+            if (!partialString.empty())
             {
                 removeUnnecessaryLastCharacters(partialString);
                 if (parseUrl(partialString))
@@ -3807,7 +3807,7 @@ bool Message::hasUrl(const string &text, string &url)
         position ++;
     }
 
-    if (partialString.size() > 0)
+    if (!partialString.empty())
     {
         removeUnnecessaryLastCharacters(partialString);
         if (parseUrl(partialString))
@@ -3853,17 +3853,20 @@ bool Message::parseUrl(const std::string &url)
     return regex_match(urlToParse, regularExpresion);
 }
 
-void Message::removeUnnecessaryLastCharacters(string &test)
+void Message::removeUnnecessaryLastCharacters(string &buf)
 {
-    char lastCharacter = test[test.size() - 1];
-    while (test.size() && (lastCharacter == '.' || lastCharacter == ',' || lastCharacter == ':'
-           || lastCharacter == '?' || lastCharacter == '!' || lastCharacter == ';'))
+    if (!buf.empty())
     {
-        test.erase(test.size() - 1);
-
-        if (test.size())
+        char lastCharacter = buf.back();
+        while (!buf.empty() && (lastCharacter == '.' || lastCharacter == ',' || lastCharacter == ':'
+                               || lastCharacter == '?' || lastCharacter == '!' || lastCharacter == ';'))
         {
-            lastCharacter = test[test.size() - 1];
+            buf.erase(buf.size() - 1);
+
+            if (!buf.empty())
+            {
+                lastCharacter = buf.back();
+            }
         }
     }
 }

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3793,18 +3793,7 @@ bool Message::hasUrl(const string &text, string &url)
         {
             if (partialString.size() > 0)
             {
-                char lastCharacter = partialString[partialString.size() - 1];
-                while (lastCharacter == '.' || lastCharacter == ',' || lastCharacter == ':'
-                       || lastCharacter == '?' || lastCharacter == '!' || lastCharacter == ';')
-                {
-                    partialString.erase(partialString.size() - 1);
-
-                    if (partialString.size())
-                    {
-                        lastCharacter = partialString[partialString.size() - 1];
-                    }
-                }
-
+                removeUnnecessaryLastCharacters(partialString);
                 if (parseUrl(partialString))
                 {
                     url = partialString;
@@ -3820,18 +3809,7 @@ bool Message::hasUrl(const string &text, string &url)
 
     if (partialString.size() > 0)
     {
-        char lastCharacter = partialString[partialString.size() - 1];
-        while (lastCharacter == '.' || lastCharacter == ',' || lastCharacter == ':'
-               || lastCharacter == '?' || lastCharacter == '!' || lastCharacter == ';')
-        {
-            partialString.erase(partialString.size() - 1);
-
-            if (partialString.size())
-            {
-                lastCharacter = partialString[partialString.size() - 1];
-            }
-        }
-
+        removeUnnecessaryLastCharacters(partialString);
         if (parseUrl(partialString))
         {
             url = partialString;
@@ -3873,5 +3851,20 @@ bool Message::parseUrl(const std::string &url)
     std::regex regularExpresion("^(WWW.|www.)?[a-z0-9A-Z-._~:/?#@!$&'()*+,;=]+([-.]{1}[a-z0-9A-Z-._~:/?#@!$&'()*+,;=]+)*.[a-zA-Z]{2,5}(:[0-9]{1,5})?([a-z0-9A-Z-._~:/?#@!$&'()*+,;=]*)?$");
 
     return regex_match(urlToParse, regularExpresion);
+}
+
+void Message::removeUnnecessaryLastCharacters(string &test)
+{
+    char lastCharacter = test[test.size() - 1];
+    while (lastCharacter == '.' || lastCharacter == ',' || lastCharacter == ':'
+           || lastCharacter == '?' || lastCharacter == '!' || lastCharacter == ';')
+    {
+        test.erase(test.size() - 1);
+
+        if (test.size())
+        {
+            lastCharacter = test[test.size() - 1];
+        }
+    }
 }
 }

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3793,9 +3793,16 @@ bool Message::hasUrl(const string &text, string &url)
         {
             if (partialString.size() > 0)
             {
-                if (partialString[partialString.size() - 1] == '.')
+                char lastCharacter = partialString[partialString.size() - 1];
+                while (lastCharacter == '.' || lastCharacter == ',' || lastCharacter == ':'
+                       || lastCharacter == '?' || lastCharacter == '!' || lastCharacter == ';')
                 {
                     partialString.erase(partialString.size() - 1);
+
+                    if (partialString.size())
+                    {
+                        lastCharacter = partialString[partialString.size() - 1];
+                    }
                 }
 
                 if (parseUrl(partialString))
@@ -3813,9 +3820,16 @@ bool Message::hasUrl(const string &text, string &url)
 
     if (partialString.size() > 0)
     {
-        if (partialString[partialString.size() - 1] == '.')
+        char lastCharacter = partialString[partialString.size() - 1];
+        while (lastCharacter == '.' || lastCharacter == ',' || lastCharacter == ':'
+               || lastCharacter == '?' || lastCharacter == '!' || lastCharacter == ';')
         {
             partialString.erase(partialString.size() - 1);
+
+            if (partialString.size())
+            {
+                lastCharacter = partialString[partialString.size() - 1];
+            }
         }
 
         if (parseUrl(partialString))

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3856,8 +3856,8 @@ bool Message::parseUrl(const std::string &url)
 void Message::removeUnnecessaryLastCharacters(string &test)
 {
     char lastCharacter = test[test.size() - 1];
-    while (lastCharacter == '.' || lastCharacter == ',' || lastCharacter == ':'
-           || lastCharacter == '?' || lastCharacter == '!' || lastCharacter == ';')
+    while (test.size() && (lastCharacter == '.' || lastCharacter == ',' || lastCharacter == ':'
+           || lastCharacter == '?' || lastCharacter == '!' || lastCharacter == ';'))
     {
         test.erase(test.size() - 1);
 

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -610,6 +610,7 @@ public:
 
     static bool hasUrl(const std::string &text, std::string &url);
     static bool parseUrl(const std::string &url);
+    static void removeUnnecessaryLastCharacters(std::string& test);
 
 protected:
     static const char* statusNames[];


### PR DESCRIPTION
Before parsing a string to check if it is a rich link, remove unnecessary last characters ('.', ',', ';', ':', ...)