### PR TITLE
 Manage termination code kErrNotSupported

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -438,6 +438,20 @@ void Connection::sendEcho()
     sendBuf(Command(OP_ECHO));
 }
 
+void Connection::sendCallReqDeclineNoSupport(Id chatid, Id callid)
+{
+    Command msg(OP_RTMSG_BROADCAST);
+    msg.write<uint64_t>(1, chatid.val);
+    msg.write<uint64_t>(9, 0);
+    msg.write<uint32_t>(17, 0);
+    msg.write<uint16_t>(21, 10);        // Payload length -> opCode(1) + callid(8) + termCode(1)
+    msg.write<uint8_t>(23, rtcModule::RTCMD_CALL_REQ_DECLINE);          // RTCMD_CALL_REQ_DECLINE
+    msg.write<uint64_t>(24, callid.val);
+    msg.write<uint8_t>(32, rtcModule::kErrNotSupported);         // Termination code kErrNotSupported = 37
+    auto& chat = mChatdClient.chats(chatid);
+    chat.sendCommand(std::move(msg));
+}
+
 Promise<void> Connection::reconnect()
 {
     mChatdClient.karereClient->setCommitMode(false);
@@ -1407,18 +1421,9 @@ void Connection::execCommand(const StaticBuffer& buf)
 #else
                 READ_ID(callid, 22);
                 READ_8(state, 30);
-                if (state == kCallDataRinging) // Ringing state
+                if (state == rtcModule::kCallDataRinging) // Ringing state
                 {
-                    chatd::Command msg(chatd::OP_RTMSG_BROADCAST);
-                    msg.write<uint64_t>(1, chatid.val);
-                    msg.write<uint64_t>(9, 0);
-                    msg.write<uint32_t>(17, 0);
-                    msg.write<uint16_t>(21, 10);        // Payload length -> opCode(1) + callid(8) + termCode(1)
-                    msg.write<uint8_t>(23, RTCMD_CALL_REQ_DECLINE);          // RTCMD_CALL_REQ_DECLINE
-                    msg.write<uint64_t>(24, callid.val);
-                    msg.write<uint8_t>(32, kErrNotSupported);         // Termination code kErrNotSupported = 37
-                    auto& chat = mChatdClient.chats(chatid);
-                    chat.sendCommand(std::move(msg));
+                    sendCallReqDeclineNoSupport(chatid, callid);
                 }
 
                 pos += payloadLen - 9;  // 9 -> callid(8) + state(1)

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1407,21 +1407,21 @@ void Connection::execCommand(const StaticBuffer& buf)
 #else
                 READ_ID(callid, 22);
                 READ_8(state, 30);
-                if (state == 1) // Ringing state
+                if (state == kCallDataRinging) // Ringing state
                 {
                     chatd::Command msg(chatd::OP_RTMSG_BROADCAST);
                     msg.write<uint64_t>(1, chatid.val);
                     msg.write<uint64_t>(9, 0);
                     msg.write<uint32_t>(17, 0);
-                    msg.write<uint16_t>(21, 10);        // Payload length
-                    msg.write<uint8_t>(23, 2);          // RTCMD_CALL_REQ_DECLINE
+                    msg.write<uint16_t>(21, 10);        // Payload length -> opCode(1) + callid(8) + termCode(1)
+                    msg.write<uint8_t>(23, RTCMD_CALL_REQ_DECLINE);          // RTCMD_CALL_REQ_DECLINE
                     msg.write<uint64_t>(24, callid.val);
-                    msg.write<uint8_t>(32, 37);         // Termination code kErrNotSupported = 37
+                    msg.write<uint8_t>(32, kErrNotSupported);         // Termination code kErrNotSupported = 37
                     auto& chat = mChatdClient.chats(chatid);
                     chat.sendCommand(std::move(msg));
                 }
 
-                pos += payloadLen - 9;
+                pos += payloadLen - 9;  // 9 -> callid(8) + state(1)
 #endif
 
                 break;

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1413,10 +1413,10 @@ void Connection::execCommand(const StaticBuffer& buf)
                     msg.write<uint64_t>(1, chatid.val);
                     msg.write<uint64_t>(9, 0);
                     msg.write<uint32_t>(17, 0);
-                    msg.write<uint16_t>(21, 10); // Payload length
-                    msg.write<uint8_t>(23, ::rtcModule::RTCMD_CALL_REQ_DECLINE);
+                    msg.write<uint16_t>(21, 10);        // Payload length
+                    msg.write<uint8_t>(23, 2);          // RTCMD_CALL_REQ_DECLINE
                     msg.write<uint64_t>(24, callid.val);
-                    msg.write<uint8_t>(32, 37);      // Termination code kErrNotSupported = 37
+                    msg.write<uint8_t>(32, 37);         // Termination code kErrNotSupported = 37
                     auto& chat = mChatdClient.chats(chatid);
                     chat.sendCommand(std::move(msg));
                 }

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -382,6 +382,7 @@ protected:
     void execCommand(const StaticBuffer& buf);
     bool sendKeepalive(uint8_t opcode);
     void sendEcho();
