### PR TITLE
Notify when a call is in progress

### DIFF
--- a/platforms/android/env-android.sh
+++ b/platforms/android/env-android.sh
@@ -13,7 +13,7 @@ fi
 # The -march value that will be passed to the compiler
 if [ -z "$XENV_TARGET_ARCH" ]; then
     export XENV_TARGET_ARCH=arm
-    export XENV_TARGET_SUBARCH=v7a
+    export XENV_TARGET_SUBARCH=v7-a
 fi
 
 #=== End of user-set variables

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -548,6 +548,7 @@ void Client::onEvent(::mega::MegaApi* /*api*/, ::mega::MegaEvent* event)
 #ifndef KARERE_DISABLE_WEBRTC
             if (rtc && rtc->isCallInProgress())
             {
+                KR_LOG_WARNING("EVENT_DISCONNECT --> skipping reconnection triggered by SDK because there's a call in progress");
                 break;
             }
 #endif
@@ -1840,6 +1841,11 @@ promise::Promise<void> ChatRoom::truncateHistory(karere::Id msgId)
     });
 }
 
+bool ChatRoom::isCallInProgress() const
+{
+    return parent.mKarereClient.isCallInProgress(mChatid);
+}
+
 promise::Promise<void> ChatRoom::archiveChat(bool archive)
 {
     auto wptr = getDelTracker();
@@ -3097,14 +3103,14 @@ const char* Client::connStateToStr(ConnState state)
     }
 }
 
-bool Client::isCallInProgress() const
+bool Client::isCallInProgress(Id chatid) const
 {
     bool callInProgress = false;
 
 #ifndef KARERE_DISABLE_WEBRTC
     if (rtc)
     {
-        callInProgress = rtc->isCallInProgress();
+        callInProgress = rtc->isCallInProgress(chatid);
     }
 #endif
 

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -109,6 +109,8 @@ public:
     /** @brief Whether this chatroom is archived or not */
     bool isArchived() const { return mIsArchived; }
 
+    bool isCallInProgress() const;
+
     /** @brief The websocket url that is used to connect to chatd for that chatroom. Contains an authentication token */
     const std::string& url() const { return mUrl; }
 
@@ -843,7 +845,8 @@ public:
     createGroupChat(std::vector<std::pair<uint64_t, chatd::Priv>> peers);
     void setCommitMode(bool commitEach);
     void saveDb();  // forces a commit
-    bool isCallInProgress() const;
+
+    bool isCallInProgress(karere::Id chatid = karere::Id::inval()) const;
 
     promise::Promise<void> pushReceived();
     void onSyncReceived(karere::Id chatid); // called upon SYNC reception

--- a/src/chatdDb.h
+++ b/src/chatdDb.h
@@ -262,7 +262,7 @@ public:
             auto msg = new chatd::Message(msgid, userid, ts, stmt.intCol(8), std::move(buf),
                 false, keyid, (unsigned char)stmt.intCol(3));
             msg->backRefId = stmt.uint64Col(7);
-            msg->setEncrypted(stmt.intCol(9));
+            msg->setEncrypted((uint8_t)stmt.intCol(9));
             messages.push_back(msg);
         }
     }

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -1220,6 +1220,11 @@ bool MegaChatListItem::isArchived() const
     return false;
 }
 
+bool MegaChatListItem::isCallInProgress() const
+{
+    return false;
+}
+
 MegaChatHandle MegaChatListItem::getPeerHandle() const
 {
     return MEGACHAT_INVALID_HANDLE;

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -3760,7 +3760,8 @@ public:
         CHANGE_TYPE_CLOSED          = 0x20, /// The chatroom has been left by own user
         CHANGE_TYPE_LAST_MSG        = 0x40, /// Last message recorded in the history, or chatroom creation data if no history at all (not even clear-history message)
         CHANGE_TYPE_LAST_TS         = 0x80, /// Timestamp of the last activity
-        CHANGE_TYPE_ARCHIVE         = 0X100 /// Archived or unarchived
+        CHANGE_TYPE_ARCHIVE         = 0x100,/// Archived or unarchived
+        CHANGE_TYPE_CALL            = 0x200 /// There's a new call or a call has finished
     };
 
     virtual ~MegaChatListItem() {}
