### PR TITLE
Resume actionpacket processing after forced reload

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -751,6 +751,11 @@ void Client::onRequestFinish(::mega::MegaApi* /*apiObj*/, ::mega::MegaRequest *r
                     api.sdk.resumeActionPackets();
                 });
             }
+            else
+            {
+                assert(state == kInitHasOnlineSession);
+                api.sdk.resumeActionPackets();
+            }
         }, appCtx);
         break;
     }


### PR DESCRIPTION
When a fetchnodes happens after a previous successful fetchnodes, the
init state of MEGAchat is `kInitHasOnlineSession`, which doesn't resume
actionpackets processing as it should --> in consequence, the app
doesn't get external changes and cannot complete a new fetchnodes.