### PR TITLE
Clean warnings and refactoring

### DIFF
--- a/examples/qt/chatWindow.cpp
+++ b/examples/qt/chatWindow.cpp
@@ -3,7 +3,7 @@
 using namespace karere;
 
 ChatWindow::ChatWindow(QWidget* parent, karere::ChatRoom& room)
-    : QDialog(parent), client(room.parent.client), mRoom(room), mWaitMsg(*this)
+    : QDialog(parent), client(room.parent.mKarereClient), mRoom(room), mWaitMsg(*this)
 {
     userp = this;
     ui.setupUi(this);

--- a/examples/qt/mainwindow.cpp
+++ b/examples/qt/mainwindow.cpp
@@ -507,7 +507,7 @@ void CListChatItem::truncateChat()
     auto& thisroom = room();
     if (thisroom.chat().empty())
         return;
-    thisroom.parent.client.api.call(
+    thisroom.parent.mKarereClient.api.call(
         &::mega::MegaApi::truncateChat,
         thisroom.chatid(),
         thisroom.chat().at(thisroom.chat().highnum()).id().val);

--- a/examples/qt/mainwindow.h
+++ b/examples/qt/mainwindow.h
@@ -446,7 +446,7 @@ public:
             for (const auto& item: mRoom.peers())
             {
                 auto& peer = *item.second;
-                const std::string* email = mRoom.parent.client.contactList->getUserEmail(item.first);
+                const std::string* email = mRoom.parent.mKarereClient.contactList->getUserEmail(item.first);
                 auto line = QString(" %1 (%2, %3): priv %4\n").arg(QString(peer.name().c_str()+1))
                         .arg(email?QString::fromStdString(*email):tr("(email unknown)"))
                         .arg(QString::fromStdString(karere::Id(item.first).toString()))

--- a/src/IGui.h
+++ b/src/IGui.h
@@ -52,7 +52,7 @@ public:
          * count, if count < 0, then there are *at least* \c count unread messages,
          * and possibly more. In that case the indicator should show e.g. '2+'
          */
-        virtual void onUnreadCountChanged(int count) {}
+        virtual void onUnreadCountChanged(int /*count*/) {}
     };
 
     /** @brief This interface must be implemented to receive events related to a chat.
@@ -78,7 +78,7 @@ public:
          * @param userid The member user handle
          * @param newName The new name. The first char of the name
          */
-        virtual void onMemberNameChanged(uint64_t userid, const std::string& newName){}
+        virtual void onMemberNameChanged(uint64_t /*userid*/, const std::string& /*newName*/){}
 
         /** @brief Returns an optionally associated user data pointer */
         void* userp = nullptr;
@@ -118,7 +118,7 @@ public:
          * @brief Called when the state of the login operation changes,
          * to inform the user about the progress of the login operation.
          */
-        virtual void setState(LoginStage state) {}
+        virtual void setState(LoginStage /*state*/) {}
         /** @brief Destroys the dialog. Directly deleting it may not be appropriate
          * for the GUI toolkit used */
         virtual void destroy() = 0;
@@ -195,17 +195,17 @@ public:
          * received when fetching history, because it is fetched from newest to oldest).
          * @param msg Contains the properties of the last text message
          */
-        virtual void onLastMessageUpdated(const chatd::LastTextMsg& msg) {}
+        virtual void onLastMessageUpdated(const chatd::LastTextMsg& /*msg*/) {}
 
         /** @brief Called when the timestamp of the most-recent message has changed.
          * This happens when a new message is received, or when there were no locally
          * known messages and the first old message is received
          */
-        virtual void onLastTsUpdated(uint32_t ts) {}
+        virtual void onLastTsUpdated(uint32_t /*ts*/) {}
 
         /** @brief Called when the connection state to the chatroom shard changes.
          */
-        virtual void onChatOnlineState(const chatd::ChatState state) {}
+        virtual void onChatOnlineState(const chatd::ChatState /*state*/) {}
     };
 
     /**
@@ -232,11 +232,11 @@ public:
          * @param userid The handle of the user
          * @param priv The privilege of the joined user - look at chatd::Priv
          */
-        virtual void onUserJoin(uint64_t userid, chatd::Priv priv) {}
+        virtual void onUserJoin(uint64_t /*userid*/, chatd::Priv /*priv*/) {}
         /** @brief User has left the chat.
          * @param userid - the user handle of the user who left the chat.
          */
-        virtual void onUserLeave(uint64_t userid) {}
+        virtual void onUserLeave(uint64_t /*userid*/) {}
     };
 
     /** @brief Manages contactlist items that in turn receive events
@@ -315,7 +315,7 @@ public:
      * @param pres The presence code
      * @param inProgress Whether the presence is being set or not
      */
-    virtual void onPresenceChanged(Id userid, Presence pres, bool inProgress) {}
+    virtual void onPresenceChanged(Id /*userid*/, Presence /*pres*/, bool /*inProgress*/) {}
 
     /**
      * @brief Called when the presence preferences have changed due to
@@ -350,9 +350,9 @@ public:
      * Look at karere::Client::InitState for the possible values of the client init
      * state and their meaning.
      */
-    virtual void onInitStateChange(int newState) {}
+    virtual void onInitStateChange(int /*newState*/) {}
 
-    virtual void onChatNotification(karere::Id chatid, const chatd::Message &msg, chatd::Message::Status status, chatd::Idx idx) {}
+    virtual void onChatNotification(karere::Id /*chatid*/, const chatd::Message &/*msg*/, chatd::Message::Status /*status*/, chatd::Idx /*idx*/) {}
 
     virtual ~IApp() {}
 };

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -93,7 +93,7 @@ protected:
 public:
     std::recursive_mutex mMutex;
     typedef std::lock_guard<std::recursive_mutex> LockGuard;
