### PR TITLE
Fix wrong assert in presence::updatePeers()

### DIFF
--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -346,6 +346,12 @@ bool Client::sendKeepalive(time_t now)
 
 void Client::updatePeers(const vector<Id> &peers, bool addOrRemove)
 {
+    if (addOrRemove && peers.empty())
+    {
+        PRESENCED_LOG_DEBUG("updatePeers: no peers to allow to see the presence status");
+        return;
+    }
+
     assert(peers.size());
     const char *buf = mApi->sdk.getSequenceNumber();
     Id scsn(buf, strlen(buf));


### PR DESCRIPTION
When the account is empty (no chats, no contacts), there's no users to
allow to see our presence status.