### PR TITLE
Fix load of messages after attempt while offline

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -395,6 +395,16 @@ void Client::onSyncReceived(Id chatid)
     }
 }
 
+bool Client::isChatRoomOpened(Id chatid)
+{
+    auto it = chats->find(chatid);
+    if (it != chats->end())
+    {
+        return it->second->hasChatHandler();
+    }
+    return false;
+}
+
 promise::Promise<void> Client::loginSdkAndInit(const char* sid)
 {
     init(sid);

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -860,6 +860,8 @@ public:
     void dumpChatrooms(::mega::MegaTextChatList& chatRooms);
     void dumpContactList(::mega::MegaUserList& clist);
 
+    bool isChatRoomOpened(Id chatid);
+
 protected:
     void heartbeat();
     void setInitState(InitState newState);

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1612,7 +1612,14 @@ void Chat::onFetchHistDone()
         else
         {
             mServerFetchState = kHistNotFetching;
-            mNextHistFetchIdx = lownum()-1;
+            // if app tries to load messages before first join and there's no local history available yet,
+            // they received a `HistSource == kSourceNotLoggedIn`. During login, received messages won't be
+            // notified, but after login the app can attempt to load messages again and should be notified
+            // about messages from the beginning
+            if (!mIsFirstJoin)
+            {
+                mNextHistFetchIdx = lownum()-1;
+            }
         }
         if (mLastServerHistFetchCount <= 0)
         {

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -621,6 +621,7 @@ protected:
 
     /** @brief Whether we have more not-loaded history in db */
     bool mHasMoreHistoryInDb = false;
+    /** When true, OLDMSGs received from chatd are notified to the app */
     bool mServerOldHistCbEnabled = false;
     /** @brief Have reached the beggining of the history (not necessarily the end of it) */
     bool mHaveAllHistory = false;


### PR DESCRIPTION
When the app tries to `loadMessages()` and it requires to fetch messages
from server but we're offline, it returns `SOURCE_ERROR` (`kSourceNotLoggedIn`). However, when
the connection is back and we are logged in into chatd, a new
`loadMessages()` should notify the received messages from server. It
loads them, but didn't notify them. The issue comes from the update of `mNextHistFetchIdx` at `onFetchHistDone()`, which doesn't take into account that there's no local history available at all.
Additionally, another bug was due to a (too) early assignment of `mServerOldHistCbEnabled` in
`getHistoryFromDbOrServer()`.
Additionally, this commit attempts to be more accurate with the
notification of `OLDMSG` after a `REJECT` of `JOINRANGEHIST` (if the
chat was not opened, we don't need to set the aforementioned flag).