### PR TITLE
 Fail upon `setOnlineStatus()` with current value

### DIFF
--- a/src/base/promise.h
+++ b/src/base/promise.h
@@ -92,7 +92,12 @@ struct ErrorShared
 
 enum
 {
-    kErrorTypeGeneric = 1
+    kErrorTypeGeneric       =   1,
+    kErrorUnknown           =  -1,
+    kErrorArgs              =  -2,
+    kErrorNoEnt             =  -9,
+    kErrorAccess            = -11,
+    kErrorAlreadyExist      = -12
 };
 enum
 {

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1330,13 +1330,21 @@ void Client::terminate(bool deleteDb)
 
 promise::Promise<void> Client::setPresence(Presence pres)
 {
-    if (!mPresencedClient.setPresence(pres))
-        return promise::Error("Not connected");
-    else
+    if (pres == mPresencedClient.config().presence())
     {
-        app.onPresenceChanged(mMyHandle, pres, true);
-        return promise::_Void();
+        std::string err = "setPresence: tried to change online state to the current configured state (";
+        err.append(mOwnPresence.toString(mOwnPresence)).append(")");
+        return promise::Error(err, kErrorArgs);
     }
+
+    bool ret = mPresencedClient.setPresence(pres);
+    if (!ret)
+    {
+        return promise::Error("setPresence: not connected", kErrorAccess);
+    }
+
+    app.onPresenceChanged(mMyHandle, pres, true);
+    return promise::_Void();
 }
 
 void Client::onUsersUpdate(mega::MegaApi* /*api*/, mega::MegaUserList *aUsers)

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2029,11 +2029,18 @@ public:
     void localLogout(MegaChatRequestListener *listener = NULL);
 
     /**
-     * @brief Set your online status.
+     * @brief Set your configuration for online status.
      *
      * The associated request type with this request is MegaChatRequest::TYPE_SET_CHAT_STATUS
      * Valid data in the MegaChatRequest object received on callbacks:
      * - MegaChatRequest::getNumber - Returns the new status of the user in chat.
+     *
+     * The request will fail with MegaChatError::ERROR_ARGS when this function is
+     * called with the same value \c status than the currently cofigured status.
+     * @see MegaChatPresenceConfig::getOnlineStatus to check the current status.
+     *
+     * The request will fail with MegaChatError::ERROR_ACCESS when this function is
+     * called and the connection to presenced is down.
      *
      * @param status Online status in the chat.
      *
@@ -2152,7 +2159,11 @@ public:
     void signalPresenceActivity(MegaChatRequestListener *listener = NULL);
 
     /**
-     * @brief Get your online status.
+     * @brief Get your currently online status.
+     *
+     * @note This function may return a different online status than the online status from
+     * MegaChatPresenceConfig::getOnlineStatus. In example, when the user has configured the
+     * autoaway option, after the timeout has expired, the status will be Away instead of Online.
      *
      * It can be one of the following values:
      * - MegaChatApi::STATUS_OFFLINE = 1

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -51,8 +51,11 @@ public:
     bool isValid() const { return mPres != kInvalid; }
     inline static const char* toString(Code pres);
     const char* toString() const { return toString(mPres); }
+
+    // capabilities
     bool canWebRtc() { return mPres & kClientCanWebrtc; }
     bool isMobile() { return mPres & kClientIsMobile; }
+    bool canLastGreen() { return mPres & kClientSupportLastGreen; }
 
 protected:
     Code mPres;
@@ -354,32 +357,36 @@ protected:
     
 public:
     Client(MyMegaApi *api, karere::Client *client, Listener& listener, uint8_t caps);
+
+    // config management
     const Config& config() const { return mConfig; }
     bool isConfigAcknowledged() { return mPrefsAckWait; }
-    bool isOnline() const { return (mConnState >= kConnected); }
     bool setPresence(karere::Presence pres);
-    bool setPersist(bool enable);
-    bool setLastGreenVisible(bool enable);
-    bool requestLastGreen(karere::Id userid);
-
-
     /** @brief Enables or disables autoaway
      * @param timeout The timeout in seconds after which the presence will be
      *  set to away
      */
     bool setAutoaway(bool enable, time_t timeout);
+    bool autoAwayInEffect();
+    bool setPersist(bool enable);
+    bool setLastGreenVisible(bool enable);
+    bool requestLastGreen(karere::Id userid);
+
+    // connection's management
+    bool isOnline() const { return (mConnState >= kConnected); }
     promise::Promise<void>
-    connect(const std::string& url, karere::Id myHandle, IdRefMap&& peers,
-        const Config& Config);
+    connect(const std::string& url, karere::Id myHandle, IdRefMap&& peers, const Config& Config);
     void disconnect();
     void doConnect();
     void retryPendingConnection(bool disconnect);
+
     /** @brief Performs server ping and check for network inactivity.
      * Must be called externally in order to have all clients
      * perform pings at a single moment, to reduce mobile radio wakeup frequency */
     void heartbeat();
     void signalActivity(bool force = false);
-    bool autoAwayInEffect();
+
+    // peers management
     void addPeer(karere::Id peer);
     void removePeer(karere::Id peer, bool force=false);
     ~Client();


### PR DESCRIPTION
Apps get a `onChatOnlineStatus(myHandle, status, inProgress)` when they
attempt to change the status to the same value than the currently
configured one (with `inProgress = true`). However, there's never
confirmation of the new status configuration success, since it's never
sent.