-    volatile unsigned flags() const { return mFlags;}
+    unsigned flags() const { return mFlags;}
     void setFlags(unsigned flags)
     {
         LockGuard lock(mMutex);

--- a/src/base/promise.h
+++ b/src/base/promise.h
@@ -158,7 +158,7 @@ public:
 
     inline C*& operator[](int idx)
     {
-        assert((idx >= 0) && (idx < items.size()));
+        assert((idx >= 0) && (idx < (int)items.size()));
         return items[idx];
     }
     inline const C*& operator[](int idx) const
@@ -323,13 +323,13 @@ protected:
         static Promise<Out> call(CB& cb, const In& val) {  return cb(val);  }
 
         template<class Out, class CbOut, class In, class CB, class=typename std::enable_if<std::is_same<In,_Void>::value && !std::is_same<CbOut, void>::value, int>::type>
-        static Promise<Out> call(CB& cb, const _Void& val) {  return cb();   }
+        static Promise<Out> call(CB& cb, const _Void& /*val*/) {  return cb();   }
 
         template<class Out, class CbOut, class In, class CB, class=typename std::enable_if<!std::is_same<In,_Void>::value && std::is_same<CbOut,void>::value, int>::type>
         static Promise<void> call(CB& cb, const In& val){ cb(val); return _Void(); }
 
         template<class Out, class CbOut, class In, class CB, class=typename std::enable_if<std::is_same<In,_Void>::value && std::is_same<CbOut,void>::value, int>::type>
-        static Promise<void> call(CB& cb, const _Void& val) { cb(); return _Void(); }
+        static Promise<void> call(CB& cb, const _Void& /*val*/) { cb(); return _Void(); }
     };
 //===
     void reset(SharedObj* other=NULL)

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -232,7 +232,7 @@ public:
             }
             ::free(mBuf);
         }
-        mBufSize = (kMinBufSize>datalen) ? kMinBufSize : datalen;
+        mBufSize = (kMinBufSize > datalen) ? (size_t) kMinBufSize : datalen;
         mBuf = (char*)malloc(mBufSize);
         if (!mBuf)
         {

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -217,7 +217,7 @@ protected:
 public:
     virtual IApp::IChatListItem* roomGui() { return mRoomGui; }
     /** @brief The userid of the other person in the 1on1 chat */
-    const uint64_t peer() const { return mPeer; }
+    uint64_t peer() const { return mPeer; }
     chatd::Priv peerPrivilege() const { return mPeerPriv; }
 
     /**
@@ -408,7 +408,7 @@ class ChatRoomList: public std::map<uint64_t, ChatRoom*> //don't use shared_ptr 
 {
 /** @cond PRIVATE */
 public:
-    Client& client;
+    Client& mKarereClient;
     void addMissingRoomsFromApi(const mega::MegaTextChatList& rooms, karere::SetOfIds& chatids);
     ChatRoom* addRoom(const mega::MegaTextChat &room);
     void removeRoom(GroupChatRoom& room);
@@ -535,6 +535,7 @@ public:
     const std::string* getUserEmail(uint64_t userid) const;
     /** @endcond */
 };
+
 /** @brief The karere Client object. Create an instance to use Karere.
  *
  *  A sequence of how the client has to be initialized:
@@ -558,19 +559,6 @@ class Client: public rtcModule::IGlobalHandler,
 {
 public:
     enum ConnState { kDisconnected = 0, kConnecting, kConnected };
-/** @cond PRIVATE */
-protected:
-    std::string mAppDir;
-//these must be before the db member, because they are initialized during the init of db member
-    Id mMyHandle = Id::null(); //mega::UNDEF
-    std::string mSid;
-    std::unique_ptr<UserAttrCache> mUserAttrCache;
-    std::string mMyEmail;
-    uint64_t mMyIdentity = 0; // seed for CLIENTID
-    ConnState mConnState = kDisconnected;
-    promise::Promise<void> mConnectPromise;
-public:
-    enum { kInitErrorType = 0x9e9a1417 }; //should resemble 'megainit'
     enum InitState: uint8_t
     {
         /** The client has just been created. \c init() has not been called yet */
@@ -633,25 +621,28 @@ public:
         kInitErrSidInvalid
     };
 
-    WebsocketsIO *websocketIO;
-    void *appCtx;
-    SqliteDb db;
-    std::unique_ptr<chatd::Client> chatd;
-    MyMegaApi api;
-    IApp& app;
+    /** @brief Convenience aliases for the \c force flag in \c setPresence() */
+    enum: bool { kSetPresOverride = true, kSetPresDynamic = false };
+
+    std::string mAppDir;        // must be before db member because it's used during the init of db member
+    WebsocketsIO *websocketIO;  // network-layer interface
+    void *appCtx;               // app's context
+    MyMegaApi api;              // MegaApi's instance
+    IApp& app;                  // app's interface
+    SqliteDb db;                // db-layer interface
+
+    std::unique_ptr<chatd::Client> mChatdClient;
+
+#ifndef KARERE_DISABLE_WEBRTC
+    std::unique_ptr<rtcModule::IRtcModule> rtc;
+#endif
+
     char mMyPrivCu25519[32] = {0};
     char mMyPrivEd25519[32] = {0};
     char mMyPrivRsa[1024] = {0};
     unsigned short mMyPrivRsaLen = 0;
     char mMyPubRsa[512] = {0};
     unsigned short mMyPubRsaLen = 0;
-    IApp::ILoginDialog::Handle mLoginDlg;
-    UserAttrCache& userAttrCache() const { return *mUserAttrCache; }
-    presenced::Client& presenced() { return mPresencedClient; }
-    bool contactsLoaded() const { return mContactsLoaded; }
-    ConnState connState() const { return mConnState; }
-    bool connected() const { return mConnState == kConnected; }
-    /** @endcond PRIVATE */
 
     /** @brief The contact list of the client */
     std::unique_ptr<ContactList> contactList;
@@ -659,18 +650,40 @@ public:
     /** @brief The list of chats that we are member of */
     std::unique_ptr<ChatRoomList> chats;
 
-    const Id myHandle() const { return mMyHandle; }
+    megaHandle mSyncTimer = 0;              // to wait for reception of SYNCs
+    int mSyncCount = -1;                     // to track if all chats returned SYNC
+    promise::Promise<void> mSyncPromise;    // resolved only when up to date
 
-    /** @brief Our own display name */
-    const std::string& myName() const { return mMyName; }
+    IApp::ILoginDialog::Handle mLoginDlg;
 
-    const std::string& myEmail() const { return mMyEmail; }
+protected:
 
-    const uint64_t myIdentity() const { return mMyIdentity; }
+    Id mMyHandle = Id::null(); //mega::UNDEF
+    std::string mMyName = std::string("\0", 1);
+    std::string mMyEmail;
+    uint64_t mMyIdentity = 0; // seed for CLIENTID
+    std::unique_ptr<UserAttrCache> mUserAttrCache;
+    UserAttrCache::Handle mOwnNameAttrHandle;
 
