### PR TITLE
Update chatd protocol

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1487,6 +1487,14 @@ void Connection::execCommand(const StaticBuffer& buf)
                 mChatdClient.karereClient->onSyncReceived(chatid);
                 break;
             }
+            case OP_CALLTIME:
+            {
+                READ_CHATID(0);
+                READ_32(duration, 8);
+                CHATDS_LOG_DEBUG("%s: recv CALLTIME: %d", ID_CSTR(chatid), duration);
+                // TODO: add management of calltime (for groupcalling)
+                break;
+            }
             default:
             {
                 CHATDS_LOG_ERROR("Unknown opcode %d, ignoring all subsequent commands", opcode);
@@ -2400,7 +2408,7 @@ void Chat::onLastSeen(Id msgid)
     {
         if (mLastSeenIdx == CHATD_IDX_INVALID)  // don't have a previous idx yet --> initialization
         {
-            CHATID_LOG_DEBUG("setMessageSeen: Setting last seen msgid to %s", ID_CSTR(msgid));
+            CHATID_LOG_DEBUG("onLastSeen: Setting last seen msgid to %s", ID_CSTR(msgid));
             mLastSeenId = msgid;
             CALL_DB(setLastSeen, msgid);
 

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -69,7 +69,6 @@ enum HistSource
 enum { kSeenTimeout = 200 };
 /** Timeout to recv SYNC (Milliseconds)**/
 enum { kSyncTimeout = 2500 };
-enum { kProtocolVersion = 0x01 };
 enum { kMaxMsgSize = 120000 };  // (in bytes)
 
 class DbInterface;
@@ -1184,7 +1183,11 @@ public:
     //  * Add commands CALLDATA and REJECT
     // - Version 2:
     //  * Add call-logging messages
-    static const unsigned chatdVersion = 2;
+    // - Version 3:
+    //  * Add CALLTIME command
+    // - Version 4:
+    //  * Add echo for SEEN command (with seen-pointer up-to-date)
+    static const unsigned chatdVersion = 4;
 };
 
 static inline const char* connStateToStr(Connection::State state)

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -86,7 +86,8 @@ enum Opcode
       *   managed across devices.
       * Send: <chatid> <msgid>
       *
-      * S->C: The last seen message has been updated from another device.
+      * S->C: The last seen message has been updated (from another device or current
+      * device). Also received as part of the login process.
       * Receive: <chatid> <msgid>
       */
     OP_SEEN = 5,
@@ -338,7 +339,15 @@ enum Opcode
       */
     OP_SYNC = 38,
 
-    OP_LAST = OP_DELREACTION
+    /**
+      ** @brief <chatid> <callDuration.4>
+      *
+      * S->C: inform about call duration in seconds for a call that exists before we get online.
+      * It is sent before any INCALL or CALLDATA.
+      */
+    OP_CALLTIME = 42,
+
+    OP_LAST = OP_CALLTIME
 };
 
 // privilege levels


### PR DESCRIPTION
chatd v4 acknowledges the seen pointer when set, or responds with the updated seen pointer if newer.
chatd v3 sends a CALLTIME when there's a groupcall in-progress. Need to consume those bytes from the buffer.