### PR TITLE
 Destroy calls after disconnect

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -371,6 +371,13 @@ void Connection::onSocketClose(int errcode, int errtype, const std::string& reas
     {
         auto& chat = mChatdClient.chats(chatid);
         chat.onDisconnect();
+
+#ifndef KARERE_DISABLE_WEBRTC
+        if (mChatdClient.karereClient->rtc)
+        {
+            mChatdClient.karereClient->rtc->removeCall(chatid);
+        }
+#endif
     }
 
     if (oldState == kStateDisconnected)

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -964,7 +964,7 @@ void Call::msgJoin(RtMessage& packet)
 }
 promise::Promise<void> Call::gracefullyTerminateAllSessions(TermCode code)
 {
-    SUB_LOG_ERROR("gracefully term all sessions");
+    SUB_LOG_DEBUG("gracefully term all sessions");
     std::vector<promise::Promise<void>> promises;
     for (auto it = mSessions.begin(); it != mSessions.end();)
     {
@@ -2171,7 +2171,7 @@ Promise<void> Session::terminateAndDestroy(TermCode code, const std::string& msg
 
     if (!msg.empty())
     {
-        SUB_LOG_ERROR("Terminating due to: %s", msg.c_str());
+        SUB_LOG_DEBUG("Terminating due to: %s", msg.c_str());
     }
     assert(!mTerminatePromise.done());
     setState(kStateTerminating);

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -565,6 +565,15 @@ bool RtcModule::isCallInProgress() const
     return callInProgress;
 }
 
+void RtcModule::removeCall(Id chatid)
+{
+    auto itCall = mCalls.find(chatid);
+    if (itCall != mCalls.end())
+    {
+        itCall->second->destroy(TermCode::kErrUserOffline, false);
+    }
+}
+
 void setConstraint(webrtc::FakeConstraints& constr, const string &name, const std::string& value,
     bool optional)
 {

--- a/src/rtcModule/webrtc.h
+++ b/src/rtcModule/webrtc.h
@@ -344,6 +344,7 @@ public:
     virtual void setMediaConstraint(const std::string& name, const std::string &value, bool optional=false) = 0;
     virtual void setPcConstraint(const std::string& name, const std::string &value, bool optional=false) = 0;
     virtual bool isCallInProgress() const = 0;
+    virtual void removeCall(karere::Id chatid) = 0;
 
     virtual ICall& joinCall(karere::Id chatid, karere::AvFlags av, ICallHandler& handler) = 0;
     virtual ICall& startCall(karere::Id chatid, karere::AvFlags av, ICallHandler& handler) = 0;

--- a/src/rtcModule/webrtcPrivate.h
+++ b/src/rtcModule/webrtcPrivate.h
@@ -211,6 +211,7 @@ public:
     virtual void setMediaConstraint(const std::string& name, const std::string &value, bool optional);
     virtual void setPcConstraint(const std::string& name, const std::string &value, bool optional);
     virtual bool isCallInProgress() const;
+    virtual void removeCall(karere::Id chatid);
     virtual ICall& joinCall(karere::Id chatid, karere::AvFlags av, ICallHandler& handler);
     virtual ICall& startCall(karere::Id chatid, karere::AvFlags av, ICallHandler& handler);
     virtual void hangupAll(TermCode reason);


### PR DESCRIPTION
UserA and UserB are in a call (state in-progress) and UserA gets disconnected. UserB receives a command indicating that UserA is off-line and he finishes the call but UserA follows in the call forever (until he hangs up the call). 
This PR solves this issue. When system detects that the connection is broken, it destroys all calls