-    /** @brief Utulity function to convert a jid to a user handle */
-    static uint64_t useridFromJid(const std::string& jid);
+    std::string mSid;
+    std::string mLastScsn;
+    InitState mInitState = kInitCreated;
+    ConnState mConnState = kDisconnected;
+    bool mContactsLoaded = false;
 
+    // resolved when fetchnodes is completed
+    promise::Promise<void> mSessionReadyPromise;
+
+    // resolved when connection to presenced is established
+    promise::Promise<void> mConnectPromise;
+
+    Presence mOwnPresence = Presence::kInvalid;
+    presenced::Client mPresencedClient;
+    std::string mPresencedUrl;
+
+    megaHandle mHeartbeatTimer = 0;
+
+public:
     /**
      * @brief Creates a karere Client.
      *
@@ -687,6 +700,19 @@ public:
            uint8_t caps, void *ctx = NULL);
 
     virtual ~Client();
+
+    const Id myHandle() const { return mMyHandle; }
+    const std::string& myName() const { return mMyName; }
+    const std::string& myEmail() const { return mMyEmail; }
+    uint64_t myIdentity() const { return mMyIdentity; }
+    UserAttrCache& userAttrCache() const { return *mUserAttrCache; }
+
+    ConnState connState() const { return mConnState; }
+    bool connected() const { return mConnState == kConnected; }
+    bool contactsLoaded() const { return mContactsLoaded; }
+
+    Presence ownPresence() const { return mOwnPresence; }
+    presenced::Client& presenced() { return mPresencedClient; }
 
     /**
      * @brief Performs karere-only login, assuming the Mega SDK is already logged in
@@ -732,7 +758,6 @@ public:
     static const char* initStateToStr(unsigned char state);
     const char* connStateStr() const { return connStateToStr(mConnState); }
     static const char* connStateToStr(ConnState state);
-
 
     /** @brief Does the actual connection to chatd and presenced. Assumes the
      * Mega SDK is already logged in. This must be called after
@@ -787,9 +812,6 @@ public:
      */
     void terminate(bool deleteDb=false);
 
-    /** @brief Convenience aliases for the \c force flag in \c setPresence() */
-    enum: bool { kSetPresOverride = true, kSetPresDynamic = false };
-
     /**
     * @brief set user's chat presence.
     * Set user's presence state
@@ -799,10 +821,6 @@ public:
     */
     promise::Promise<void> setPresence(const Presence pres);
 
-    /**
-     * @brief Returns our own presence, as received by the presenced client
-     */
-    Presence ownPresence() const { return mOwnPresence; }
     /** @brief Creates a group chatroom with the specified peers, privileges
      * and title.
      * @param peers A vector of userhandle and privilege pairs for each of
@@ -814,48 +832,33 @@ public:
      */
     promise::Promise<karere::Id>
     createGroupChat(std::vector<std::pair<uint64_t, chatd::Priv>> peers);
+
     void setCommitMode(bool commitEach);
     void saveDb();  // forces a commit
+
     bool isCallInProgress() const;
 #ifndef KARERE_DISABLE_WEBRTC
-    std::unique_ptr<rtcModule::IRtcModule> rtc;
     virtual rtcModule::ICallHandler* onCallIncoming(rtcModule::ICall& call, karere::AvFlags av);
 #endif
 
     promise::Promise<void> pushReceived();
-    megaHandle mSyncTimer = 0;              // to wait for reception of SYNCs
-    int mSyncCount;                         // to track if all chats returned SYNC
-    promise::Promise<void> mSyncPromise;    // resolved only when up to date
     void onSyncReceived(karere::Id chatid); // called upon SYNC reception
 
-/** @cond PRIVATE */
     void dumpChatrooms(::mega::MegaTextChatList& chatRooms);
     void dumpContactList(::mega::MegaUserList& clist);
 
 protected:
-    std::string mMyName;
-    bool mContactsLoaded = false;
-    promise::Promise<void> mSessionReadyPromise;
-    Presence mOwnPresence;
-    /** @brief Our own email address */
-    std::string mEmail;
-    /** @brief Our password */
-    std::string mPassword;
-    /** @brief Client's contact list */
-    presenced::Client mPresencedClient;
-    std::string mPresencedUrl;
-    UserAttrCache::Handle mOwnNameAttrHandle;
-    megaHandle mHeartbeatTimer = 0;
-    std::string mLastScsn;
     void heartbeat();
-    InitState mInitState = kInitCreated;
     void setInitState(InitState newState);
+
+    // db-related methods
     std::string dbPath(const std::string& sid) const;
     bool openDb(const std::string& sid);
     void createDb();
     void wipeDb(const std::string& sid);
     void createDbSchema();
-    void connectToChatd(bool isInBackground);
+
+    // initialization of own handle/email/identity/keys/contacts...
     karere::Id getMyHandleFromDb();
     karere::Id getMyHandleFromSdk();
     std::string getMyEmailFromDb();
@@ -865,11 +868,15 @@ protected:
     void loadOwnKeysFromDb();
     void loadContactListFromApi();
     void loadContactListFromApi(::mega::MegaUserList& contactList);
+
     strongvelope::ProtocolHandler* newStrongvelope(karere::Id chatid);
+
+    // connection-related methods
+    void connectToChatd(bool isInBackground);
     promise::Promise<void> connectToPresenced(Presence pres);
     promise::Promise<void> connectToPresencedWithUrl(const std::string& url, Presence forcedPres);
- //   void setOwnPresence(Presence pres);
     promise::Promise<int> initializeContactList();
+
     /** @brief A convenience method to log in the associated Mega SDK instance,
      *  using IApp::ILoginDialog to ask the user/app for credentials. This
      * method is to be used in a standalone chat app where the SDK instance is not
@@ -908,10 +915,10 @@ protected:
     virtual void onConnStateChange(presenced::Client::ConnState state);
     virtual void onPresenceChange(Id userid, Presence pres);
     virtual void onPresenceConfigChanged(const presenced::Config& state, bool pending);
+
     //==
     friend class ChatRoom;
     friend class ChatRoomList;
-/** @endcond PRIVATE */
 };
 
 }

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -457,7 +457,7 @@ Promise<void> Connection::reconnect()
         mState = kStateResolving;
 
         auto wptr = weakHandle();
