### PR TITLE
Update static ICE servers

### DIFF
--- a/src/karereCommon.h
+++ b/src/karereCommon.h
@@ -50,11 +50,8 @@
 
 #define KARERE_DEFAULT_TURN_SERVERS \
    "[{\"host\":\"turn:trn270n001.karere.mega.nz:3478?transport=udp\"}," \
-    "{\"host\":\"turn:trn270n002.karere.mega.nz:3478?transport=udp\"}," \
-    "{\"host\":\"turn:trn530n001.karere.mega.nz:3478?transport=udp\"}," \
-    "{\"host\":\"turn:trn530n002.karere.mega.nz:3478?transport=udp\"}," \
     "{\"host\":\"turn:trn302n001.karere.mega.nz:3478?transport=udp\"}," \
-    "{\"host\":\"turn:trn302n002.karere.mega.nz:3478?transport=udp\"}]"
+    "{\"host\":\"turn:trn530n001.karere.mega.nz:3478?transport=udp\"}]"
 
 #define KARERE_TURN_USERNAME "inoo20jdnH"
 #define KARERE_TURN_PASSWORD "02nNKDBkkS"


### PR DESCRIPTION
One per geographical location, rather than most of the available ones.
Remember the ICE servers should be retrieved by GeLB, so they are load-
balanced instead of using the static ones by default.