### PR TITLE
Return the MEGAChatCall or nil on 'chatCallForCallId' or 'chatCallForChatId' (Obj-C)

### DIFF
--- a/bindings/Objective-C/MEGAChatSdk.mm
+++ b/bindings/Objective-C/MEGAChatSdk.mm
@@ -777,11 +777,13 @@ static DelegateMEGAChatLoggerListener *externalLogger = NULL;
 }
 
 - (MEGAChatCall *)chatCallForCallId:(uint64_t)callId {
-    return [[MEGAChatCall alloc] initWithMegaChatCall:self.megaChatApi->getChatCallByCallId(callId) cMemoryOwn:YES];
+    MegaChatCall *chatCall = self.megaChatApi->getChatCallByCallId(callId);
+    return chatCall ? [[MEGAChatCall alloc] initWithMegaChatCall:chatCall cMemoryOwn:YES] : nil;
 }
 
 - (MEGAChatCall *)chatCallForChatId:(uint64_t)chatId {
-    return [[MEGAChatCall alloc] initWithMegaChatCall:self.megaChatApi->getChatCall(chatId) cMemoryOwn:YES];
+    MegaChatCall *chatCall = self.megaChatApi->getChatCall(chatId);
+    return chatCall ? [[MEGAChatCall alloc] initWithMegaChatCall:chatCall cMemoryOwn:YES] : nil;
 }
 
 - (NSInteger)numCalls {


### PR DESCRIPTION
An empty MEGAChatCall was initialized when the MegaChatCall was NULL.