### PR TITLE
Hotfix: improve reconnections

### DIFF
--- a/bindings/Objective-C/MEGAChatSdk.h
+++ b/bindings/Objective-C/MEGAChatSdk.h
@@ -90,6 +90,7 @@ typedef NS_ENUM (NSInteger, MEGAChatConnection) {
 - (void)disconnect;
 - (MEGAChatConnection)chatConnectionState:(uint64_t)chatId;
 - (void)retryPendingConnections;
+- (void)reconnect;
 
 #pragma mark - Logout
 

--- a/bindings/Objective-C/MEGAChatSdk.mm
+++ b/bindings/Objective-C/MEGAChatSdk.mm
@@ -105,6 +105,10 @@ static DelegateMEGAChatLoggerListener *externalLogger = NULL;
     self.megaChatApi->retryPendingConnections();
 }
 
+- (void)reconnect {
+    self.megaChatApi->retryPendingConnections(true);
+}
+
 - (void)dealloc {
     delete _megaChatApi;
     pthread_mutex_destroy(&listenerMutex);

--- a/bindings/java/nz/mega/sdk/MegaChatApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaChatApiJava.java
@@ -345,8 +345,8 @@ public class MegaChatApiJava {
      *
      * @param listener MegaChatRequestListener to track this request
      */
-    public void retryPendingConnections(MegaChatRequestListenerInterface listener){
-        megaChatApi.retryPendingConnections(createDelegateRequestListener(listener));
+    public void retryPendingConnections(boolean disconnect, MegaChatRequestListenerInterface listener){
+        megaChatApi.retryPendingConnections(disconnect, createDelegateRequestListener(listener));
     }
 
     /**

--- a/src/base/retryHandler.h
+++ b/src/base/retryHandler.h
@@ -39,7 +39,8 @@ enum { kErrorType = 0x2e7294d1 };//should resemble 'retryhdl'
 enum
 {
     kDefaultMaxAttemptCount = 0,
-    kDefaultMaxSingleWaitTime = 60000
+    kDefaultMaxSingleWaitTime = 60000,
+    kDefaultMinInitialDelay = 1000
 };
 
 class IRetryController
@@ -419,7 +420,7 @@ static inline auto retry(const std::string& aName, Func&& func, DeleteTrackable:
     unsigned attemptTimeout = 0,
     size_t maxRetries = rh::kDefaultMaxAttemptCount,
     size_t maxSingleWaitTime = rh::kDefaultMaxSingleWaitTime,
-    short backoffStart = 1000)
+    short backoffStart = rh::kDefaultMinInitialDelay)
 ->decltype(func(0, wptr))
 {
     auto self = new rh::RetryController<Func, CancelFunc>(aName,
@@ -437,7 +438,7 @@ static inline rh::RetryController<Func, CancelFunc>* createRetryController(
     const std::string& aName, Func&& func,CancelFunc&& cancelFunc = nullptr, unsigned attemptTimeout = 0,
     size_t maxRetries = rh::kDefaultMaxAttemptCount,
     size_t maxSingleWaitTime = rh::kDefaultMaxSingleWaitTime,
-    short backoffStart = 1000)
+    short backoffStart = rh::kDefaultMinInitialDelay)
 {
     auto retryController = new rh::RetryController<Func, CancelFunc>(aName,
         std::forward<Func>(func),

--- a/src/base/retryHandler.h
+++ b/src/base/retryHandler.h
@@ -435,14 +435,17 @@ static inline auto retry(const std::string& aName, Func&& func, DeleteTrackable:
 /** Similar to retry(), but returns a heap-allocated RetryController object */
 template <class Func, class CancelFunc=void*>
 static inline rh::RetryController<Func, CancelFunc>* createRetryController(
-    const std::string& aName, Func&& func,CancelFunc&& cancelFunc = nullptr, unsigned attemptTimeout = 0,
+    const std::string& aName, Func&& func,
+    DeleteTrackable::Handle wptr, void *ctx,
+    CancelFunc&& cancelFunc = nullptr,
+    unsigned attemptTimeout = 0,
     size_t maxRetries = rh::kDefaultMaxAttemptCount,
     size_t maxSingleWaitTime = rh::kDefaultMaxSingleWaitTime,
     short backoffStart = rh::kDefaultMinInitialDelay)
 {
-    auto retryController = new rh::RetryController<Func, CancelFunc>(aName,
+    rh::RetryController<Func, CancelFunc>* retryController = new rh::RetryController<Func, CancelFunc>(aName,
         std::forward<Func>(func),
-        std::forward<CancelFunc>(cancelFunc), attemptTimeout,
+        std::forward<CancelFunc>(cancelFunc), attemptTimeout, wptr, ctx,
         maxSingleWaitTime, maxRetries, backoffStart);
     return retryController;
 }

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -263,11 +263,12 @@ Client::~Client()
 
 promise::Promise<void> Client::retryPendingConnections()
 {
-    if (mConnState == kConnecting)
+    if (mConnState == kConnecting)  // already a connection attempt in-progress
+    {
         return mConnectPromise;
+    }
 
     std::vector<Promise<void>> promises;
-
     promises.push_back(mPresencedClient.retryPendingConnection());
     if (mChatdClient)
     {
@@ -866,46 +867,46 @@ promise::Promise<void> Client::connect(Presence pres, bool isInBackground)
 // only the first connect() needs to wait for the mSessionReadyPromise.
 // Any subsequent connect()-s (preceded by disconnect()) can initiate
 // the connect immediately
-    if (mConnState == kConnecting)
+    if (mConnState == kConnecting)      // already connecting, wait for completion
+    {
         return mConnectPromise;
-    else if (mConnState == kConnected)
+    }
+    else if (mConnState == kConnected)  // nothing to do
+    {
         return promise::_Void();
+    }
 
     assert(mConnState == kDisconnected);
     auto sessDone = mSessionReadyPromise.done();    // wait for fetchnodes completion
     switch (sessDone)
     {
-    case promise::kSucceeded:   // if session was already ready...
-        return doConnect(pres, isInBackground);
-    case promise::kFailed:
-        return mSessionReadyPromise.error();
-    default:                    // if session is not ready yet
-        assert(sessDone == promise::kNotResolved);
-        mConnectPromise = mSessionReadyPromise
+        case promise::kSucceeded:   // if session is ready...
+            return doConnect(pres, isInBackground);
+
+        case promise::kFailed:      // if session failed...
+            return mSessionReadyPromise.error();
+
+        default:                    // if session is not ready yet... wait for it and then connect
+            assert(sessDone == promise::kNotResolved);
+            mConnectPromise = mSessionReadyPromise
             .then([this, pres, isInBackground]() mutable
             {
                 return doConnect(pres, isInBackground);
-            })
-            .then([this]()
-            {
-                setConnState(kConnected);
-            })
-            .fail([this](const promise::Error& err)
-            {
-                setConnState(kDisconnected);
-                return err;
             });
-        return mConnectPromise;
+            return mConnectPromise;
     }
 }
 
 promise::Promise<void> Client::doConnect(Presence pres, bool isInBackground)
 {
-    assert(mSessionReadyPromise.succeeded());
+    KR_LOG_DEBUG("Connecting to account '%s'(%s)...", SdkString(api.sdk.getMyEmail()).c_str(), mMyHandle.toString().c_str());
+
     setConnState(kConnecting);
     mOwnPresence = pres;
-    KR_LOG_DEBUG("Connecting to account '%s'(%s)...", SdkString(api.sdk.getMyEmail()).c_str(), mMyHandle.toString().c_str());
+
+    assert(mSessionReadyPromise.succeeded());
     assert(mUserAttrCache);
+
     mUserAttrCache->onLogin();
     mOwnNameAttrHandle = mUserAttrCache->getAttr(mMyHandle, USER_ATTR_FULLNAME, this,
     [](Buffer* buf, void* userp)
@@ -951,7 +952,7 @@ promise::Promise<void> Client::doConnect(Presence pres, bool isInBackground)
         }
 
         heartbeat();
-    }, 10000, appCtx);
+    }, kHeartbeatTimeout, appCtx);
     return pms;
 }
 
@@ -959,6 +960,7 @@ void Client::disconnect()
 {
     if (mConnState == kDisconnected)
         return;
+
     setConnState(kDisconnected);
     // stop sync of user attributes in cache
     assert(mOwnNameAttrHandle.isValid());
@@ -977,6 +979,7 @@ void Client::disconnect()
     mChatdClient->disconnect();
     mPresencedClient.disconnect();
 }
+
 void Client::setConnState(ConnState newState)
 {
     mConnState = newState;

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -791,7 +791,7 @@ public:
      * @brief Retry pending connections to chatd and presenced
      * @return A promise to track the result of the action.
      */
-    promise::Promise<void> retryPendingConnections();
+    void retryPendingConnections(bool disconnect);
 
     /**
      * @brief A convenience method that logs in the Mega SDK and then inits

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -628,6 +628,11 @@ public:
         kInitErrSidInvalid
     };
 
+    enum
+    {
+        kHeartbeatTimeout = 10000     /// Timeout for heartbeats (ms)
+    };
+
     /** @brief Convenience aliases for the \c force flag in \c setPresence() */
     enum: bool { kSetPresOverride = true, kSetPresDynamic = false };
 

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -309,11 +309,6 @@ void Chat::connect()
     }
 }
 
