### PR TITLE
Make sure strongvelope initialize with unified-key

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -351,9 +351,9 @@ promise::Promise<void> Client::sdkLoginExistingSession(const char* sid)
 promise::Promise<uint64_t> Client::loadChatLink(uint64_t publicHandle, const std::string &key)
 {
     auto wptr = weakHandle();
-    std::string chatKey = key;
+    std::shared_ptr<std::string> unifiedKey = std::make_shared<std::string>(key);
     return api.call(&::mega::MegaApi::getChatLinkURL, publicHandle)
-    .then([this, chatKey, wptr](ReqResult result) -> promise::Promise<uint64_t>
+    .then([this, unifiedKey, wptr](ReqResult result) -> promise::Promise<uint64_t>
     {
         if (wptr.deleted())
             return Id::inval().val;
@@ -380,7 +380,7 @@ promise::Promise<uint64_t> Client::loadChatLink(uint64_t publicHandle, const std
             return promise::Error("Chatlink Url returned for chatid "+chatId.toString()+" is not valid. ", kErrorTypeGeneric);
         }
 
-        GroupChatRoom *room = new GroupChatRoom(*chats, chatId, shard, chatd::Priv::PRIV_RDONLY, 0, false, title, ph, true, chatKey, numPeers, url);
+        GroupChatRoom *room = new GroupChatRoom(*chats, chatId, shard, chatd::Priv::PRIV_RDONLY, 0, false, title, ph, true, unifiedKey, numPeers, url);
         chats->emplace(chatId, room);
         room->connect();
         return chatId.val;
@@ -1474,12 +1474,15 @@ Client::createGroupChat(std::vector<std::pair<uint64_t, chatd::Priv>> peers, boo
 
     //Add own user to strongvelope set of users to encrypt unified key for us
     users->insert(myhandle);
+    Buffer *buf = strongvelope::ProtocolHandler::createUnifiedKey();
+    std::shared_ptr<std::string> unifiedKey = std::make_shared<std::string>(buf->buf(), buf->dataSize());
+    delete buf;
     std::shared_ptr<strongvelope::ProtocolHandler> crypto(new strongvelope::ProtocolHandler(mMyHandle,
             StaticBuffer(mMyPrivCu25519, 32), StaticBuffer(mMyPrivEd25519, 32),
-            StaticBuffer(mMyPrivRsa, mMyPrivRsaLen), *mUserAttrCache, db, karere::Id::inval(), strongvelope::CHAT_MODE_PUBLIC, appCtx));
+            StaticBuffer(mMyPrivRsa, mMyPrivRsaLen), *mUserAttrCache, db, karere::Id::inval(),
+            unifiedKey, false, appCtx));
 
     crypto->setUsers(users.get());  // ownership belongs to this method, it will be released after `crypto`
-    crypto->createUnifiedKey();
 
     promise::Promise<std::shared_ptr<Buffer>> pms;
     if (title)
@@ -1635,18 +1638,21 @@ ApiPromise ChatRoom::requestRevokeAccess(mega::MegaNode *node, mega::MegaHandle 
     return parent.mKarereClient.api.call(&::mega::MegaApi::removeAccessInChat, chatid(), node, userHandle);
 }
 
-strongvelope::ProtocolHandler* Client::newStrongvelope(karere::Id chatid)
+strongvelope::ProtocolHandler* Client::newStrongvelope(karere::Id chatid,
+        std::shared_ptr<std::string> unifiedKey, bool isUnifiedKeyEncrypted)
 {
     return new strongvelope::ProtocolHandler(mMyHandle,
-        StaticBuffer(mMyPrivCu25519, 32), StaticBuffer(mMyPrivEd25519, 32),
-        StaticBuffer(mMyPrivRsa, mMyPrivRsaLen), *mUserAttrCache, db, chatid, appCtx);
+         StaticBuffer(mMyPrivCu25519, 32), StaticBuffer(mMyPrivEd25519, 32),
+         StaticBuffer(mMyPrivRsa, mMyPrivRsaLen), *mUserAttrCache, db, chatid,
+         unifiedKey, isUnifiedKeyEncrypted, appCtx);
 }
 
-void ChatRoom::createChatdChat(const karere::SetOfIds& initialUsers)
+void ChatRoom::createChatdChat(const karere::SetOfIds& initialUsers,
+        std::shared_ptr<std::string> unifiedKey, bool isUnifiedKeyEncrypted)
 {
     mChat = &parent.mKarereClient.mChatdClient->createChat(
         mChatid, mShardNo, mUrl, this, initialUsers,
-        parent.mKarereClient.newStrongvelope(chatid()), mCreationTs, mIsGroup);
+        parent.mKarereClient.newStrongvelope(mChatid, unifiedKey, isUnifiedKeyEncrypted), mCreationTs, mIsGroup);
 }
 
 template <class T, typename F>
@@ -1759,12 +1765,94 @@ IApp::IGroupChatListItem* GroupChatRoom::addAppItem()
     return list ? list->addGroupChatItem(*this) : nullptr;
 }
 