+    void sendCallReqDeclineNoSupport(karere::Id chatid, karere::Id callid);
     friend class Client;
     friend class Chat;
 public:

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -202,6 +202,11 @@ bool MegaChatCall::isOutgoing() const
     return false;
 }
 
+MegaChatHandle MegaChatCall::getCaller() const
+{
+    return MEGACHAT_INVALID_HANDLE;
+}
+
 MegaChatApi::MegaChatApi(MegaApi *megaApi)
 {
     this->pImpl = new MegaChatApiImpl(this, megaApi);

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -495,7 +495,7 @@ public:
      * @brief Returns the handle from user that has started the call
      *
      * This function only returns a valid value when call is or has gone through CALL_STATUS_RING_IN state.
-     * In other case will be MEGACHAT_INVALID_HANDLE
+     * In any other case, it will be MEGACHAT_INVALID_HANDLE
      *
      * @return user handle of caller
      */

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -479,15 +479,27 @@ public:
 
     /**
      * @brief Returns if call is incoming
+     *
      * @return Ture if incoming call, false if outgoing
      */
     virtual bool isIncoming() const;
 
     /**
      * @brief Returns if call is outgoing
+     *
      * @return Ture if outgoing call, false if incoming
      */
     virtual bool isOutgoing() const;
+
+    /**
+     * @brief Returns the handle from user that has started the call
+     *
+     * This funcion only return a valid value when call is or has gone throght CALL_STATUS_RING_IN state.
+     * In other case will be a not valid value
+     *
+     * @return user handle from caller
+     */
+    virtual MegaChatHandle getCaller() const;
 };
 
 /**

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -494,10 +494,10 @@ public:
     /**
      * @brief Returns the handle from user that has started the call
      *
-     * This funcion only return a valid value when call is or has gone throght CALL_STATUS_RING_IN state.
-     * In other case will be a not valid value
+     * This function only returns a valid value when call is or has gone through CALL_STATUS_RING_IN state.
+     * In other case will be MEGACHAT_INVALID_HANDLE
      *
-     * @return user handle from caller
+     * @return user handle of caller
      */
     virtual MegaChatHandle getCaller() const;
 };

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -4199,7 +4199,7 @@ MegaChatCallPrivate::MegaChatCallPrivate(const rtcModule::ICall& call)
     ignored = false;
     changed = 0;
     peerId = 0;
-    callerId = call.caller();
+    callerId = call.caller() ? call.caller().val : MEGACHAT_INVALID_HANDLE;
     // At this point, there aren't any Session. It isn't neccesary create `sessionStatus` from Icall::sessionState()
 }
 