-        return retry("chatd", [this](int no, DeleteTrackable::Handle wptr)
+        return retry("chatd", [this](int /*no*/, DeleteTrackable::Handle wptr)
         {
             if (wptr.deleted())
             {

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -100,7 +100,7 @@ public:
      * @param status - The 'seen' status of the message. Normally it should be
      * 'not seen', until we call setMessageSeen() on it
      */
-    virtual void onRecvNewMessage(Idx idx, Message& msg, Message::Status status){}
+    virtual void onRecvNewMessage(Idx /*idx*/, Message& /*msg*/, Message::Status /*status*/){}
 
     /** @brief A history message has been received, as a result of getHistory().
      * @param idx The index of the message in the history buffer
@@ -109,7 +109,7 @@ public:
      * @param isLocal The message can be received from the server, or from the app's local
      * history db via \c fetchDbHistory() - this parameter specifies the source
      */
-    virtual void onRecvHistoryMessage(Idx idx, Message& msg, Message::Status status, bool isLocal){}
+    virtual void onRecvHistoryMessage(Idx /*idx*/, Message& /*msg*/, Message::Status /*status*/, bool /*isLocal*/){}
 
     /**
      * @brief The retrieval of the requested history batch, via \c getHistory(), was completed
@@ -119,7 +119,7 @@ public:
      * from mixing messages from local source and from server, as they are never
      * mixed in one history chunk.
      */
-    virtual void onHistoryDone(HistSource source) {}
+    virtual void onHistoryDone(HistSource /*source*/) {}
 
     /**
      * @brief An unsent message was loaded from local db. The app should normally
@@ -128,7 +128,7 @@ public:
      * the message posting ocurrent, from the oldest to the newest,
      * i.e. subsequent onUnsentMsgLoaded() calls are for newer unsent messages
      */
-    virtual void onUnsentMsgLoaded(Message& msg) {}
+    virtual void onUnsentMsgLoaded(Message& /*msg*/) {}
 
     /**
      * @brief An unsent edit of a message was loaded. Similar to \c onUnsentMsgLoaded()
@@ -138,7 +138,7 @@ public:
      * @note The calls to \c onUnsentMsgLoaded() and \c onUnsentEditLoaded()
      * are done in the order of the corresponding events (send, edit)
      */
-    virtual void onUnsentEditLoaded(Message& msg, bool oriMsgIsSending) {}
+    virtual void onUnsentEditLoaded(Message& /*msg*/, bool /*oriMsgIsSending*/) {}
 
     /** @brief A message sent by us was acknoledged by the server, assigning it a MSGID.
       * At this stage, the message state is "received-by-server", and it is in the history
@@ -148,7 +148,7 @@ public:
       * @param msg - The message object - \c id() returns a real msgid, and \c isSending() is \c false
       * @param idx - The history buffer index at which the message was put
       */
-    virtual void onMessageConfirmed(karere::Id msgxid, const Message& msg, Idx idx){}
+    virtual void onMessageConfirmed(karere::Id /*msgxid*/, const Message& /*msg*/, Idx /*idx*/){}
 
      /** @brief A message was rejected by the server for some reason.
       * As the message is not yet in the history buffer, its \c id()
@@ -174,13 +174,13 @@ public:
       * of the message. The client must have already received this message as
       * a NEWMSG upon reconnect, so it can just remove the pending message.
       */
-    virtual void onMessageRejected(const Message& msg, uint8_t reason){}
+    virtual void onMessageRejected(const Message& /*msg*/, uint8_t /*reason*/){}
 
     /** @brief A message was delivered, seen, etc. When the seen/received pointers are advanced,
      * this will be called for each message of the pointer-advanced range, so the application
      * doesn't need to iterate over ranges by itself
      */
-    virtual void onMessageStatusChange(Idx idx, Message::Status newStatus, const Message& msg){}
+    virtual void onMessageStatusChange(Idx /*idx*/, Message::Status /*newStatus*/, const Message& /*msg*/){}
 
     /**
      * @brief Called when a message edit is received, i.e. MSGUPD is received.
@@ -191,14 +191,14 @@ public:
      * @param msg The edited message
      * @param idx - the index of the edited message
      */
-    virtual void onMessageEdited(const Message& msg, Idx idx){}
+    virtual void onMessageEdited(const Message& /*msg*/, Idx /*idx*/){}
 
     /** @brief An edit posted by us was rejected for some reason.
      * // TODO
      * @param msg
      * @param reason
      */
-    virtual void onEditRejected(const Message& msg, ManualSendReason reason){}
+    virtual void onEditRejected(const Message& /*msg*/, ManualSendReason /*reason*/){}
 
     /** @brief The chatroom connection (to the chatd server shard) state
      * has changed.
@@ -208,13 +208,13 @@ public:
     /** @brief A user has joined the room, or their privilege has
      * changed.
      */
-    virtual void onUserJoin(karere::Id userid, Priv privilege){}
+    virtual void onUserJoin(karere::Id /*userid*/, Priv /*privilege*/){}
 
     /**
      * @brief onUserLeave User has been excluded from the group chat
      * @param userid The userid of the user
      */
-    virtual void onUserLeave(karere::Id userid){}
+    virtual void onUserLeave(karere::Id /*userid*/){}
 
     /** @brief We have been excluded from this chatroom */
     virtual void onExcludedFromChat() {}
@@ -237,7 +237,7 @@ public:
      * this is used to identify the message in seubsequent retry/cancel
      * @param reason - The code of the reason why the message could not be auto sent
      */
-    virtual void onManualSendRequired(Message* msg, uint64_t id, ManualSendReason reason) {}
+    virtual void onManualSendRequired(Message* /*msg*/, uint64_t /*id*/, ManualSendReason /*reason*/) {}
 
     /**
      * @brief onHistoryTruncated The history of the chat was truncated by someone
@@ -247,7 +247,7 @@ public:
      * overwritten with a management message that contains information who truncated the message.
      * @param idx - The index of \c msg
      */
-    virtual void onHistoryTruncated(const Message& msg, Idx idx) {}
+    virtual void onHistoryTruncated(const Message& /*msg*/, Idx /*idx*/) {}
 
     /**
      * @brief onMsgOrderVerificationFail The message ordering check for \c msg has
@@ -269,7 +269,7 @@ public:
      * @param userid The user that is typing. The app can use the user attrib
      * cache to get a human-readable name for the user.
      */
-    virtual void onUserTyping(karere::Id userid) {}
+    virtual void onUserTyping(karere::Id /*userid*/) {}
 
     /**
      * @brief onUserStopTyping Called when a signal is received that a peer
@@ -278,14 +278,14 @@ public:
      * @param userid The user that has stop to type. The app can use the user attrib
      * cache to get a human-readable name for the user.
      */
-    virtual void onUserStopTyping(karere::Id userid) {}
+    virtual void onUserStopTyping(karere::Id /*userid*/) {}
 
     /**
      * @brief Called when the last known text message changes/is updated, so that
      * the app can display it next to the chat title
      * @param msg Contains the properties of the last text message
      */
-    virtual void onLastTextMessageUpdated(const LastTextMsg& msg) {}
+    virtual void onLastTextMessageUpdated(const LastTextMsg& /*msg*/) {}
     /**
      * @brief Called when a message with a newer timestamp/modification time
      * is encountered. This can be used by the app to order chats in the chat
@@ -293,7 +293,7 @@ public:
      * @param ts The timestamp of the newer message. If a message is edited,
      * ts is the sum of the original message timestamp and the update delta.
      */
-    virtual void onLastMessageTsUpdated(uint32_t ts) {}
+    virtual void onLastMessageTsUpdated(uint32_t /*ts*/) {}
 
     /**
      * @brief Called when a chat is going to reload its history after the server rejects JOINRANGEHIST
@@ -305,11 +305,11 @@ class Connection;
 class IRtcHandler
 {
 public:
-    virtual void handleMessage(Chat& chat, const StaticBuffer& msg) {}
-    virtual void handleCallData(Chat& chat, karere::Id chatid, karere::Id userid, uint32_t clientid, const StaticBuffer& msg) {}
+    virtual void handleMessage(Chat& /*chat*/, const StaticBuffer& /*msg*/) {}
+    virtual void handleCallData(Chat& /*chat*/, karere::Id /*chatid*/, karere::Id /*userid*/, uint32_t /*clientid*/, const StaticBuffer& /*msg*/) {}
     virtual void onShutdown() {}
-    virtual void onUserOffline(karere::Id chatid, karere::Id userid, uint32_t clientid) {}
-    virtual void onDisconnect(chatd::Connection& conn) {}
+    virtual void onUserOffline(karere::Id /*chatid*/, karere::Id /*userid*/, uint32_t /*clientid*/) {}
+    virtual void onDisconnect(chatd::Connection& /*conn*/) {}
 
     /**
      * @brief This function is used to stop incall timer call during reconnection process

--- a/src/chatdICrypto.h
+++ b/src/chatdICrypto.h
@@ -80,17 +80,17 @@ public:
     /**
      * @brief The chatroom connection (to the chatd server shard) state state has changed.
      */
-    virtual void onOnlineStateChange(ChatState state){}
+    virtual void onOnlineStateChange(ChatState /*state*/){}
 
     /**
      * @brief A user has joined, or their privilege has changed
      * @param privilege - the new privilege, if it is PRIV_NOTPRESENT, then the user
      * left the chat
      */
-    virtual void onUserJoin(karere::Id userid){}
+    virtual void onUserJoin(karere::Id /*userid*/){}
 
     /**  @brief A user has left the room */
-    virtual void onUserLeave(karere::Id userid){}
+    virtual void onUserLeave(karere::Id /*userid*/){}
 
     /**
     * @brief A key was received from the server, and added to Chat.keys

--- a/src/karereCommon.cpp
+++ b/src/karereCommon.cpp
@@ -38,7 +38,7 @@ void globalCleanup()
     services_shutdown();
 }
 
-void RemoteLogger::log(krLogLevel level, const char* msg, size_t len, unsigned flags)
+void RemoteLogger::log(krLogLevel /*level*/, const char* msg, size_t len, unsigned /*flags*/)
 {
 //WARNING:
 //This is a logger callback, and can be called by worker threads.

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -93,7 +93,7 @@ int MegaChatCall::getChanges() const
     return 0;
 }
 
-bool MegaChatCall::hasChanged(int changeType) const
+bool MegaChatCall::hasChanged(int ) const
 {
     return false;
 }
@@ -133,7 +133,7 @@ bool MegaChatCall::isRinging() const
     return false;
 }
 
-int MegaChatCall::getSessionStatus(MegaChatHandle peerId) const
+int MegaChatCall::getSessionStatus(MegaChatHandle /*peerId*/) const
 {
     return SESSION_STATUS_NO_SESSION;
 }
@@ -838,7 +838,7 @@ MegaChatRoomList *MegaChatRoomList::copy() const
     return NULL;
 }
 