-void Chat::disconnect()
-{
-    setOnlineState(kChatStateOffline);
-}
-
 void Chat::login()
 {
     assert(mConnection.isOnline());

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -189,7 +189,10 @@ void Client::sendEcho()
 {
     for (auto& conn: mConnections)
     {
-        conn.second->sendEcho();
+        if (conn.second->isOnline())
+        {
+            conn.second->sendEcho();
+        }
     }
 }
 
@@ -422,6 +425,7 @@ void Connection::sendEcho()
         mEchoTimer = 0;
 
         CHATDS_LOG_DEBUG("Echo response not received in %d secs. Reconnecting...", kEchoTimeout);
+        mChatdClient.karereClient->api.callIgnoreResult(&::mega::MegaApi::sendEvent, 99001, "ECHO response timed out");
 
         mState = kStateDisconnected;
         mHeartbeatEnabled = false;

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -65,10 +65,13 @@ enum HistSource
     kHistSourceServer = 3, //< History is being retrieved from the server
     kHistSourceNotLoggedIn = 4 //< History has to be fetched from server, but we are not logged in yet
 };
-/** Timeout to send SEEN (Milliseconds)**/
-enum { kSeenTimeout = 200 };
-/** Timeout to recv SYNC (Milliseconds)**/
-enum { kSyncTimeout = 2500 };
+
+enum
+{
+    kSeenTimeout = 200,     /// Delay to send SEEN (ms)
+    kSyncTimeout = 2500     /// Timeout to recv SYNC (ms)
+};
+
 enum { kMaxMsgSize = 120000 };  // (in bytes)
 
 class DbInterface;
