### PR TITLE
Adjust termination code for end call message

### DIFF
--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -794,7 +794,8 @@ public:
         END_CALL_REASON_REJECTED    = 2,    /// Call was rejected by callee
         END_CALL_REASON_NO_ANSWER   = 3,    /// Call wasn't answered
         END_CALL_REASON_FAILED      = 4,    /// Call finished by an error
-        END_CALL_REASON_CANCELLED   = 5     /// Call was canceled by caller
+        END_CALL_REASON_CANCELLED   = 5     /// (deprecated) Call was canceled by caller.
+                                            /// Instead of this termCode apps receives END_CALL_REASON_NO_ANSWER
     };
 
     enum

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -5650,7 +5650,27 @@ MegaChatMessagePrivate::MegaChatMessagePrivate(const Message &msg, Message::Stat
                 }
 
                 priv = callEndInfo->duration;
-                code = callEndInfo->termCode;
+                switch(callEndInfo->termCode)
+                {
+                    case END_CALL_REASON_CANCELLED:
+                        code = END_CALL_REASON_NO_ANSWER;
+                        break;
+                    case END_CALL_REASON_ENDED:
+                    case END_CALL_REASON_FAILED:
+                        if (priv > 0)
+                        {
+                            code = END_CALL_REASON_ENDED;
+                        }
+                        else
+                        {
+                            code = END_CALL_REASON_FAILED;
+                        }
+                        break;
+                    default:
+                        code = callEndInfo->termCode;
+                        break;
+                }
+
                 delete callEndInfo;
             }
             break;

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -5657,7 +5657,7 @@ MegaChatMessagePrivate::MegaChatMessagePrivate(const Message &msg, Message::Stat
                         break;
                     case END_CALL_REASON_ENDED:
                     case END_CALL_REASON_FAILED:
-                        if (priv > 0)
+                        if (callEndInfo->duration > 0)
                         {
                             code = END_CALL_REASON_ENDED;
                         }


### PR DESCRIPTION
Termination code from end call message is translated from one type to other type at UI level.
Conversion:
 - A call with termination code END_CALL_REASON_CANCELLED will be converted to END_CALL_REASON_NO_ANSWER
 - A call with duration > 0 and termination code END_CALL_REASON_ENDED or END_CALL_REASON_FAILED will be converted to END_CALL_REASON_ENDED
 - A call with duration == 0 and termination code END_CALL_REASON_ENDED or END_CALL_REASON_FAILED will be converted to END_CALL_REASON_FAILED