+//Create chat or receive an invitation
+GroupChatRoom::GroupChatRoom(ChatRoomList& parent, const mega::MegaTextChat& aChat)
+:ChatRoom(parent, aChat.getHandle(), true, aChat.getShard(),
+  (chatd::Priv)aChat.getOwnPrivilege(), aChat.getCreationTime(), aChat.isArchived()),
+  mRoomGui(nullptr), mIsUnifiedKeyEncrypted(false), mPreviewMode(false), mNumPeers(0)
+{
+    // Initialize list of peers and fetch their names
+    auto peers = aChat.getPeerList();
+    std::vector<promise::Promise<void>> promises;
+    if (peers)
+    {
+        mNumPeers = peers->size();
+        for (int i = 0; i < mNumPeers; i++)
+        {
+            auto handle = peers->getPeerHandle(i);
+            assert(handle != parent.mKarereClient.myHandle());
+            mPeers[handle] = new Member(*this, handle, (chatd::Priv)peers->getPeerPrivilege(i)); //may try to access mContactGui, but we have set it to nullptr, so it's ok
+            promises.push_back(mPeers[handle]->nameResolved());
+        }
+    }
+    // If there is not any promise at vector promise, promise::when is resolved directly
+    mMemberNamesResolved = promise::when(promises);
+
+    // Initialize title, if any
+    std::string title = aChat.getTitle() ? aChat.getTitle() : "";
+    initChatTitle(title);
+
+    // Initialize unified-key, if any
+    if (aChat.getUnifiedKey()) // --> only public chats should bring a unified key
+    {
+        assert(aChat.isPublicChat());
+
+        std::string unifiedKeyB64(aChat.getUnifiedKey());
+        mUnifiedKey.reset(new std::string);
+        int len = ::mega::Base64::atob(unifiedKeyB64, *mUnifiedKey);
+        assert(len == strongvelope::SVCRYPTO_KEY_SIZE + ::mega::MegaClient::USERHANDLE);
+        mIsUnifiedKeyEncrypted = true;
+    }
+    assert(!(aChat.isPublicChat() && !aChat.getUnifiedKey()));
+
+    // Save Chatroom into DB
+    auto db = parent.mKarereClient.db;
+    db.query("insert or replace into chats(chatid, shard, peer, peer_priv, "
+             "own_priv, ts_created, archived) values(?,?,-1,0,?,?,?)",
+             mChatid, mShardNo, mOwnPriv, aChat.getCreationTime(), aChat.isArchived());
+    // Save (still) encrypted unified key
+    if (isPublicChat())
+    {
+        std::string auxBuf(*mUnifiedKey);
+        auxBuf.insert(auxBuf.begin(), '1');  // prefix to indicate it's encrypted
+        db.query("insert or replace into chat_vars(chatid, name, value)"
+                 " values(?,'unified_key',?)", mChatid, auxBuf.c_str());
+    }
+    db.query("delete from chat_peers where chatid=?", mChatid); // clean any obsolete data
+    SqliteStmt stmt(db, "insert into chat_peers(chatid, userid, priv) values(?,?,?)");
+    for (auto& m: mPeers)
+    {
+        stmt << mChatid << m.first << m.second->mPriv;
+        stmt.step();
+        stmt.reset().clearBind();
+    }
+    // TODO: save the encrypted title, if any
+
+    // Initialize chatd::Client (and strongvelope)
+    initWithChatd();
+
+    if (mHasTitle)
+    {
+        decryptTitle()
+        .fail([this](const promise::Error& e)
+        {
+            KR_LOG_ERROR("Failed to decrypt title for private chat %s: %s", ID_CSTR(mChatid), e.what());
+        });
+    }
+
+    mRoomGui = addAppItem();
+    mIsInitializing = false;
+}
+
 //Resume from cache
 GroupChatRoom::GroupChatRoom(ChatRoomList& parent, const uint64_t& chatid,
-    unsigned char aShard, chatd::Priv aOwnPriv, uint32_t ts, bool aIsArchived, const std::string& title,  const std::string& unifiedKey)
-    :ChatRoom(parent, chatid, true, aShard, aOwnPriv, ts, aIsArchived, title), mRoomGui(nullptr)
+    unsigned char aShard, chatd::Priv aOwnPriv, uint32_t ts, bool aIsArchived,
+    const std::string& title, std::shared_ptr<std::string> unifiedKey, bool isUnifiedKeyEncrypted)
+    :ChatRoom(parent, chatid, true, aShard, aOwnPriv, ts, aIsArchived, title),
+    mRoomGui(nullptr), mUnifiedKey(unifiedKey), mIsUnifiedKeyEncrypted(isUnifiedKeyEncrypted),
+    mPreviewMode(false), mNumPeers(0)
 {
-    mPreviewMode = false;
+    // Initialize list of peers
     SqliteStmt stmt(parent.mKarereClient.db, "select userid, priv from chat_peers where chatid=?");
     stmt << mChatid;
     std::vector<promise::Promise<void> > promises;
@@ -1774,39 +1862,12 @@ GroupChatRoom::GroupChatRoom(ChatRoomList& parent, const uint64_t& chatid,
     }
     mMemberNamesResolved = promise::when(promises);
 
-    bool hasCustomTitle = (!title.empty() && title.at(0));
-    if (hasCustomTitle)
-    {
-        mEncryptedTitle = title;
-        mHasTitle = true;
-    }
-    else
-    {
-        auto wptr = weakHandle();
-        mMemberNamesResolved.then([wptr, this]()
-        {
-            wptr.throwIfDeleted();
-            makeTitleFromMemberNames();
-        });
-    }
-
+    // Initialize title, if any
+    initChatTitle(mTitleString);
     notifyTitleChanged();
-    initWithChatd();
 
-    mPublicChat = !unifiedKey.empty();
-    if (mPublicChat)
-    {
-        if(unifiedKey.size() == strongvelope::SVCRYPTO_KEY_SIZE)
-        {
-            chat().crypto()->setUnifiedKey(unifiedKey);
-            chat().crypto()->setChatMode(strongvelope::CHAT_MODE_PUBLIC);
-        }
-        else
-        {
-            KR_LOG_ERROR("Error with unifiedKey format for chat %s:\n.", ID_CSTR(mChatid));
-            mChat->disable(true);
-        }
-    }
+    // Initialize chatd::Client (and strongvelope)
+    initWithChatd();
 
     mRoomGui = addAppItem();
     mIsInitializing = false;
@@ -1815,28 +1876,28 @@ GroupChatRoom::GroupChatRoom(ChatRoomList& parent, const uint64_t& chatid,
 //Load chatLink
 GroupChatRoom::GroupChatRoom(ChatRoomList& parent, const uint64_t& chatid,
     unsigned char aShard, chatd::Priv aOwnPriv, uint32_t ts, bool aIsArchived, const std::string& title,
-    const uint64_t &publicHandle, bool previewMode, const std::string& unifiedKey, int aNumPeers, std::string aUrl)
+    const uint64_t &publicHandle, bool previewMode, std::shared_ptr<std::string> unifiedKey, int aNumPeers, std::string aUrl)
 :ChatRoom(parent, chatid, true, aShard, aOwnPriv, ts, aIsArchived, title),
-  mRoomGui(nullptr), mPreviewMode(previewMode), mNumPeers(aNumPeers)
+  mRoomGui(nullptr), mUnifiedKey(unifiedKey), mIsUnifiedKeyEncrypted(false), mPreviewMode(previewMode), mNumPeers(aNumPeers)
 {
     initWithChatd();
     mChat->setPublicHandle(publicHandle);
-    mChat->crypto()->setChatMode(strongvelope::CHAT_MODE_PUBLIC);
-    mChat->crypto()->setUnifiedKey(unifiedKey);
     mChat->crypto()->setPreviewMode(previewMode);
     mUrl = aUrl;
 
     //Add my own handle to peers list
     const Id myHandle = parent.mKarereClient.myHandle();
     mPeers[myHandle] = new Member(*this, myHandle, chatd::PRIV_RDONLY);
+
     //save to db
     auto db = parent.mKarereClient.db;
-    db.query("delete from chat_peers where chatid=?", mChatid);
 
+    std::string auxBuf(*unifiedKey);
+    auxBuf.insert(auxBuf.begin(), '0');  // prefix to indicate it's encrypted
     db.query(
         "insert or replace into chat_vars(chatid, name, value)"
         " values(?,'unified_key',?)",
-        this->mChatid, unifiedKey);
+        mChatid, auxBuf.c_str());
 
     db.query(
         "insert or replace into chat_vars(chatid, name, value)"
@@ -1848,6 +1909,7 @@ GroupChatRoom::GroupChatRoom(ChatRoomList& parent, const uint64_t& chatid,
         "own_priv, ts_created) values(?,?,-1,0,?,?)",
         mChatid, mShardNo, mOwnPriv, mCreationTs);
 
+    db.query("delete from chat_peers where chatid=?", mChatid);
     SqliteStmt stmt(db, "insert into chat_peers(chatid, userid, priv) values(?,?,?)");
     for (auto& m: mPeers)
     {
@@ -1886,7 +1948,7 @@ void GroupChatRoom::initWithChatd()
     {
         users.insert(peer.first);
     }
-    createChatdChat(users);
+    createChatdChat(users, mUnifiedKey, mIsUnifiedKeyEncrypted);
 }
 
 void GroupChatRoom::connect()
@@ -2190,14 +2252,18 @@ void ChatRoomList::loadFromDb()
             SqliteStmt auxstmt(mKarereClient.db, "select value from chat_vars where chatid=? and name ='unified_key'");
             auxstmt << chatid;
 
-            std::string unifiedKey;
+            std::shared_ptr<std::string> unifiedKey(new std::string);
+            bool isUnifiedKeyEncrypted = false;
             if(auxstmt.step())
             {
-                unifiedKey.assign(auxstmt.stringCol(0));
+                unifiedKey->assign(auxstmt.stringCol(0));
+                assert(unifiedKey->size() == 17);
+                isUnifiedKeyEncrypted = (unifiedKey->at(0) == '1');
+                unifiedKey->assign(unifiedKey->substr(1));
             }
             // else  --> not public chat anymore
 
-            room = new GroupChatRoom(*this, chatid, stmt.intCol(2), (chatd::Priv)stmt.intCol(3), stmt.intCol(1), stmt.intCol(7), stmt.stringCol(6), unifiedKey);
+            room = new GroupChatRoom(*this, chatid, stmt.intCol(2), (chatd::Priv)stmt.intCol(3), stmt.intCol(1), stmt.intCol(7), stmt.stringCol(6), unifiedKey, isUnifiedKeyEncrypted);
         }
         emplace(chatid, room);
     }