@@ -749,7 +752,6 @@ public:
       */
     void connect();
 
-    void disconnect();
     /** @brief The online state of the chatroom */
     ChatState onlineState() const { return mOnlineState; }
 

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -11,10 +11,11 @@
 #include <base/promise.h>
 #include <base/timers.hpp>
 #include <base/trackDelete.h>
-#include "chatdMsg.h"
-#include "url.h"
-#include "net/websocketsIO.h"
-#include "userAttrCache.h"
+#include <chatdMsg.h>
+#include <url.h>
+#include <net/websocketsIO.h>
+#include <userAttrCache.h>
+#include <base/retryHandler.h>
 
 namespace karere {
     class Client;
@@ -358,6 +359,7 @@ protected:
     std::string mTargetIp;
     DNScache &mDNScache;
     bool mHeartbeatEnabled = false;
+    std::unique_ptr<karere::rh::IRetryController> mRetryCtrl;
     time_t mTsLastRecv = 0;
     megaHandle mEchoTimer = 0;
     promise::Promise<void> mConnectPromise;
@@ -371,6 +373,7 @@ protected:
 
     void onSocketClose(int ercode, int errtype, const std::string& reason);
     promise::Promise<void> reconnect();
+    void abortRetryController();
     void disconnect();
     void doConnect();
 // Destroys the buffer content

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -396,7 +396,7 @@ public:
     }
     const std::set<karere::Id>& chatIds() const { return mChatIds; }
     uint32_t clientId() const { return mClientId; }