-const MegaChatRoom *MegaChatRoomList::get(unsigned int i) const
+const MegaChatRoom *MegaChatRoomList::get(unsigned int /*i*/) const
 {
     return NULL;
 }
@@ -900,27 +900,27 @@ int MegaChatRoom::getOwnPrivilege() const
     return PRIV_UNKNOWN;
 }
 
-int MegaChatRoom::getPeerPrivilegeByHandle(MegaChatHandle userhandle) const
+int MegaChatRoom::getPeerPrivilegeByHandle(MegaChatHandle /*userhandle*/) const
 {
     return PRIV_UNKNOWN;
 }
 
-const char *MegaChatRoom::getPeerFirstnameByHandle(MegaChatHandle userhandle) const
+const char *MegaChatRoom::getPeerFirstnameByHandle(MegaChatHandle /*userhandle*/) const
 {
     return NULL;
 }
 
-const char *MegaChatRoom::getPeerLastnameByHandle(MegaChatHandle userhandle) const
+const char *MegaChatRoom::getPeerLastnameByHandle(MegaChatHandle /*userhandle*/) const
 {
     return NULL;
 }
 
-const char *MegaChatRoom::getPeerFullnameByHandle(MegaChatHandle userhandle) const
+const char *MegaChatRoom::getPeerFullnameByHandle(MegaChatHandle /*userhandle*/) const
 {
     return NULL;
 }
 
-const char *MegaChatRoom::getPeerEmailByHandle(MegaChatHandle userhandle) const
+const char *MegaChatRoom::getPeerEmailByHandle(MegaChatHandle /*userhandle*/) const
 {
     return NULL;
 }