@@ -2240,10 +2306,6 @@ ChatRoom* ChatRoomList::addRoom(const mega::MegaTextChat& apiRoom)
     }
     else    // 1on1
     {
-        auto peers = apiRoom.getPeerList();
-        assert(peers);
-        assert(peers->size() == 1);
-
         room = new PeerChatRoom(*this, apiRoom);
     }
 
@@ -2355,170 +2417,6 @@ ChatRoomList::~ChatRoomList()
         delete room.second;
 }
 
-//Create chat or receive an invitation
-GroupChatRoom::GroupChatRoom(ChatRoomList& parent, const mega::MegaTextChat& aChat)
-:ChatRoom(parent, aChat.getHandle(), true, aChat.getShard(),
-  (chatd::Priv)aChat.getOwnPrivilege(), aChat.getCreationTime(), aChat.isArchived()), mRoomGui(nullptr), mPublicChat(aChat.isPublicChat())
-{
-    mPreviewMode = false;
-    auto peers = aChat.getPeerList();
-    std::vector<promise::Promise<void> > promises;
-    if (peers)
-    {
-        auto size = peers->size();
-        for (int i = 0; i < size; i++)
-        {
-            auto handle = peers->getPeerHandle(i);
-            assert(handle != parent.mKarereClient.myHandle());
-            mPeers[handle] = new Member(*this, handle, (chatd::Priv)peers->getPeerPrivilege(i)); //may try to access mContactGui, but we have set it to nullptr, so it's ok
-            promises.push_back(mPeers[handle]->nameResolved());
-        }
-    }
-    initWithChatd();
-
-    //save to db
-    auto db = parent.mKarereClient.db;
-    db.query("delete from chat_peers where chatid=?", mChatid);
-    db.query(
-        "insert or replace into chats(chatid, shard, peer, peer_priv, "
-        "own_priv, ts_created, archived) values(?,?,-1,0,?,?,?)",
-        mChatid, mShardNo, mOwnPriv, aChat.getCreationTime(), aChat.isArchived());
-
-    SqliteStmt stmt(db, "insert into chat_peers(chatid, userid, priv) values(?,?,?)");
-    for (auto& m: mPeers)
-    {
-        stmt << mChatid << m.first << m.second->mPriv;
-        stmt.step();
-        stmt.reset().clearBind();
-    }
-
-    auto ct = aChat.getTitle();
-    bool hasCt = (ct && ct[0]);
-    if (hasCt)
-    {
-        mEncryptedTitle = ct;
-        mHasTitle = true;
-    }
-
-    if (!mHasTitle)
-    {
-        if (peers)
-        {
-            auto wptr = weakHandle();
-            // If there is not any promise at vector promise, promise::when is resolved directly
-            mMemberNamesResolved = promise::when(promises)
-            .then([wptr, this]()
-            {
-                if (wptr.deleted())
-                    return;
-
-                clearTitle();
-            });
-        }
-        else
-        {
-            clearTitle();
-        }
-    }
-
-    if (mPublicChat)
-    {
-        //Get B64 unified key
-        const char *bufB64 = aChat.getUnifiedKey();
-        if (bufB64)
-        {
-            //Convert received key from B64 to Bin
-            int lenKey = strongvelope::SVCRYPTO_KEY_SIZE;
-            int lenPair = mega::MegaClient::CHATLINKHANDLE + lenKey;
-            char *bufBin = new char[lenPair];
-            int len = mega::Base64::atob(bufB64, (byte *)bufBin, lenPair);
-            if (len == lenPair)
-            {
-                //Parse invitor handle (First 8 Bytes)
-                uint64_t invitorHandle;
-                memcpy(&invitorHandle, bufBin, sizeof invitorHandle);
-
-                //Parse unified key (Last 16 Bytes)
-                auto bufunifiedkey = std::make_shared<Buffer>(lenKey);
-                bufunifiedkey->assign(&bufBin[mega::USERHANDLE], lenKey);
-                auto wptr = getDelTracker();
-
-                try
-                {
-                    //Decrypt unifiedkey
-                    chat().crypto()->decryptUnifiedKey(bufunifiedkey, invitorHandle, invitorHandle)
-                    .then([this, wptr, invitorHandle](std::string unifiedKey)
-                    {
-                        if (wptr.deleted())
-                            return;
-
-                        //Set unifiedkey in strongvelope
-                        chat().crypto()->setUnifiedKey(unifiedKey);
-                        chat().crypto()->setChatMode(strongvelope::CHAT_MODE_PUBLIC);
-
-                        // Save Unified key decrypted
-                        this->parent.mKarereClient.db.query(
-                                    "insert or replace into chat_vars(chatid, name, value)"
-                                    " values(?,'unified_key',?)",
-                                    mChatid, unifiedKey.c_str());
-
-                        if (mHasTitle)
-                        {
-                            decryptTitle()
-                            .fail([wptr, this](const promise::Error& e)
-                            {
-                                if (wptr.deleted())
-                                    return;
-
-                                KR_LOG_ERROR("Failed to decrypt title for public chat %s: %s", ID_CSTR(mChatid), e.what());
-                            });
-                        }
-                    })
-                    .fail([wptr, this](const promise::Error& e)
-                    {
-                        if (wptr.deleted())
-                            return;
-
-                        KR_LOG_ERROR("Error decrypting unifiedKey for chat %s: %s", ID_CSTR(mChatid), e.what());
-                        mChat->disable(true);
-                    });
-
-                }
-                catch(std::exception& e)
-                {
-                    KR_LOG_ERROR("Failed to base64-decode unified key for chat %s: %s", ID_CSTR(mChatid), e.what());
-                    mChat->disable(true);
-                }
-            }
-            else
-            {
-                KR_LOG_ERROR("Invalid length of unified key for chat %s", ID_CSTR(mChatid));
-                mChat->disable(true);
-            }
-            delete [] bufBin;
-        }
-        else
-        {
-            KR_LOG_ERROR("Public chat %s don't have a unified key", ID_CSTR(mChatid));
-            mChat->disable(true);
-        }
-    }
-    else
-    {
-        if (mHasTitle)
-        {
-            decryptTitle()
-            .fail([this](const promise::Error& e)
-            {
-                KR_LOG_ERROR("Failed to decrypt title for private chat %s: %s", ID_CSTR(mChatid), e.what());
-            });
-        }
-    }
-
-    mRoomGui = addAppItem();
-    mIsInitializing = false;
-}
-
 promise::Promise<void> GroupChatRoom::decryptTitle()
 {
     if (mEncryptedTitle.empty())
@@ -2526,12 +2424,11 @@ promise::Promise<void> GroupChatRoom::decryptTitle()
         return promise::_Void();
     }
 