-    promise::Promise<void> retryPendingConnection();
+    void retryPendingConnection(bool disconnect);
     virtual ~Connection()
     {
         disconnect();
@@ -1165,7 +1165,7 @@ public:
     /** @brief Leaves the specified chatroom */
     void leave(karere::Id chatid);
     void disconnect();
-    promise::Promise<void> retryPendingConnections();
+    void retryPendingConnections(bool disconnect);
     void heartbeat();
     bool manualResendWhenUserJoins() const { return options & kOptManualResendWhenUserJoins; }
     void notifyUserIdle();

--- a/src/karereCommon.h
+++ b/src/karereCommon.h
@@ -45,8 +45,8 @@
 #endif
 
 #define KARERE_LOGIN_TIMEOUT 15000
-#define KARERE_RECONNECT_DELAY_MAX 10000
 #define KARERE_RECONNECT_DELAY_INITIAL 1000
+#define KARERE_RECONNECT_DELAY_MAX 5000
 
 #define KARERE_DEFAULT_TURN_SERVERS \
    "[{\"host\":\"turn:trn270n001.karere.mega.nz:3478?transport=udp\"}," \

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -228,9 +228,9 @@ int MegaChatApi::getChatConnectionState(MegaChatHandle chatid)
     return pImpl->getChatConnectionState(chatid);
 }
 
-void MegaChatApi::retryPendingConnections(MegaChatRequestListener *listener)
+void MegaChatApi::retryPendingConnections(bool disconnect, MegaChatRequestListener *listener)
 {
-    pImpl->retryPendingConnections(listener);
+    pImpl->retryPendingConnections(disconnect, listener);
 }
 
 void MegaChatApi::logout(MegaChatRequestListener *listener)

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -1970,6 +1970,7 @@ public:
      *
      * The associated request type with this request is MegaChatRequest::TYPE_RETRY_PENDING_CONNECTIONS
      *
+     * @param disconnect False to simply abort any backoff, true to disconnect and reconnect from scratch.
      * @param listener MegaChatRequestListener to track this request
      */
     void retryPendingConnections(bool disconnect = false, MegaChatRequestListener *listener = NULL);

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -1972,7 +1972,7 @@ public:
      *
      * @param listener MegaChatRequestListener to track this request
      */
-    void retryPendingConnections(MegaChatRequestListener *listener = NULL);
+    void retryPendingConnections(bool disconnect = false, MegaChatRequestListener *listener = NULL);
 
     /**
      * @brief Logout of chat servers invalidating the session

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -917,7 +917,7 @@ public:
     int getConnectionState();
     int getChatConnectionState(MegaChatHandle chatid);
     static int convertChatConnectionState(chatd::ChatState state);
-    void retryPendingConnections(MegaChatRequestListener *listener = NULL);
+    void retryPendingConnections(bool disconnect = false, MegaChatRequestListener *listener = NULL);
     void logout(MegaChatRequestListener *listener = NULL);
     void localLogout(MegaChatRequestListener *listener = NULL);
 

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -425,7 +425,7 @@ promise::Promise<void> Client::retryPendingConnection()
     {
         setConnState(kDisconnected);
         mHeartbeatEnabled = false;
-        PRESENCED_LOG_WARNING("Retry pending connections...");
+        PRESENCED_LOG_WARNING("Retry pending connection...");
         return reconnect();
     }
     return promise::Error("No valid URL provided to retry pending connections");

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -64,6 +64,7 @@ void Client::wsConnectCb()
     setConnState(kConnected);
     assert(!mConnectPromise.done());
     mConnectPromise.resolve();
+    mRetryCtrl.reset();
 }
 
 void Client::wsCloseCb(int errcode, int errtype, const char *preason, size_t /*reason_len*/)
@@ -165,6 +166,20 @@ void Client::signalActivity(bool force)
         sendUserActive(true, force);
 }
 
