### PR TITLE
Fix race-condition in find last text message

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3847,7 +3847,7 @@ bool Chat::findLastTextMsg()
         if (wptr.deleted())
             return;
 
-        if (mOnlineState == kChatStateOnline)
+        if (mOnlineState == kChatStateOnline && !mLastTextMsg.isFetching())
         {
             CHATID_LOG_DEBUG("lastTextMessage: fetching history from server");
 


### PR DESCRIPTION
It may happen that multiple marshall calls get queued, resulting on more
than one `HIST` sent to server, which is ilegal and causes issues. This
commit aims to protect against parallel requests to fetch messages.