### PR TITLE
Fixes to load history and sending queue

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1001,10 +1001,9 @@ HistSource Chat::getHistory(unsigned count)
                 auto& msg = at(i);
                 if (msg.isPendingToDecrypt())
                 {
-                    assert(false);
                     CHATID_LOG_WARNING("Skipping the load of a message still encrypted. "
                                        "msgid: %s idx: %d", ID_CSTR(msg.id()), i);
-                    continue;
+                    break;
                 }
 
                 CALL_LISTENER(onRecvHistoryMessage, i, msg, getMsgStatus(msg, i), true);

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2235,7 +2235,7 @@ bool Chat::msgEncryptAndSend(OutputQueue::iterator it)
         assert(keyCmd->localKeyid() == msg->keyid);
         assert(msgCmd->keyId() == CHATD_KEYID_UNCONFIRMED);
 
-        SendingItem item = mSending.front();
+        SendingItem &item = mSending.front();
         item.msgCmd = msgCmd;
         item.keyCmd = keyCmd;
         CALL_DB(addBlobsToSendingItem, rowid, item.msgCmd, item.keyCmd, msg->keyid);


### PR DESCRIPTION
The sending queue is not properly updated when the sending item is modified, since the changes are not actually saved in the sending queue (but in cache).
On the other hand, the load of history when there are incoming messages still encrypted should follow as usual, instead of fail an assertion as it used to be.