@@ -4225,7 +4225,7 @@ MegaChatCallPrivate::MegaChatCallPrivate(Id chatid, Id callid, uint32_t duration
     ignored = false;
     changed = 0;
     peerId = 0;
-    callerId = 0;
+    callerId = MEGACHAT_INVALID_HANDLE;
 }
 
 MegaChatCallPrivate::MegaChatCallPrivate(const MegaChatCallPrivate &call)

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -4415,7 +4415,7 @@ MegaChatSession *MegaChatCallPrivate::getMegaChatSession(MegaChatHandle peerId)
 
 int MegaChatCallPrivate::getNumParticipants() const
 {
-    return sessions.size();
+    return participants.size();
 }
 
 MegaHandleList *MegaChatCallPrivate::getParticipants() const

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -6691,7 +6691,8 @@ void MegaChatCallHandler::onDestroy(rtcModule::TermCode /*reason*/, bool /*byPee
     {
         chatid = chatCall->getChatid();
         MegaHandleList *participants = chatCall->getParticipants();
-        if (participants && participants->size() > 0)
+        bool uniqueParticipant = (participants && participants->size() == 1 && participants->get(0) == megaChatApi->getMyUserHandle());
+        if (participants && participants->size() > 0 && !uniqueParticipant)
         {
             chatCall->setStatus(MegaChatCall::CALL_STATUS_USER_NO_PRESENT);
             megaChatApi->fireOnChatCallUpdate(chatCall);

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -221,6 +221,7 @@ public:
     virtual bool isIgnored() const;
     virtual bool isIncoming() const;
     virtual bool isOutgoing() const;
+    virtual MegaChatHandle getCaller() const;
 
     void setStatus(int status);
     void setLocalAudioVideoFlags(karere::AvFlags localAVFlags);
@@ -245,6 +246,7 @@ public:
     bool isParticipating(karere::Id userid);
     void removeAllParticipants();
     void setId(karere::Id callid);
+    void setCaller(karere::Id caller);
 
 protected:
     MegaChatHandle chatid;
@@ -260,6 +262,7 @@ protected:
     std::map<karere::Id, MegaChatSession *> sessions;
     std::map<chatd::EndpointId, karere::AvFlags> participants;
     MegaChatHandle peerId;  // to identify the updated session
+    MegaChatHandle callerId;
 
     int termCode;
     bool ignored;

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -933,6 +933,17 @@ void Call::msgCallReqDecline(RtMessage& packet)
     {
         handleBusy(packet);
     }
+    else if (code == TermCode::kErrNotSupported)
+    {
+        if (packet.userid != mChat.client().userId() && !mChat.isGroup())
+        {
+            mNotSupportedAnswer = true;
+        }
+        else
+        {
+            SUB_LOG_WARNING("Ingoring CALL_REQ_DECLINE (kErrNotSupported) group Chat or same user");
+        }
+    }
     else
     {
         SUB_LOG_WARNING("Ingoring CALL_REQ_DECLINE with unexpected termnation code %s", termCodeToStr(code));
@@ -1330,7 +1341,14 @@ bool Call::broadcastCallReq()
 
         if (mState == Call::kStateReqSent)
         {
-            destroy(TermCode::kRingOutTimeout, true);
+            if (mNotSupportedAnswer && !mChat.isGroup())
+            {
+                destroy(static_cast<TermCode>(TermCode::kErrNotSupported | TermCode::kPeer), true);
+            }
+            else
+            {
+                destroy(TermCode::kRingOutTimeout, true);
+            }
         }
         else if (chat().isGroup() && mState == Call::kStateInProgress)
         {
@@ -2805,6 +2823,7 @@ const char* termCodeToStr(uint8_t code)
     switch(code)
     {
         RET_ENUM_NAME(kUserHangup);
+        RET_ENUM_NAME(kCallReqCancel);
         RET_ENUM_NAME(kCallRejected);
         RET_ENUM_NAME(kAnsElsewhere);
         RET_ENUM_NAME(kRejElsewhere);
@@ -2827,6 +2846,8 @@ const char* termCodeToStr(uint8_t code)
         RET_ENUM_NAME(kErrSdp);
         RET_ENUM_NAME(kErrPeerOffline);
         RET_ENUM_NAME(kErrSessRetryTimeout);
+        RET_ENUM_NAME(kErrAlready);
+        RET_ENUM_NAME(kErrNotSupported);
         RET_ENUM_NAME(kInvalid);
         RET_ENUM_NAME(kNotFinished);
         default: return "(invalid term code)";

--- a/src/rtcModule/webrtc.h
+++ b/src/rtcModule/webrtc.h
@@ -116,8 +116,8 @@ enum TermCode: uint8_t
     kErrSessRetryTimeout = 35,  // < timed out waiting for peer to retry a failed session
     kErrAlready = 36,           // < There is already a call in this chatroom
     kErrNotSupported = 37,      // < Clients that don't support calls send CALL_REQ_CANCEL with this code
-    kErrorLast = 36,            // < Last enum indicating call termination due to error
-    kLast = 36,                 // < Last call terminate enum value
+    kErrorLast = 37,            // < Last enum indicating call termination due to error
+    kLast = 37,                 // < Last call terminate enum value
     kPeer = 128,                // < If this flag is set, the condition specified by the code happened at the peer,
                                 // < not at our side
     kInvalid = 0x7f

--- a/src/rtcModule/webrtc.h
+++ b/src/rtcModule/webrtc.h
@@ -115,6 +115,7 @@ enum TermCode: uint8_t
     kErrSessSetupTimeout = 34,  // < timed out waiting for session
     kErrSessRetryTimeout = 35,  // < timed out waiting for peer to retry a failed session
     kErrAlready = 36,           // < There is already a call in this chatroom
+    kErrNotSupported = 37,      // < Clients that don't support calls send CALL_REQ_CANCEL with this code
     kErrorLast = 36,            // < Last enum indicating call termination due to error
     kLast = 36,                 // < Last call terminate enum value
     kPeer = 128,                // < If this flag is set, the condition specified by the code happened at the peer,

--- a/src/rtcModule/webrtc.h
+++ b/src/rtcModule/webrtc.h
@@ -32,6 +32,9 @@ class ICall {};
 class IRtcModule;
 class RtcModule;
 typedef uint8_t TermCode;
+uint8_t kErrNotSupported = 37;
+uint8_t RTCMD_CALL_REQ_DECLINE = 2;
+uint8_t kCallDataRinging = 1;
 }
 
 #else

--- a/src/rtcModule/webrtcPrivate.h
+++ b/src/rtcModule/webrtcPrivate.h
@@ -119,6 +119,7 @@ protected:
     megaHandle mDestroySessionTimer = 0;
     unsigned int mTotalSessionRetry = 0;
     uint8_t mPredestroyState;
+    bool mNotSupportedAnswer = false;
     void setState(uint8_t newState);
     void handleMessage(RtMessage& packet);
     void msgCallTerminate(RtMessage& packet);


### PR DESCRIPTION
- Manage termination code kErrNotSupported. It's returned when client doesn't manage webrtc
- Destroy call handler when we finish a call and we are the last participant. Avoid maintain alive a MegaChatCallHandler if we don't receive a ' ENDCALL'  command (lost connection or we are unique participant at chat room)
