### PR TITLE
Fix race-condition loading contacts

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -720,6 +720,7 @@ void Client::onRequestFinish(::mega::MegaApi* apiObj, ::mega::MegaRequest *reque
                 checkSyncWithSdkDb(scsn, *contactList, *chatList);
                 setInitState(kInitHasOnlineSession);
                 mSessionReadyPromise.resolve();
+                api.sdk.resumeActionPackets();
             }
             else if (state == kInitWaitingNewSession || state == kInitErrNoCache)
             {
@@ -729,15 +730,16 @@ void Client::onRequestFinish(::mega::MegaApi* apiObj, ::mega::MegaRequest *reque
                 .fail([this](const promise::Error& err)
                 {
                     mSessionReadyPromise.reject(err);
+                    api.sdk.resumeActionPackets();
                     return err;
                 })
                 .then([this]()
                 {
                     setInitState(kInitHasOnlineSession);
                     mSessionReadyPromise.resolve();
+                    api.sdk.resumeActionPackets();
                 });
             }
-            api.sdk.resumeActionPackets();
         }, appCtx);
         break;
     }


### PR DESCRIPTION
When callback for fetchnodes completion is received by MEGAchat, in case
it's a new session (or there's no cache for MEGAchat), the resumption of
actionpackets must not happen until the MEGAchat client is fully
initialized. However, the `initWithNewSession()` is asynchronous and it
means that updates from actionpackets may happen before the engine is
fully initialized.
This commit solves the issue and the eventually failed assertion
`assert(mContactsLoaded)` in the callback `onChatsUpdate()`, which was
called as soon as there are pending APs received right after the
fetchnodes, while MEGAchat is fetching own keys.