### PR TITLE
Avoid to consider management msgs for backrefids

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2718,6 +2718,12 @@ Idx Chat::msgConfirm(Id msgxid, Id msgid)
     auto idx = mIdToIndexMap[msgid] = highnum();
     CALL_DB(addMsgToHistory, *msg, idx);
 
+    assert(msg->backRefId);
+    if (!mRefidToIdxMap.emplace(msg->backRefId, idx).second)
+    {
+        CALL_LISTENER(onMsgOrderVerificationFail, *msg, idx, "A message with that backrefId "+std::to_string(msg->backRefId)+" already exists");
+    }
+
     //update any following MSGUPDX-s referring to this msgxid
     int count = 0;
     for (auto& item: mSending)

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2071,27 +2071,17 @@ void Chat::createMsgBackRefs(Chat::OutputQueue::iterator msgit)
             idx = rangeStart;
         }
 
-        uint64_t backref = 0;
-        if (idx < (Idx)sendingIdx.size())
+        Message &msg = (idx < (Idx)sendingIdx.size())
+                ? *(sendingIdx[sendingIdx.size()-1-idx]->msg)   // msg is from sending queue
+                : at(highnum()-(idx-sendingIdx.size()));        // msg is from history buffer
+
+        if (!msg.isManagementMessage()) // management-msgs don't have a valid backrefid
         {
-            backref = sendingIdx[sendingIdx.size()-1-idx]->msg->backRefId; // reference a not-yet confirmed message
+            msgit->msg->backRefs.push_back(msg.backRefId);
         }
         else
         {
-            Message &msg = at(highnum()-(idx-sendingIdx.size()));
-            if (!msg.isManagementMessage()) // management-msgs don't have a valid backrefid
-            {
-                backref = at(highnum()-(idx-sendingIdx.size())).backRefId; // reference a regular history message
-            }
-            else
-            {
-                CHATID_LOG_WARNING("Skipping backrefid for a management message: %s", ID_CSTR(msg.id()));
-            }
-        }
-
-        if (backref)
-        {
-            msgit->msg->backRefs.push_back(backref);
+            CHATID_LOG_WARNING("Skipping backrefid for a management message: %s", ID_CSTR(msg.id()));
         }
 
         if (rangeEnd == maxEnd)

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2082,6 +2082,8 @@ void Chat::createMsgBackRefs(Chat::OutputQueue::iterator msgit)
         else
         {
             CHATID_LOG_WARNING("Skipping backrefid for a management message: %s", ID_CSTR(msg.id()));
+            // TODO: instead of skipping the backrefid for this range, we should try to find another
+            // message with a valid backrefid within the current range
         }
 
         if (rangeEnd == maxEnd)

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3616,6 +3616,7 @@ void Chat::verifyMsgOrder(const Message& msg, Idx idx)
         if (targetIdx >= idx)
         {
             CALL_LISTENER(onMsgOrderVerificationFail, msg, idx, "Message order verification failed, possible history tampering");
+            client().karereClient->api.callIgnoreResult(&::mega::MegaApi::sendEvent, 99616, "order tampering");
             return;
         }
     }

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3616,7 +3616,7 @@ void Chat::verifyMsgOrder(const Message& msg, Idx idx)
         if (targetIdx >= idx)
         {
             CALL_LISTENER(onMsgOrderVerificationFail, msg, idx, "Message order verification failed, possible history tampering");
-            client().karereClient->api.callIgnoreResult(&::mega::MegaApi::sendEvent, 99616, "order tampering");
+            client().karereClient->api.callIgnoreResult(&::mega::MegaApi::sendEvent, 99000, "order tampering native");
             return;
         }
     }

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2071,17 +2071,28 @@ void Chat::createMsgBackRefs(Chat::OutputQueue::iterator msgit)
             idx = rangeStart;
         }
 
-        uint64_t backref;
+        uint64_t backref = 0;
         if (idx < (Idx)sendingIdx.size())
         {
             backref = sendingIdx[sendingIdx.size()-1-idx]->msg->backRefId; // reference a not-yet confirmed message
         }
         else
         {
-            backref = at(highnum()-(idx-sendingIdx.size())).backRefId; // reference a regular history message
+            Message &msg = at(highnum()-(idx-sendingIdx.size()));
+            if (!msg.isManagementMessage()) // management-msgs don't have a valid backrefid
+            {
+                backref = at(highnum()-(idx-sendingIdx.size())).backRefId; // reference a regular history message
+            }
+            else
+            {
+                CHATID_LOG_WARNING("Skipping backrefid for a management message: %s", ID_CSTR(msg.id()));
+            }
         }
 
-        msgit->msg->backRefs.push_back(backref);
+        if (backref)
+        {
+            msgit->msg->backRefs.push_back(backref);
+        }
 
         if (rangeEnd == maxEnd)
         {

--- a/src/strongvelope/strongvelope.h
+++ b/src/strongvelope/strongvelope.h
@@ -171,8 +171,6 @@ struct ParsedMessage: public karere::DeleteTrackable
     Buffer signedContent;
     Buffer signature;
     unsigned char type;
-    chatd::BackRefId backRefId = 0;
-    std::vector<chatd::BackRefId> backRefs;
     //legacy key stuff
     uint64_t keyId;
     uint64_t prevKeyId;


### PR DESCRIPTION
Management messages are created by server and, therefore, they are not
client-side encrypted. They don't include any `backrefid`, so they
shouldn't be used to prepare the array of `backrefids` that are later
used to verification of the order.

In order to send the event when a msg order tampering is detected, we need the SDK branch `feature/new-event-types` (https://github.com/meganz/sdk/pull/1140)