+void Client::abortRetryController()
+{
+    if (!mRetryCtrl)
+    {
+        return;
+    }
+
+    assert(!isOnline());
+
+    PRESENCED_LOG_DEBUG("Reconnection was aborted");
+    mRetryCtrl->abort();
+    mRetryCtrl.reset();
+}
+
 Promise<void>
 Client::reconnect(const std::string& url)
 {
@@ -186,16 +201,17 @@ Client::reconnect(const std::string& url)
 
         setConnState(kResolving);
 
+        // if there were an existing retry in-progress, abort it first or it will kick in after its backoff
+        abortRetryController();
+
+        // create a new retry controller and return its promise for reconnection
         auto wptr = weakHandle();
-        return retry("presenced", [this](int /*no*/, DeleteTrackable::Handle wptr)
+        mRetryCtrl.reset(createRetryController("presenced", [this](int /*no*/, DeleteTrackable::Handle wptr) -> Promise<void>
         {
             if (wptr.deleted())
             {
                 PRESENCED_LOG_DEBUG("Reconnect attempt initiated, but presenced client was deleted.");
-
-                promise::Promise<void> pms = Promise<void>();
-                pms.resolve();
-                return pms;
+                return promise::_Void();
             }
 
             disconnect();
@@ -300,8 +316,12 @@ Client::reconnect(const std::string& url)
                 mHeartbeatEnabled = true;
                 login();
             });
-        }, wptr, karereClient->appCtx, nullptr, 0, 0, KARERE_RECONNECT_DELAY_MAX, KARERE_RECONNECT_DELAY_INITIAL);
+
+        }, wptr, karereClient->appCtx, nullptr, 0, 0, KARERE_RECONNECT_DELAY_MAX, KARERE_RECONNECT_DELAY_INITIAL));
+
+        return static_cast<Promise<void>&>(mRetryCtrl->start());
     }
+
     KR_EXCEPTION_TO_PROMISE(kPromiseErrtype_presenced);
 }
     
@@ -425,6 +445,7 @@ promise::Promise<void> Client::retryPendingConnection()
     {
         setConnState(kDisconnected);
         mHeartbeatEnabled = false;
+        abortRetryController();
         PRESENCED_LOG_WARNING("Retry pending connection...");
         return reconnect();
     }

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -315,7 +315,7 @@ public:
         const Config& Config);
     void disconnect();
     void doConnect();
-    promise::Promise<void> retryPendingConnection();
+    void retryPendingConnection(bool disconnect);
     /** @brief Performs server ping and check for network inactivity.
      * Must be called externally in order to have all clients
      * perform pings at a single moment, to reduce mobile radio wakeup frequency */

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -7,9 +7,10 @@
 #include <base/promise.h>
 #include <base/timers.hpp>
 #include <karereId.h>
-#include "url.h"
+#include <url.h>
 #include <base/trackDelete.h>
-#include "net/websocketsIO.h"
+#include <net/websocketsIO.h>
+#include <base/retryHandler.h>
 
 #define PRESENCED_LOG_DEBUG(fmtString,...) KARERE_LOG_DEBUG(krLogChannel_presenced, fmtString, ##__VA_ARGS__)
 #define PRESENCED_LOG_INFO(fmtString,...) KARERE_LOG_INFO(krLogChannel_presenced, fmtString, ##__VA_ARGS__)
@@ -256,6 +257,7 @@ protected:
     karere::Client *karereClient;
     MyMegaApi *mApi;
     bool mHeartbeatEnabled = false;
+    std::unique_ptr<karere::rh::IRetryController> mRetryCtrl;
     promise::Promise<void> mConnectPromise;
     uint8_t mCapabilities;
     karere::Url mUrl;
@@ -271,7 +273,6 @@ protected:
     time_t mTsLastSend = 0;
     bool mPrefsAckWait = false;
     IdRefMap mCurrentPeers;
-    void initWebsocketCtx();
     void setConnState(ConnState newState);
 
     virtual void wsConnectCb();
@@ -280,6 +281,7 @@ protected:
     
     void onSocketClose(int ercode, int errtype, const std::string& reason);
     promise::Promise<void> reconnect(const std::string& url=std::string());
+    void abortRetryController();
     void handleMessage(const StaticBuffer& buf); // Destroys the buffer content
     bool sendCommand(Command&& cmd);
     bool sendCommand(const Command& cmd);


### PR DESCRIPTION
This branch requires the app to call `MegaChatApi::retryPendingConnections(bool disconnect)` in order to properly retry connections.