@@ -930,32 +930,32 @@ unsigned int MegaChatRoom::getPeerCount() const
     return 0;
 }
 
-MegaChatHandle MegaChatRoom::getPeerHandle(unsigned int i) const
+MegaChatHandle MegaChatRoom::getPeerHandle(unsigned int /*i*/) const
 {
     return MEGACHAT_INVALID_HANDLE;
 }
 
-int MegaChatRoom::getPeerPrivilege(unsigned int i) const
+int MegaChatRoom::getPeerPrivilege(unsigned int /*i*/) const
 {
     return PRIV_UNKNOWN;
 }
 
-const char *MegaChatRoom::getPeerFirstname(unsigned int i) const
+const char *MegaChatRoom::getPeerFirstname(unsigned int /*i*/) const
 {
     return NULL;
 }
 
-const char *MegaChatRoom::getPeerLastname(unsigned int i) const
+const char *MegaChatRoom::getPeerLastname(unsigned int /*i*/) const
 {
     return NULL;
 }
 
-const char *MegaChatRoom::getPeerFullname(unsigned int i) const
+const char *MegaChatRoom::getPeerFullname(unsigned int /*i*/) const
 {
     return NULL;
 }
 
-const char *MegaChatRoom::getPeerEmail(unsigned int i) const
+const char *MegaChatRoom::getPeerEmail(unsigned int /*i*/) const
 {
     return NULL;
 }
@@ -1040,38 +1040,38 @@ int MegaChatPeerList::size() const
 }
 
 
-void MegaChatVideoListener::onChatVideoData(MegaChatApi *api, MegaChatHandle chatid, int width, int height, char *buffer, size_t size)
+void MegaChatVideoListener::onChatVideoData(MegaChatApi */*api*/, MegaChatHandle /*chatid*/, int /*width*/, int /*height*/, char */*buffer*/, size_t /*size*/)
 {
 
 }
 
 
-void MegaChatCallListener::onChatCallUpdate(MegaChatApi *api, MegaChatCall *call)
+void MegaChatCallListener::onChatCallUpdate(MegaChatApi */*api*/, MegaChatCall */*call*/)
 {
 
 }
 
-void MegaChatListener::onChatListItemUpdate(MegaChatApi *api, MegaChatListItem *item)
+void MegaChatListener::onChatListItemUpdate(MegaChatApi */*api*/, MegaChatListItem */*item*/)
 {
 
 }
 
-void MegaChatListener::onChatInitStateUpdate(MegaChatApi *api, int newState)
+void MegaChatListener::onChatInitStateUpdate(MegaChatApi */*api*/, int /*newState*/)
 {
 
 }
 
-void MegaChatListener::onChatOnlineStatusUpdate(MegaChatApi* api, MegaChatHandle userhandle, int status, bool inProgress)
+void MegaChatListener::onChatOnlineStatusUpdate(MegaChatApi* /*api*/, MegaChatHandle /*userhandle*/, int /*status*/, bool /*inProgress*/)
 {
 
 }
 
-void MegaChatListener::onChatPresenceConfigUpdate(MegaChatApi *api, MegaChatPresenceConfig *config)
+void MegaChatListener::onChatPresenceConfigUpdate(MegaChatApi */*api*/, MegaChatPresenceConfig */*config*/)
 {
 
 }
 
-void MegaChatListener::onChatConnectionStateUpdate(MegaChatApi *api, MegaChatHandle chatid, int newState)
+void MegaChatListener::onChatConnectionStateUpdate(MegaChatApi */*api*/, MegaChatHandle /*chatid*/, int /*newState*/)
 {
 
 }
@@ -1086,7 +1086,7 @@ int MegaChatListItem::getChanges() const
     return 0;
 }
 
-bool MegaChatListItem::hasChanged(int changeType) const
+bool MegaChatListItem::hasChanged(int /*changeType*/) const
 {
     return 0;
 }
@@ -1161,27 +1161,27 @@ MegaChatHandle MegaChatListItem::getLastMessageHandle() const
     return MEGACHAT_INVALID_HANDLE;
 }
 
-void MegaChatRoomListener::onChatRoomUpdate(MegaChatApi *api, MegaChatRoom *chat)
+void MegaChatRoomListener::onChatRoomUpdate(MegaChatApi */*api*/, MegaChatRoom */*chat*/)
 {
 
 }
 
-void MegaChatRoomListener::onMessageLoaded(MegaChatApi *api, MegaChatMessage *msg)
+void MegaChatRoomListener::onMessageLoaded(MegaChatApi */*api*/, MegaChatMessage */*msg*/)
 {
 
 }
 
-void MegaChatRoomListener::onMessageReceived(MegaChatApi *api, MegaChatMessage *msg)
+void MegaChatRoomListener::onMessageReceived(MegaChatApi */*api*/, MegaChatMessage */*msg*/)
 {
 
 }
 
-void MegaChatRoomListener::onMessageUpdate(MegaChatApi *api, MegaChatMessage *msg)
+void MegaChatRoomListener::onMessageUpdate(MegaChatApi */*api*/, MegaChatMessage */*msg*/)
 {
 
 }
 
-void MegaChatRoomListener::onHistoryReloaded(MegaChatApi *api, MegaChatRoom *chat)
+void MegaChatRoomListener::onHistoryReloaded(MegaChatApi */*api*/, MegaChatRoom */*chat*/)
 {
 
 }
@@ -1387,7 +1387,7 @@ MegaChatListItemList *MegaChatListItemList::copy() const
     return NULL;
 }
 