@@ -3916,6 +3917,12 @@ public:
     virtual bool isArchived() const;
 
     /**
+     * @brief Returns whether the chat has a call in progress or not.
+     * @return True if a call is in progress in this chat, false otherwise.
+     */
+    virtual bool isCallInProgress() const;
+
+    /**
      * @brief Returns the userhandle of the Contact in 1on1 chatrooms
      *
      * The returned value is only valid for 1on1 chatrooms. For groupchats, it will
@@ -3960,7 +3967,7 @@ public:
         CHANGE_TYPE_CLOSED              = 0x20, /// The chatroom has been left by own user
         CHANGE_TYPE_OWN_PRIV            = 0x40, /// Our privilege level has changed
         CHANGE_TYPE_USER_STOP_TYPING    = 0x80, /// User has stopped to typing. \see MegaChatRoom::getUserTyping()
-        CHANGE_TYPE_ARCHIVE             = 0X100 /// Archived or unarchived
+        CHANGE_TYPE_ARCHIVE             = 0x100 /// Archived or unarchived
     };
 
     enum {

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1583,6 +1583,19 @@ void MegaChatApiImpl::fireOnChatCallUpdate(MegaChatCallPrivate *call)
         (*it)->onChatCallUpdate(chatApi, call);
     }
 
+    if (call->hasChanged(MegaChatCall::CHANGE_TYPE_STATUS)
+            && (call->getStatus() == MegaChatCall::CALL_STATUS_RING_IN          // for callee, incoming call
+                || call->getStatus() == MegaChatCall::CALL_STATUS_REQUEST_SENT  // for caller, outgoing call
+                || call->getStatus() == MegaChatCall::CALL_STATUS_DESTROYED))   // call finished
+    {
+        // notify at MegaChatListItem level about new calls and calls being terminated
+        ChatRoom *room = findChatRoom(call->getChatid());
+        MegaChatListItemPrivate *item = new MegaChatListItemPrivate(*room);
+        item->setCallInProgress();
+
+        fireOnChatListItemUpdate(item);
+    }
+
     call->removeChanges();
 }
 
@@ -5760,6 +5773,7 @@ MegaChatListItemPrivate::MegaChatListItemPrivate(ChatRoom &chatroom)
     this->active = chatroom.isActive();
     this->ownPriv = chatroom.ownPriv();
     this->archived =  chatroom.isArchived();
+    this->mIsCallInProgress = chatroom.isCallInProgress();
     this->changed = 0;
     this->peerHandle = !group ? ((PeerChatRoom&)chatroom).peer() : MEGACHAT_INVALID_HANDLE;
     this->lastMsgPriv = Priv::PRIV_INVALID;
@@ -5851,6 +5865,7 @@ MegaChatListItemPrivate::MegaChatListItemPrivate(const MegaChatListItem *item)
     this->peerHandle = item->getPeerHandle();
     this->mLastMsgId = item->getLastMessageId();
     this->archived = item->isArchived();
+    this->mIsCallInProgress = item->isCallInProgress();
     this->lastMsgPriv = item->getLastMessagePriv();
     this->lastMsgHandle = item->getLastMessageHandle();
 }
@@ -5934,6 +5949,11 @@ bool MegaChatListItemPrivate::isArchived() const
     return archived;
 }
 
+bool MegaChatListItemPrivate::isCallInProgress() const
+{
+    return mIsCallInProgress;
+}
+
 MegaChatHandle MegaChatListItemPrivate::getPeerHandle() const
 {
     return peerHandle;
@@ -5987,6 +6007,11 @@ void MegaChatListItemPrivate::setArchived(bool archived)
 {
     this->archived = archived;
     this->changed |= MegaChatListItem::CHANGE_TYPE_ARCHIVE;
+}
+
+void MegaChatListItemPrivate::setCallInProgress()
+{
+    this->changed |= MegaChatListItem::CHANGE_TYPE_CALL;
 }
 
 void MegaChatListItemPrivate::setLastMessage()

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1584,9 +1584,10 @@ void MegaChatApiImpl::fireOnChatCallUpdate(MegaChatCallPrivate *call)
     }
 
     if (call->hasChanged(MegaChatCall::CHANGE_TYPE_STATUS)
-            && (call->getStatus() == MegaChatCall::CALL_STATUS_RING_IN          // for callee, incoming call
-                || call->getStatus() == MegaChatCall::CALL_STATUS_REQUEST_SENT  // for caller, outgoing call
-                || call->getStatus() == MegaChatCall::CALL_STATUS_DESTROYED))   // call finished
+            && (call->getStatus() == MegaChatCall::CALL_STATUS_RING_IN              // for callee, incoming call
+                || call->getStatus() == MegaChatCall::CALL_STATUS_USER_NO_PRESENT   // for callee (groupcalls)
+                || call->getStatus() == MegaChatCall::CALL_STATUS_REQUEST_SENT      // for caller, outgoing call
+                || call->getStatus() == MegaChatCall::CALL_STATUS_DESTROYED))       // call finished
     {
         // notify at MegaChatListItem level about new calls and calls being terminated
         ChatRoom *room = findChatRoom(call->getChatid());

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -324,6 +324,7 @@ private:
     bool group;
     bool active;
     bool archived;
+    bool mIsCallInProgress;
     MegaChatHandle peerHandle;  // only for 1on1 chatrooms
     MegaChatHandle mLastMsgId;
     int lastMsgPriv;
@@ -345,6 +346,7 @@ public:
     virtual bool isGroup() const;
     virtual bool isActive() const;
     virtual bool isArchived() const;
+    virtual bool isCallInProgress() const;
     virtual MegaChatHandle getPeerHandle() const;
     virtual int getLastMessagePriv() const;
     virtual MegaChatHandle getLastMessageHandle() const;
@@ -356,6 +358,7 @@ public:
     void setClosed();
     void setLastTimestamp(int64_t ts);
     void setArchived(bool);
+    void setCallInProgress();
 
     /**
      * If the message is of type MegaChatMessage::TYPE_ATTACHMENT, this function

--- a/src/net/libwsIO.cpp
+++ b/src/net/libwsIO.cpp
@@ -62,11 +62,16 @@ bool LibwsIO::wsResolveDNS(const char *hostname, std::function<void (int, std::v
         {
             ipv4 = ip;
         }
-        f(0, ipv4, ipv6);
+        std::vector<std::string> vs4;
+        vs4.push_back(ipv4);
+        std::vector<std::string> vs6;
+        vs6.push_back(ipv6);
+        f(0, vs4, vs6);
     })
     .fail([f](const promise::Error& err)
-    {       
-        f(err.code(), string(), string());
+    {
+        std::vector<std::string> vs;
+        f(err.code(), vs, vs);
     });
     return 0;
 }

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -124,15 +124,15 @@ enum: uint8_t
       */
     OP_ADDPEERS = 4,
 