-    Buffer buf(mEncryptedTitle.size());
-    size_t decLen;
+    Buffer buf(mEncryptedTitle.size());    
     try
     {
-        decLen = base64urldecode(mEncryptedTitle.c_str(), mEncryptedTitle.size(),
-            buf.buf(), buf.bufSize());
+        size_t decLen = base64urldecode(mEncryptedTitle.c_str(), mEncryptedTitle.size(), buf.buf(), buf.bufSize());
+        buf.setDataSize(decLen);
     }
     catch(std::exception& e)
     {
@@ -2543,21 +2440,8 @@ promise::Promise<void> GroupChatRoom::decryptTitle()
         return promise::Error(err);
     }
 
-    buf.setDataSize(decLen);
     auto wptr = getDelTracker();
-    promise::Promise<std::string> pms;
-
-    if (mPublicChat)
-    {
-        std::string auxTitle = chat().crypto()->decryptPublicChatTitle(buf);
-        pms = promise::Promise<std::string>();
-        pms.resolve(auxTitle);
-    }
-    else
-    {
-        pms = chat().crypto()->decryptChatTitle(buf);
-    }
-
+    promise::Promise<std::string> pms = chat().crypto()->decryptChatTitle(buf);
     return pms.then([wptr, this](const std::string title)
     {
         wptr.throwIfDeleted();
@@ -2728,7 +2612,7 @@ promise::Promise<void> GroupChatRoom::invite(uint64_t userid, chatd::Priv priv)
     {
         wptr.throwIfDeleted();
         ApiPromise invitePms;
-        if(mPublicChat)
+        if(isPublicChat())
         {
             std::string titleCpy = title;
             invitePms = chat().crypto()->encryptUnifiedKeyForAllParticipants(userid)
@@ -3039,26 +2923,9 @@ void GroupChatRoom::setPreviewMode(bool previewMode)
     mPreviewMode = previewMode;
 }
 
-bool GroupChatRoom::publicChat() const
+std::shared_ptr<std::string> GroupChatRoom::unifiedKey()
 {
-    return mPublicChat;
-}
-
-void GroupChatRoom::setPublicChat(bool publicChat)
-{
-    mPublicChat = publicChat;
-}
-
-std::string GroupChatRoom::chatkey()
-{
-    if (mPublicChat)
-    {
-        return chat().crypto()->getUnifiedKey();
-    }
-    else
-    {
-        return std::string();
-    }
+    return mUnifiedKey;
 }
 
 int GroupChatRoom::getNumPeers() const
@@ -3139,6 +3006,28 @@ bool GroupChatRoom::syncMembers(const mega::MegaTextChat& chat)
 
     return peersChanged;
 }
+
+void GroupChatRoom::initChatTitle(std::string &title)
+{
+    bool hasCustomTitle = (!title.empty() && title.at(0));
+    if (hasCustomTitle)
+    {
+        mEncryptedTitle = title;
+        mHasTitle = true;
+    }
+    else
+    {
+        auto wptr = weakHandle();
+        mMemberNamesResolved.then([wptr, this]()
+        {
+            if (wptr.deleted())
+                return;
+
+            makeTitleFromMemberNames();
+        });
+    }
+}
+
 void GroupChatRoom::clearTitle()
 {
     makeTitleFromMemberNames();
@@ -3147,15 +3036,16 @@ void GroupChatRoom::clearTitle()
 
 bool GroupChatRoom::syncWithApi(const mega::MegaTextChat& chat)
 {
+    // Mode changed
+    if (!chat.isPublicChat() && isPublicChat())
+    {
+        KR_LOG_DEBUG("Chatroom[%s]: API event: mode changed to private", ID_CSTR(mChatid));
+        setChatPrivateMode();
+    }
+
     // Own privilege changed
     auto oldPriv = mOwnPriv;
     bool ownPrivChanged = syncOwnPriv((chatd::Priv) chat.getOwnPrivilege());
-
-    if (!chat.isPublicChat() && mPublicChat)
-    {
-        this->setChatPrivateMode();
-    }
-
     if (ownPrivChanged)
     {
         if (oldPriv == chatd::PRIV_NOTPRESENT)
@@ -3175,7 +3065,7 @@ bool GroupChatRoom::syncWithApi(const mega::MegaTextChat& chat)
         else if (mOwnPriv == chatd::PRIV_NOTPRESENT)
         {
             //we were excluded
-            KR_LOG_DEBUG("Chatroom[%s]: API event: We were removed",  ID_CSTR(mChatid));
+            KR_LOG_DEBUG("Chatroom[%s]: API event: We were removed", ID_CSTR(mChatid));
             setRemoved(); // may delete 'this'
             return true;
         }
@@ -3228,17 +3118,14 @@ void GroupChatRoom::setChatPrivateMode()
     if (mPreviewMode)
     {
         mPreviewMode = false;
-        mPublicChat = false;
         mChat->setPublicHandle(Id::inval());
         removeAppChatHandler();
         return;
     }
 
-    //Update chatRoom
-    mPublicChat = false;
-
     //Update strongvelope
     chat().crypto()->setChatMode(strongvelope::CHAT_MODE_PRIVATE);
+    // TODO: reset unified-key and send-key must be done atomically in setChatMode() to avoid mistakes
     chat().crypto()->resetUnifiedKey();
     chat().crypto()->resetSendKey();
 

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2608,7 +2608,7 @@ promise::Promise<void> GroupChatRoom::invite(uint64_t userid, chatd::Priv priv)
     {
         wptr.throwIfDeleted();
         ApiPromise invitePms;
-        if(isPublicChat())
+        if (publicChat())
         {
             std::string titleCpy = title;
             invitePms = chat().crypto()->encryptUnifiedKeyForAllParticipants(userid)
@@ -2908,6 +2908,11 @@ void ChatRoom::notifyChatModeChanged()
     }, parent.mKarereClient.appCtx);
 }
 
+bool GroupChatRoom::publicChat()
+{
+    return mUnifiedKey != nullptr;
+}
+
 // return true if new peer, peer removed or peer's privilege updated
 bool GroupChatRoom::previewMode() const
 {
@@ -3033,7 +3038,7 @@ void GroupChatRoom::clearTitle()
 bool GroupChatRoom::syncWithApi(const mega::MegaTextChat& chat)
 {
     // Mode changed
-    if (!chat.isPublicChat() && isPublicChat())
+    if (!chat.isPublicChat() && publicChat())
     {
         KR_LOG_DEBUG("Chatroom[%s]: API event: mode changed to private", ID_CSTR(mChatid));
         setChatPrivateMode();

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -340,7 +340,6 @@ protected:
     virtual void connect();
     promise::Promise<void> memberNamesResolved() const;
     void initChatTitle(std::string &title);
-    bool isPublicChat() { return mUnifiedKey != nullptr; }
 
     friend class ChatRoomList;
     friend class Member;
@@ -423,6 +422,8 @@ public:
 
     virtual promise::Promise<void> requesGrantAccessToNodes(mega::MegaNodeList *nodes);
     virtual promise::Promise<void> requestRevokeAccessToNode(mega::MegaNode *node);
+
+    virtual bool publicChat();
 
     virtual bool previewMode() const;
     void setPreviewMode(bool previewMode);

--- a/src/chatdICrypto.h
+++ b/src/chatdICrypto.h
@@ -140,13 +140,8 @@ public:
     virtual promise::Promise<std::string>
     decryptChatTitle(const Buffer& data) = 0;
 
-    virtual std::string
-    decryptPublicChatTitle(const Buffer& data) = 0;
-
     virtual promise::Promise<std::string>
     decryptUnifiedKey(std::shared_ptr<Buffer>& key, uint64_t sender, uint64_t receiver) = 0;
-
-    virtual void createUnifiedKey() = 0;
 
     virtual void setUnifiedKey(const std::string &key) = 0;
 

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -887,21 +887,22 @@ void MegaChatApiImpl::sendPendingRequests()
             pms.then([request, this] (uint64_t ph)
             {
                 GroupChatRoom *room = (GroupChatRoom *) findChatRoom(request->getChatHandle());
-                string keybin(room->chatkey());
+                shared_ptr<string> unifiedKey(room->unifiedKey());
                 MegaChatErrorPrivate *megaChatError;
-                if (keybin.size() != 16 || (!request->getFlag() && ph == Id::inval()))
+                if (!unifiedKey || unifiedKey->size() != 16 || (!request->getFlag() && ph == Id::inval()))
                 {
                     megaChatError = new MegaChatErrorPrivate(MegaChatError::ERROR_NOENT);
                 }
                 else
                 {
-                    char *ph64 = new char[8];
-                    Base64::btoa((byte*)&(ph), MegaClient::CHATLINKHANDLE, ph64);
-                    std::string phstr(ph64, 8);
+                    string unifiedKeyB64;
+                    Base64::btoa(*unifiedKey, unifiedKeyB64);
 
-                    string keystr;
-                    Base64::btoa(keybin, keystr);
-                    string link = "https://mega.nz/c/" + phstr + "#" + keystr;
+                    string phBin((const char*)&ph, MegaClient::CHATLINKHANDLE);
+                    string phB64;
+                    Base64::btoa(phBin, phB64);
+
+                    string link = "https://mega.nz/c/" + phB64 + "#" + unifiedKeyB64;
                     request->setText(link.c_str());
                     megaChatError = new MegaChatErrorPrivate(MegaChatError::ERROR_OK);
                 }

--- a/src/strongvelope/strongvelope.cpp
+++ b/src/strongvelope/strongvelope.cpp
@@ -499,13 +499,13 @@ void ProtocolHandler::setChatMode(unsigned int chatMode)
 }
 
 ProtocolHandler::ProtocolHandler(karere::Id ownHandle,
-    const StaticBuffer& privCu25519,
-    const StaticBuffer& privEd25519,
-    const StaticBuffer& privRsa,
-    karere::UserAttrCache& userAttrCache, SqliteDb &db, Id aChatId, void *ctx)
+    const StaticBuffer& privCu25519, const StaticBuffer& privEd25519,
+    const StaticBuffer& privRsa,karere::UserAttrCache& userAttrCache,
+    SqliteDb &db, Id aChatId, std::shared_ptr<std::string> unifiedKey, bool isUnifiedKeyEncrypted, void *ctx)
 : chatd::ICrypto(ctx), mOwnHandle(ownHandle), myPrivCu25519(privCu25519),
- myPrivEd25519(privEd25519), myPrivRsaKey(privRsa),
- mUserAttrCache(userAttrCache), mDb(db), chatid(aChatId)
+  myPrivEd25519(privEd25519), myPrivRsaKey(privRsa),
+  mUserAttrCache(userAttrCache), mDb(db), chatid(aChatId),
+  mIsUnifiedKeyEncrypted(isUnifiedKeyEncrypted)
 {
     getPubKeyFromPrivKey(myPrivEd25519, kKeyTypeEd25519, myPubEd25519);
     loadKeysFromDb();
@@ -516,26 +516,42 @@ ProtocolHandler::ProtocolHandler(karere::Id ownHandle,
         mForceRsa = true;
         STRONGVELOPE_LOG_WARNING("KRCHAT_FORCE_RSA env var detected, will force RSA for key encryption");
     }
-}
 
-ProtocolHandler::ProtocolHandler(karere::Id ownHandle,
-    const StaticBuffer& privCu25519,
-    const StaticBuffer& privEd25519,
-    const StaticBuffer& privRsa,
-    karere::UserAttrCache& userAttrCache, SqliteDb &db, Id aChatId, int chatMode, void *ctx)
-: chatd::ICrypto(ctx), mOwnHandle(ownHandle), myPrivCu25519(privCu25519),
- myPrivEd25519(privEd25519), myPrivRsaKey(privRsa),
- mUserAttrCache(userAttrCache), mDb(db), mChatMode(chatMode), chatid(aChatId)
-{
-    getPubKeyFromPrivKey(myPrivEd25519, kKeyTypeEd25519, myPubEd25519);
-    if (this->mChatMode == CHAT_MODE_PRIVATE)
+    mChatMode = unifiedKey ? CHAT_MODE_PUBLIC : CHAT_MODE_PRIVATE;
+    if (mChatMode == CHAT_MODE_PUBLIC)
     {
-        loadKeysFromDb();
-        auto var = getenv("KRCHAT_FORCE_RSA");
-        if (var)
+        if (mIsUnifiedKeyEncrypted)
         {
-            mForceRsa = true;
-            STRONGVELOPE_LOG_WARNING("KRCHAT_FORCE_RSA env var detected, will force RSA for key encryption");
+            //Parse invitor handle (First 8 Bytes)
+            uint64_t invitorHandle;
+            memcpy(&invitorHandle, unifiedKey->data(), sizeof invitorHandle);
+
+            //Parse unified key (Last 16 Bytes)
+            auto bufunifiedkey = std::make_shared<Buffer>();
+            bufunifiedkey->assign(unifiedKey->data() + sizeof invitorHandle, SVCRYPTO_KEY_SIZE);
+            auto wptr = getDelTracker();
+
+            //Decrypt unifiedkey
+            mUnifiedKeyDecrypted = decryptKey(bufunifiedkey, invitorHandle, invitorHandle);
+            mUnifiedKeyDecrypted.then([this, wptr](std::shared_ptr<UnifiedKey> unifiedKey)
+            {
+                if (wptr.deleted())
+                    return;
+
+                mIsUnifiedKeyEncrypted = false;
+                mUnifiedKey = unifiedKey;
+
+                // Save Unified key decrypted
+                std::string auxBuf(unifiedKey->buf(), unifiedKey->size());
+                auxBuf.insert(auxBuf.begin(), '0');  // prefix to indicate it's encrypted
+                mDb.query("insert or replace into chat_vars(chatid, name, value)"
+                         " values(?,'unified_key',?)", chatid, auxBuf.c_str());
+            });
+        }
+        else
+        {
+            mUnifiedKey.reset(new UnifiedKey(unifiedKey->data(), unifiedKey->size()));
+            mUnifiedKeyDecrypted.resolve(mUnifiedKey);
         }
     }
 }
@@ -854,12 +870,13 @@ ProtocolHandler::decryptKey(std::shared_ptr<Buffer>& key, Id sender, Id receiver
     }
 }
 
-void ProtocolHandler::createUnifiedKey()
+Buffer* ProtocolHandler::createUnifiedKey()
 {
-    // initialize a new unified key
-    mUnifiedKey.reset(new UnifiedKey);
-    mUnifiedKey->setDataSize(AES::BLOCKSIZE);
-    randombytes_buf(mUnifiedKey->ubuf(), AES::BLOCKSIZE);
+    Buffer *unifiedKey = new Buffer(SVCRYPTO_KEY_SIZE);
+    randombytes_buf(unifiedKey->ubuf(), SVCRYPTO_KEY_SIZE);
+    unifiedKey->setDataSize(SVCRYPTO_KEY_SIZE);
+
+    return unifiedKey;
 }
 
 void ProtocolHandler::setUnifiedKey(const std::string &key)
@@ -1030,15 +1047,43 @@ ProtocolHandler::decryptChatTitle(const Buffer& data)
     {
         Buffer copy(data.dataSize());
         copy.copyFrom(data);
-        auto msg = std::make_shared<chatd::Message>(
-            karere::Id::null(), karere::Id::null(), 0, 0, std::move(copy));
-
+        auto msg = std::make_shared<chatd::Message>(Id::null(), Id::null(), 0, 0, std::move(copy));
         auto parsedMsg = std::make_shared<ParsedMessage>(*msg, *this);
-        return parsedMsg->decryptChatTitle(msg.get(), false)
+
+        promise::Promise<Message*> pms;
+        if (mChatMode == CHAT_MODE_PRIVATE)
+        {
+            pms = parsedMsg->decryptChatTitle(msg.get(), false);
+        }
+        else    // public mode
+        {
+            auto unifiedKeyDecrypted = mUnifiedKeyDecrypted.done();    // wait for unified key decryption
+            switch (unifiedKeyDecrypted)
+            {
+            case promise::kSucceeded:   // if already decrypted...
+                assert(mUnifiedKey);
+                pms = parsedMsg->decryptPublicChatTitle(msg.get(), mUnifiedKey);
+
+            case promise::kFailed:
+                STRONGVELOPE_LOG_WARNING("[decryptChatTitle]: unified key decryption failed. Cannot decrypt chat title");
+                return mUnifiedKeyDecrypted.error();
+
+            default:
+                STRONGVELOPE_LOG_WARNING("[decryptChatTitle]: unified key is not decrypted yet");
+
+                assert(unifiedKeyDecrypted == promise::kNotResolved);
+                pms = mUnifiedKeyDecrypted
+                .then([this, msg, parsedMsg](std::shared_ptr<UnifiedKey> unifiedKey) -> promise::Promise<Message*>
+                {
+                    return parsedMsg->decryptPublicChatTitle(msg.get(), unifiedKey);
+                });
+            }
+        }
+
         // warning: parsedMsg must be kept alive when .then() is executed, so we
         // capture the shared pointer to it. Msg also must be kept alive, as
         // the promise returns it
-        .then([msg, parsedMsg](Message* retMsg)
+        return pms.then([msg, parsedMsg](Message* retMsg)
         {
             return std::string(retMsg->buf(), retMsg->dataSize());
         });
@@ -1046,36 +1091,6 @@ ProtocolHandler::decryptChatTitle(const Buffer& data)
     catch(std::exception& e)
     {
         return promise::Error(e.what(), EPROTO, SVCRYPTO_ERRTYPE);
-    }
-}
-
-std::string
-ProtocolHandler::decryptPublicChatTitle(const Buffer& data)
-{
-    try
-    {
-        if (!mUnifiedKey)
-        {
-            return std::string();
-        }
-
-        Buffer copy(data.dataSize());
-        copy.copyFrom(data);
-        auto msg = std::make_shared<chatd::Message>(
-            karere::Id::null(), karere::Id::null(), 0, 0, std::move(copy));
-        auto parsedMsg = std::make_shared<ParsedMessage>(*msg, *this);
-
-        auto unifiedKey = std::make_shared<SendKey>();
-        memcpy(unifiedKey->buf(), mUnifiedKey->buf(), AES::BLOCKSIZE);
-
-        chatd::Message *decryptedMsg = parsedMsg->decryptPublicChatTitle(msg.get(), unifiedKey);
-        std::string res(decryptedMsg->buf(), decryptedMsg->size());
-        return res;
-    }
-    catch(std::exception& e)
-    {
-        STRONGVELOPE_LOG_ERROR("Failed to decrypt chat title: %s", e.what());
-        return std::string();
     }
 }
 
@@ -1617,7 +1632,7 @@ ProtocolHandler::encryptUnifiedKeyForAllParticipants(uint64_t extraUser)
     });
 }
 
-chatd::Message* ParsedMessage::decryptPublicChatTitle(chatd::Message *msg, const std::shared_ptr<SendKey>& key)
+promise::Promise<chatd::Message*> ParsedMessage::decryptPublicChatTitle(chatd::Message *msg, const std::shared_ptr<UnifiedKey>& key)
 {
     symmetricDecrypt(*key, *msg);
     msg->setEncrypted(Message::kNotEncrypted);
@@ -1627,10 +1642,10 @@ promise::Promise<chatd::Message*>
 ParsedMessage::decryptChatTitle(chatd::Message* msg, bool msgCanBeDeleted)
 {
     const char* pos = encryptedKey.buf();
-    const char* end = encryptedKey.buf()+encryptedKey.dataSize();
-    karere::Id receiver;
+    const char* end = pos + encryptedKey.dataSize();
 
     //pick the version that is encrypted for us
+    karere::Id receiver;
     while (pos < end)
     {
         receiver = Buffer::alignSafeRead<uint64_t>(pos);

--- a/src/strongvelope/strongvelope.cpp
+++ b/src/strongvelope/strongvelope.cpp
@@ -542,10 +542,11 @@ ProtocolHandler::ProtocolHandler(karere::Id ownHandle,
                 mUnifiedKey = unifiedKey;
 
                 // Save Unified key decrypted
-                std::string auxBuf(unifiedKey->buf(), unifiedKey->size());
-                auxBuf.insert(auxBuf.begin(), '0');  // prefix to indicate it's encrypted
+                Buffer auxBuf;
+                auxBuf.write(0, '0');  // prefix to indicate it's encrypted
+                auxBuf.append(*unifiedKey);
                 mDb.query("insert or replace into chat_vars(chatid, name, value)"
-                         " values(?,'unified_key',?)", chatid, auxBuf.c_str());
+                         " values(?,'unified_key',?)", chatid, auxBuf);
             });
         }
         else
@@ -1063,6 +1064,7 @@ ProtocolHandler::decryptChatTitle(const Buffer& data)
             case promise::kSucceeded:   // if already decrypted...
                 assert(mUnifiedKey);
                 pms = parsedMsg->decryptPublicChatTitle(msg.get(), mUnifiedKey);
+                break;
 
             case promise::kFailed:
                 STRONGVELOPE_LOG_WARNING("[decryptChatTitle]: unified key decryption failed. Cannot decrypt chat title");
@@ -1077,6 +1079,7 @@ ProtocolHandler::decryptChatTitle(const Buffer& data)
                 {
                     return parsedMsg->decryptPublicChatTitle(msg.get(), unifiedKey);
                 });
+                break;
             }
         }
 


### PR DESCRIPTION
- Make decryption of chat-title wait for decryption of unified-key.
- Store unified-key encrypted in DB to avoid missing it upon
close/crash.
- Revamping of GroupChatRoom ctor.
- Code cleanup.