-const MegaChatListItem *MegaChatListItemList::get(unsigned int i) const
+const MegaChatListItem *MegaChatListItemList::get(unsigned int /*i*/) const
 {
     return NULL;
 }

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1531,7 +1531,7 @@ void MegaChatApiImpl::fireOnChatPresenceConfigUpdate(MegaChatPresenceConfig *con
 
 void MegaChatApiImpl::fireOnChatConnectionStateUpdate(MegaChatHandle chatid, int newState)
 {
-    bool allConnected = (newState == MegaChatApi::CHAT_CONNECTION_ONLINE) ? mClient->chatd->areAllChatsLoggedIn() : false;
+    bool allConnected = (newState == MegaChatApi::CHAT_CONNECTION_ONLINE) ? mClient->mChatdClient->areAllChatsLoggedIn() : false;
 
     for(set<MegaChatListener *>::iterator it = listeners.begin(); it != listeners.end() ; it++)
     {
@@ -1692,7 +1692,7 @@ int MegaChatApiImpl::getOnlineStatus()
 {
     sdkMutex.lock();
 
-    int status = mClient ? mClient->ownPresence().status() : MegaChatApi::STATUS_INVALID;
+    int status = mClient ? mClient->ownPresence().status() : (int)MegaChatApi::STATUS_INVALID;
 
     sdkMutex.unlock();
 
@@ -1766,9 +1766,9 @@ int MegaChatApiImpl::getBackgroundStatus()
 
     sdkMutex.lock();
 
-    if (mClient && mClient->chatd)
+    if (mClient && mClient->mChatdClient)
     {
-        status = (mClient->chatd->keepaliveType() == chatd::OP_KEEPALIVE) ? 0 : 1;
+        status = (mClient->mChatdClient->keepaliveType() == chatd::OP_KEEPALIVE) ? 0 : 1;
     }
 
     sdkMutex.unlock();
@@ -2695,7 +2695,7 @@ void MegaChatApiImpl::sendStopTypingNotification(MegaChatHandle chatid, MegaChat
 
 bool MegaChatApiImpl::isMessageReceptionConfirmationActive() const
 {
-    return mClient ? mClient->chatd->isMessageReceivedConfirmationActive() : false;
+    return mClient ? mClient->mChatdClient->isMessageReceivedConfirmationActive() : false;
 }
 
 void MegaChatApiImpl::saveCurrentState()
@@ -4400,7 +4400,7 @@ std::set<MegaChatHandle> *MegaChatRoomHandler::handleNewMessage(MegaChatMessage 
     return msgToUpdate;
 }
 
-void MegaChatRoomHandler::onMemberNameChanged(uint64_t userid, const std::string &newName)
+void MegaChatRoomHandler::onMemberNameChanged(uint64_t /*userid*/, const std::string &/*newName*/)
 {
     MegaChatRoomPrivate *chat = (MegaChatRoomPrivate *) chatApiImpl->getChatRoom(chatid);
     chat->setMembersUpdated();
@@ -4473,7 +4473,7 @@ void MegaChatRoomHandler::onRecvNewMessage(Idx idx, Message &msg, Message::Statu
     }
 }
 
-void MegaChatRoomHandler::onRecvHistoryMessage(Idx idx, Message &msg, Message::Status status, bool isLocal)
+void MegaChatRoomHandler::onRecvHistoryMessage(Idx idx, Message &msg, Message::Status status, bool /*isLocal*/)
 {
     MegaChatMessagePrivate *message = new MegaChatMessagePrivate(msg, status, idx);
     handleHistoryMessage(message);
@@ -5513,7 +5513,7 @@ void MegaChatListItemHandler::onRejoinedChat()
     chatApi.fireOnChatListItemUpdate(item);
 }
 
-void MegaChatListItemHandler::onLastMessageUpdated(const LastTextMsg& msg)
+void MegaChatListItemHandler::onLastMessageUpdated(const LastTextMsg& /*msg*/)
 {
     MegaChatListItemPrivate *item = new MegaChatListItemPrivate(this->mRoom);
     item->setLastMessage();
@@ -5998,7 +5998,7 @@ void LoggerHandler::setLogToConsole(bool enable)
     gLogger.logToConsole(enable);
 }
 
-void LoggerHandler::log(krLogLevel level, const char *msg, size_t len, unsigned flags)
+void LoggerHandler::log(krLogLevel level, const char *msg, size_t /*len*/, unsigned /*flags*/)
 {
     mutex.lock();
     if (megaLogger)
@@ -6089,7 +6089,7 @@ void MegaChatCallHandler::onStateChange(uint8_t newState)
     }
 }
 
-void MegaChatCallHandler::onDestroy(rtcModule::TermCode reason, bool byPeer, const string &msg)
+void MegaChatCallHandler::onDestroy(rtcModule::TermCode /*reason*/, bool /*byPeer*/, const string &/*msg*/)
 {
     assert(chatCall != NULL);
     if (chatCall != NULL)

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -75,7 +75,7 @@ void Client::notifyLoggedIn()
     mLoginPromise.resolve();
 }
 
-void Client::wsCloseCb(int errcode, int errtype, const char *preason, size_t reason_len)
+void Client::wsCloseCb(int errcode, int errtype, const char *preason, size_t /*reason_len*/)
 {
     onSocketClose(errcode, errtype, preason);
 }
@@ -201,7 +201,7 @@ Client::reconnect(const std::string& url)
         setConnState(kResolving);
 
         auto wptr = weakHandle();
-        return retry("presenced", [this](int no, DeleteTrackable::Handle wptr)
+        return retry("presenced", [this](int /*no*/, DeleteTrackable::Handle wptr)
         {
             if (wptr.deleted())
             {

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -276,7 +276,7 @@ protected:
     void setConnState(ConnState newState);
 
     virtual void wsConnectCb();
-    virtual void wsCloseCb(int errcode, int errtype, const char *preason, size_t reason_len);
+    virtual void wsCloseCb(int errcode, int errtype, const char *preason, size_t /*preason_len*/);
     virtual void wsHandleMsgCb(char *data, size_t len);
     
     void onSocketClose(int ercode, int errtype, const std::string& reason);

--- a/src/rtcModule/IVideoRenderer.h
+++ b/src/rtcModule/IVideoRenderer.h
@@ -74,9 +74,9 @@ public:
 class NullRenderer: public IVideoRenderer
 {
 public:
-    virtual void* getImageBuffer(unsigned short width, unsigned short height, void*& userData)
+    virtual void* getImageBuffer(unsigned short /*width*/, unsigned short /*height*/, void*& /*userData*/)
     { return nullptr; }
-    virtual void frameComplete(void* userp) {}
+    virtual void frameComplete(void* /*userp*/) {}
     virtual void released() { delete this; } //we don't post frames to the GUI so no problem with deleting immediately
 };
 }

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -101,7 +101,7 @@ void RtcModule::init()
         KR_LOG_ERROR("Gelb failed with error '%s', using static server list", err.what());
     });
 
-    mClient.chatd->setRtcHandler(this);
+    mClient.mChatdClient->setRtcHandler(this);
 }
 
 IRtcModule* create(karere::Client &client, IGlobalHandler &handler, IRtcCrypto* crypto, const char* iceServers)
@@ -452,7 +452,7 @@ void RtcModule::getVideoInDevices(std::vector<std::string>& devices) const
 std::shared_ptr<Call> RtcModule::startOrJoinCall(karere::Id chatid, AvFlags av,
     ICallHandler& handler, bool isJoin)
 {
-    auto& chat = mClient.chatd->chats(chatid);
+    auto& chat = mClient.mChatdClient->chats(chatid);
     auto callIt = mCalls.find(chatid);
     if (callIt != mCalls.end())
     {

--- a/src/rtcModule/webrtc.h
+++ b/src/rtcModule/webrtc.h
@@ -158,12 +158,12 @@ public:
      * to obtain the ICall object earlier, via this callback.
      */
     virtual void setCall(ICall* call)  = 0;
-    virtual void onStateChange(uint8_t newState) {}
+    virtual void onStateChange(uint8_t /*newState*/) {}
     virtual void onDestroy(TermCode reason, bool byPeer, const std::string& msg) = 0;
-    virtual ISessionHandler* onNewSession(ISession& sess) { return nullptr; }
-    virtual void onLocalStreamObtained(IVideoRenderer*& rendererOut) {}
-    virtual void onLocalMediaError(const std::string errors) {}
-    virtual void onRingOut(karere::Id peer) {}
+    virtual ISessionHandler* onNewSession(ISession& /*sess*/) { return nullptr; }
+    virtual void onLocalStreamObtained(IVideoRenderer*& /*rendererOut*/) {}
+    virtual void onLocalMediaError(const std::string /*errors*/) {}
+    virtual void onRingOut(karere::Id /*peer*/) {}
     virtual void onCallStarting() {}
     virtual void onCallStarted() {}
 };

--- a/src/sdkApi.h
+++ b/src/sdkApi.h
@@ -44,7 +44,7 @@ class MyListener: public mega::MegaRequestListener
 public:
     MyListener(void *ctx, karere::DeleteTrackable::Handle wptr) : appCtx(ctx), wptr(wptr) { }
     ApiPromise mPromise;
-    virtual void onRequestFinish(mega::MegaApi* api, mega::MegaRequest *request, mega::MegaError* e)
+    virtual void onRequestFinish(mega::MegaApi* /*api*/, mega::MegaRequest *request, mega::MegaError* e)
     {
         if (wptr.deleted())
             return;
@@ -84,7 +84,7 @@ public:
     MyListenerNoResult(void *ctx, karere::DeleteTrackable::Handle wptr) : appCtx(ctx), wptr(wptr) { }
 
     promise::Promise<void> mPromise;
-    virtual void onRequestFinish(mega::MegaApi* api, mega::MegaRequest *request, mega::MegaError* e)
+    virtual void onRequestFinish(mega::MegaApi* /*api*/, mega::MegaRequest */*request*/, mega::MegaError* e)
     {
         int errCode = e->getErrorCode();
         karere::marshallCall([this, errCode]()
@@ -113,7 +113,7 @@ public:
 
 class MyMegaLogger: public ::mega::MegaLogger
 {
-    virtual void log(const char *time, int loglevel, const char *source, const char *message)
+    virtual void log(const char */*time*/, int loglevel, const char *source, const char *message)
     {
         static krLogLevel sdkToKarereLogLevels[mega::MegaApi::LOG_LEVEL_MAX+1] =
         {

--- a/src/strongvelope/strongvelope.cpp
+++ b/src/strongvelope/strongvelope.cpp
@@ -1287,7 +1287,7 @@ void ProtocolHandler::onUserJoin(Id userid)
     mUserAttrCache.getAttr(userid, USER_ATTR_RSA_PUBKEY, nullptr, nullptr);
 }
 
-void ProtocolHandler::onUserLeave(Id userid)
+void ProtocolHandler::onUserLeave(Id /*userid*/)
 {
     mParticipantsChanged = true;
     resetSendKey(); //just in case

--- a/src/userAttrCache.cpp
+++ b/src/userAttrCache.cpp
@@ -45,7 +45,7 @@ inline static Buffer* bufFromTLV(const ::mega::MegaStringMap *map, const char *k
     return buf ? new Buffer(buf, strlen(buf)) : new Buffer(nullptr, 0);
 }
 
-Buffer* getDataNotImpl(const ::mega::MegaRequest& req)
+Buffer* getDataNotImpl(const ::mega::MegaRequest& /*req*/)
 {
      throw std::runtime_error("Not implemented");
 }
@@ -324,7 +324,7 @@ void UserAttrCacheItem::error(UserAttrPair key, int errCode)
     notify();
 }
 
-void UserAttrCacheItem::errorNoDb(int errCode)
+void UserAttrCacheItem::errorNoDb(int /*errCode*/)
 {
     pending = kCacheFetchNotPending;
     data.reset();
@@ -459,7 +459,7 @@ void UserAttrCache::fetchUserFullName(UserAttrPair key, std::shared_ptr<UserAttr
         if (!data->empty())
             ctx->firstname.assign(data->buf(), data->dataSize());
     })
-    .fail([](const Error& err)
+    .fail([](const Error& /*err*/)
     {
         return _Void();
     });
@@ -470,7 +470,7 @@ void UserAttrCache::fetchUserFullName(UserAttrPair key, std::shared_ptr<UserAttr
         if (!data->empty())
             ctx->lastname.assign(data->buf(), data->dataSize());
     })
-    .fail([](const Error& err)
+    .fail([](const Error& /*err*/)
     {
         return _Void();
     });

--- a/src/userAttrCache.h
+++ b/src/userAttrCache.h
@@ -51,7 +51,7 @@ struct UserAttrDesc
     int type;
     GetDataFunc getData;
     int changeMask;
-    UserAttrDesc(int aType, GetDataFunc aGetData, int aChangeMask, unsigned char aFlags = 0)
+    UserAttrDesc(int aType, GetDataFunc aGetData, int aChangeMask)
         :type(aType), getData(aGetData), changeMask(aChangeMask){}
 };
 


### PR DESCRIPTION
- Clean warnings related to unused params.
- Clean warnings related to comparisions between different types: enums
with integers and similar.
- Remove unused methods.
- Refactoring of some members, like `client` --> `mKarereClient` and
similar.
- Fix wrong order of initialization list of members in `ChatClient`.
- Reorder of members in `ChatClient`