### PR TITLE
Do not update the `mNextHistFetchIdx` upon first login

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1610,7 +1610,14 @@ void Chat::onFetchHistDone()
         else
         {
             mServerFetchState = kHistNotFetching;
-            mNextHistFetchIdx = lownum()-1;
+            // if app tries to load messages before first join and there's no local history available yet,
+            // they received a `HistSource == kSourceNotLoggedIn`. During login, received messages won't be
+            // notified, but after login the app can attempt to load messages again and should be notified
+            // about messages from the beginning
+            if (!mIsFirstJoin)
+            {
+                mNextHistFetchIdx = lownum()-1;
+            }
         }
         if (mLastServerHistFetchCount <= 0)
         {


### PR DESCRIPTION
If app tries to load messages before first join and there's no local
history available yet, they received a `HistSource ==
kSourceNotLoggedIn`. During login, received messages won't be notified,
but after login the app can attempt to load messages again and should be
notified about messages from the beginning, not from the last received
message.