-    /**
-      * @brief
-      * C->S
-      * This command is sent when the client doesn't want to know the status of a peer or a contact
-      * anymore. In example, the contact relationship is broken or a non-contact doesn't participate
-      * in any groupchat any longer.
-      *
-      * <1> <peerHandle>
-      */
+     /**
+     * @brief
+     * C->S
+     * This command is sent when the client doesn't want to a peer to see its status
+     * anymore. In example, the contact relationship is broken or a non-contact doesn't participate
+     * in any groupchat any longer.
+     *
+     * <1> <peerHandle>
+     */
     OP_DELPEERS = 5,
 
     /**

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -534,17 +534,27 @@ void RtcModule::setPcConstraint(const string& name, const string &value, bool op
     rtcModule::setConstraint(mPcConstraints, name, value, optional);
 }
 
-bool RtcModule::isCallInProgress() const
+bool RtcModule::isCallInProgress(Id chatid) const
 {
     bool callInProgress = false;
 
-    for (auto& item: mCalls)
+    if (chatid.isValid())
     {
-        auto& call = item.second;
-        if (call->state() == Call::kStateInProgress || call->state() == Call::kStateReqSent)
+        auto it = mCalls.find(chatid);
+        if (it != mCalls.end())
         {
-            callInProgress = true;
-            break;
+            callInProgress = it->second->isInProgress();
+        }
+    }
+    else    // find a call in progress in any chatroom
+    {
+        for (auto it: mCalls)
+        {
+            if (it.second->isInProgress())
+            {
+                callInProgress = true;
+                break;
+            }
         }
     }
 
@@ -2696,6 +2706,11 @@ const char* ICall::stateToStr(uint8_t state)
         RET_ENUM_NAME(kStateDestroyed);
         default: return "(invalid call state)";
     }
+}
+
+bool ICall::isInProgress() const
+{
+    return (mState > Call::kStateInitial && mState < Call::kStateTerminating);
 }
 
 const char* ISession::stateToStr(uint8_t state)

--- a/src/rtcModule/webrtc.h
+++ b/src/rtcModule/webrtc.h
@@ -275,6 +275,7 @@ public:
     void changeHandler(ICallHandler* handler) { mHandler = handler; }
     TermCode termCode() const {return mTermCode; }
     bool isJoiner() { return mIsJoiner; }
+    bool isInProgress() const;
     ICallHandler *callHandler() { return mHandler; }
     virtual karere::AvFlags sentAv() const = 0;
     virtual void hangup(TermCode reason=TermCode::kInvalid) = 0;
@@ -367,9 +368,9 @@ public:
     virtual bool isCaptureActive() const = 0;
     virtual void setMediaConstraint(const std::string& name, const std::string &value, bool optional=false) = 0;
     virtual void setPcConstraint(const std::string& name, const std::string &value, bool optional=false) = 0;
-    virtual bool isCallInProgress() const = 0;
     virtual void removeCall(karere::Id chatid, bool keepCallHandler = false) = 0;
     virtual void removeCallWithoutParticipants(karere::Id chatid) = 0;
+    virtual bool isCallInProgress(karere::Id chatid = karere::Id::inval()) const = 0;
 
     virtual ICall& joinCall(karere::Id chatid, karere::AvFlags av, ICallHandler& handler, karere::Id callid) = 0;
     virtual ICall& startCall(karere::Id chatid, karere::AvFlags av, ICallHandler& handler) = 0;

--- a/src/rtcModule/webrtcPrivate.h
+++ b/src/rtcModule/webrtcPrivate.h
@@ -218,7 +218,7 @@ public:
     virtual bool isCaptureActive() const;
     virtual void setMediaConstraint(const std::string& name, const std::string &value, bool optional);
     virtual void setPcConstraint(const std::string& name, const std::string &value, bool optional);
-    virtual bool isCallInProgress() const;
+    virtual bool isCallInProgress(karere::Id chatid) const;
     virtual void removeCall(karere::Id chatid, bool keepCallHandler = false);
     virtual void removeCallWithoutParticipants(karere::Id chatid);
     virtual void addCallHandler(karere::Id chatid, ICallHandler* callHandler);


### PR DESCRIPTION
Testing this branch it seems that WebRTC notifies the same status more than once. It may need adjustments to avoid so.
Steps: 
 - User A starts a groupcall
 - User B launches the app and gets notified about the groupcall as user not present, but more than once.