### PR TITLE
Support for share-geolocation messages

### DIFF
--- a/bindings/Objective-C/Karere.xcodeproj/project.pbxproj
+++ b/bindings/Objective-C/Karere.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		A879F3CA1F96685E007C5394 /* libuvWaiter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A879F3C91F96685D007C5394 /* libuvWaiter.cpp */; };
 		A879F3D91F966D8E007C5394 /* rtcCrypto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A879F3D81F966D8E007C5394 /* rtcCrypto.cpp */; };
 		A8AA1BF92195B21800E15B60 /* DelegateMEGAChatNodeHistoryListener.mm in Sources */ = {isa = PBXBuildFile; fileRef = A8AA1BF82195B21800E15B60 /* DelegateMEGAChatNodeHistoryListener.mm */; };
+		A8F96C1A219DE3A2005A3EB6 /* MEGAChatGeolocation.mm in Sources */ = {isa = PBXBuildFile; fileRef = A8F96C19219DE3A2005A3EB6 /* MEGAChatGeolocation.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -130,6 +131,7 @@
 		947566401F18D61100FE8664 /* libeventWaiter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = libeventWaiter.h; path = ../../src/waiter/libeventWaiter.h; sourceTree = "<group>"; };
 		947566441F197C0A00FE8664 /* libuvWaiter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = libuvWaiter.h; path = ../../src/waiter/libuvWaiter.h; sourceTree = "<group>"; };
 		947566551F3397AE00FE8664 /* cservices.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cservices.cpp; path = ../../src/base/cservices.cpp; sourceTree = "<group>"; };
+		A819DE8D219EE12E00EA9C22 /* MEGAChatGeolocation+init.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "MEGAChatGeolocation+init.h"; path = "Private/MEGAChatGeolocation+init.h"; sourceTree = "<group>"; };
 		A82750B91E9788A3007CD9E2 /* MEGAChatDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MEGAChatDelegate.h; sourceTree = "<group>"; };
 		A82750BA1E9788A3007CD9E2 /* MEGAChatError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MEGAChatError.h; sourceTree = "<group>"; };
 		A82750BB1E9788A3007CD9E2 /* MEGAChatError.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MEGAChatError.mm; sourceTree = "<group>"; };
@@ -206,6 +208,8 @@
 		A8AA1BF62195B11B00E15B60 /* MEGAChatNodeHistoryDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MEGAChatNodeHistoryDelegate.h; sourceTree = "<group>"; };
 		A8AA1BF72195B21800E15B60 /* DelegateMEGAChatNodeHistoryListener.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DelegateMEGAChatNodeHistoryListener.h; path = Private/DelegateMEGAChatNodeHistoryListener.h; sourceTree = "<group>"; };
 		A8AA1BF82195B21800E15B60 /* DelegateMEGAChatNodeHistoryListener.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = DelegateMEGAChatNodeHistoryListener.mm; path = Private/DelegateMEGAChatNodeHistoryListener.mm; sourceTree = "<group>"; };
+		A8F96C18219DE3A2005A3EB6 /* MEGAChatGeolocation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MEGAChatGeolocation.h; sourceTree = "<group>"; };
+		A8F96C19219DE3A2005A3EB6 /* MEGAChatGeolocation.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MEGAChatGeolocation.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -373,6 +377,7 @@
 				A837387E213019CA0014328D /* DelegateMEGAChatNotificationListener.mm */,
 				A8AA1BF72195B21800E15B60 /* DelegateMEGAChatNodeHistoryListener.h */,
 				A8AA1BF82195B21800E15B60 /* DelegateMEGAChatNodeHistoryListener.mm */,
+				A819DE8D219EE12E00EA9C22 /* MEGAChatGeolocation+init.h */,
 			);
 			name = private;
 			sourceTree = "<group>";
@@ -415,6 +420,8 @@
 				77875CDC2097A80700B8340F /* MEGAChatRichPreview.mm */,
 				A837387A213018CB0014328D /* MEGAChatNotificationDelegate.h */,
 				A8AA1BF62195B11B00E15B60 /* MEGAChatNodeHistoryDelegate.h */,
+				A8F96C18219DE3A2005A3EB6 /* MEGAChatGeolocation.h */,
+				A8F96C19219DE3A2005A3EB6 /* MEGAChatGeolocation.mm */,
 			);
 			name = binding;
 			sourceTree = "<group>";
@@ -581,6 +588,7 @@
 				A879F3C21F96683A007C5394 /* presenced.cpp in Sources */,
 				A82750EE1E9788D8007CD9E2 /* DelegateMEGAChatListener.mm in Sources */,
 				A82750D81E9788A3007CD9E2 /* MEGAChatRequest.mm in Sources */,
+				A8F96C1A219DE3A2005A3EB6 /* MEGAChatGeolocation.mm in Sources */,
 				A82750DB1E9788A3007CD9E2 /* MEGAChatSdk.mm in Sources */,
 				A83D5BF61F974AF900A038F7 /* webrtcAdapter.cpp in Sources */,
 				A82750D91E9788A3007CD9E2 /* MEGAChatRoom.mm in Sources */,

--- a/bindings/Objective-C/MEGAChatContainsMeta.h
+++ b/bindings/Objective-C/MEGAChatContainsMeta.h
@@ -2,15 +2,20 @@
 #import <Foundation/Foundation.h>
 
 #import "MEGAChatRichPreview.h"
+#import "MEGAChatGeolocation.h"
 
 typedef NS_ENUM(NSInteger, MEGAChatContainsMetaType) {
     MEGAChatContainsMetaTypeInvalid     = -1,
-    MEGAChatContainsMetaTypeRichPreview = 0
+    MEGAChatContainsMetaTypeRichPreview = 0,
+    MEGAChatContainsMetaTypeGeolocation = 1
 };
 
 @interface MEGAChatContainsMeta : NSObject
 
 @property (readonly, nonatomic) MEGAChatContainsMetaType type;
+@property (readonly, nonatomic) NSString *textMessage;
 @property (readonly, nonatomic) MEGAChatRichPreview *richPreview;
+@property (readonly, nonatomic) MEGAChatGeolocation *geolocation;
+
 
 @end

--- a/bindings/Objective-C/MEGAChatContainsMeta.mm
+++ b/bindings/Objective-C/MEGAChatContainsMeta.mm
@@ -4,6 +4,7 @@
 #import "megachatapi.h"
 
 #import "MEGAChatRichPreview+init.h"
+#import "MEGAChatGeolocation+init.h"
 
 using namespace megachat;
 
@@ -45,8 +46,18 @@ using namespace megachat;
     return self.megaChatContainsMeta ? (MEGAChatContainsMetaType)self.megaChatContainsMeta->getType() : MEGAChatContainsMetaTypeInvalid;
 }
 
+- (NSString *)textMessage {
+    if (!self.megaChatContainsMeta) return nil;
+    const char *ret = self.megaChatContainsMeta->getTextMessage();
+    return ret ? [[NSString alloc] initWithUTF8String:ret] : nil;
+}
+
 - (MEGAChatRichPreview *)richPreview {
     return self.megaChatContainsMeta->getRichPreview() ? [[MEGAChatRichPreview alloc] initWithMegaChatRichPreview:self.megaChatContainsMeta->getRichPreview()->copy() cMemoryOwn:YES] : nil;
+}
+
+- (MEGAChatGeolocation *)geolocation {
+    return self.megaChatContainsMeta->getGeolocation() ? [[MEGAChatGeolocation alloc] initWithMegaChatGeolocation:self.megaChatContainsMeta->getGeolocation() cMemoryOwn:YES] : nil;
 }
 
 @end

--- a/bindings/Objective-C/MEGAChatGeolocation.h
+++ b/bindings/Objective-C/MEGAChatGeolocation.h
@@ -1,0 +1,14 @@
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MEGAChatGeolocation : NSObject
+
+@property (readonly, nonatomic) float longitude;
+@property (readonly, nonatomic) float latitude;
+@property (nullable, readonly, nonatomic) NSString *image;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/bindings/Objective-C/MEGAChatGeolocation.mm
+++ b/bindings/Objective-C/MEGAChatGeolocation.mm
@@ -1,0 +1,47 @@
+
+#import "MEGAChatGeolocation.h"
+
+#import "megachatapi.h"
+
+using namespace megachat;
+
+@interface MEGAChatGeolocation ()
+
+@property MegaChatGeolocation *megaChatGeolocation;
+@property BOOL cMemoryOwn;
+
+@end
+
+@implementation MEGAChatGeolocation
+
+- (instancetype)initWithMegaChatGeolocation:(MegaChatGeolocation *)megaChatGeolocation cMemoryOwn:(BOOL)cMemoryOwn {
+    NSParameterAssert(megaChatGeolocation);
+    
+    if (self = [super init]) {
+        _megaChatGeolocation = megaChatGeolocation;
+        _cMemoryOwn = cMemoryOwn;
+    }
+    
+    return self;
+}
+
+- (void)dealloc {
+    if (self.cMemoryOwn) {
+        delete _megaChatGeolocation;
+    }
+}
+
+- (float)longitude {
+    return self.megaChatGeolocation->getLongitude();
+}
+
+- (float)latitude {
+    return self.megaChatGeolocation->getLatitude();
+}
+
+- (NSString *)image {
+    if (!self.megaChatGeolocation) return nil;    
+    return self.megaChatGeolocation->getImage() ? [[NSString alloc] initWithUTF8String:self.megaChatGeolocation->getImage()] : nil;
+}
+
+@end

--- a/bindings/Objective-C/MEGAChatSdk.h
+++ b/bindings/Objective-C/MEGAChatSdk.h
@@ -217,6 +217,7 @@ typedef NS_ENUM (NSInteger, MEGAChatConnection) {
 - (MEGAChatMessage *)forwardContactFromChat:(uint64_t)sourceChatId messageId:(uint64_t)messageId targetChatId:(uint64_t)targetChatId;
 - (void)attachNodesToChat:(uint64_t)chatId nodes:(NSArray *)nodesArray delegate:(id<MEGAChatRequestDelegate>)delegate;
 - (void)attachNodesToChat:(uint64_t)chatId nodes:(NSArray *)nodesArray;
+- (MEGAChatMessage *)sendGeolocationToChat:(uint64_t)chatId longitude:(float)longitude latitude:(float)latitude image:(NSString *)image;
 - (void)revokeAttachmentToChat:(uint64_t)chatId node:(uint64_t)nodeHandle delegate:(id<MEGAChatRequestDelegate>)delegate;
 - (void)revokeAttachmentToChat:(uint64_t)chatId node:(uint64_t)nodeHandle;
 - (void)attachNodeToChat:(uint64_t)chatId node:(uint64_t)nodeHandle delegate:(id<MEGAChatRequestDelegate>)delegate;

--- a/bindings/Objective-C/MEGAChatSdk.mm
+++ b/bindings/Objective-C/MEGAChatSdk.mm
@@ -682,6 +682,11 @@ static DelegateMEGAChatLoggerListener *externalLogger = NULL;
     self.megaChatApi->attachNodes(chatId, (nodeList != nil) ? [nodeList getCPtr] : NULL);
 }
 
+- (MEGAChatMessage *)sendGeolocationToChat:(uint64_t)chatId longitude:(float)longitude latitude:(float)latitude image:(NSString *)image {
+    MegaChatMessage *message = self.megaChatApi->sendGeolocation(chatId, longitude, latitude, image ? [image UTF8String] : NULL);
+    return message ? [[MEGAChatMessage alloc] initWithMegaChatMessage:message cMemoryOwn:YES] : nil;
+}
+
 - (void)revokeAttachmentToChat:(uint64_t)chatId node:(uint64_t)nodeHandle delegate:(id<MEGAChatRequestDelegate>)delegate {
     self.megaChatApi->revokeAttachment(chatId, nodeHandle, [self createDelegateMEGAChatRequestListener:delegate singleListener:YES]);
 }

--- a/bindings/Objective-C/Private/MEGAChatGeolocation+init.h
+++ b/bindings/Objective-C/Private/MEGAChatGeolocation+init.h
@@ -1,0 +1,13 @@
+
+#import "MEGAChatGeolocation.h"
+#import "megachatapi.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MEGAChatGeolocation (init)
+
+- (instancetype)initWithMegaChatGeolocation:(const megachat::MegaChatGeolocation *)megaChatGeolocation cMemoryOwn:(BOOL)cMemoryOwn;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/bindings/java/nz/mega/sdk/MegaChatApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaChatApiJava.java
@@ -1494,6 +1494,33 @@ public class MegaChatApiJava {
     }
 
     /**
+     * Share a geolocation in the specified chatroom
+     *
+     * The MegaChatMessage object returned by this function includes a message transaction id,
+     * That id is not the definitive id, which will be assigned by the server. You can obtain the
+     * temporal id with MegaChatMessage::getTempId
+     *
+     * When the server confirms the reception of the message, the MegaChatRoomListener::onMessageUpdate
+     * is called, including the definitive id and the new status: MegaChatMessage::STATUS_SERVER_RECEIVED.
+     * At this point, the app should refresh the message identified by the temporal id and move it to
+     * the final position in the history, based on the reported index in the callback.
+     *
+     * If the message is rejected by the server, the message will keep its temporal id and will have its
+     * a message id set to MEGACHAT_INVALID_HANDLE.
+     *
+     * You take the ownership of the returned value.
+     *
+     * @param chatid MegaChatHandle that identifies the chat room
+     * @param longitude from shared geolocation
+     * @param latitude from shared geolocation
+     * @param img Preview as a byte array encoded in Base64URL. It can be NULL
+     * @return MegaChatMessage that will be sent. The message id is not definitive, but temporal.
+     */
+    public MegaChatMessage sendGeolocation(long chatid, float longitude, float latitude, String img){
+        return megaChatApi.sendGeolocation(chatid, longitude, latitude, img);
+    }
+
+    /**
      * Revoke the access to a node in the specified chatroom
      *
      * In contrast to other functions to send messages, such as

--- a/examples/qtmegachatapi/chatMessage.cpp
+++ b/examples/qtmegachatapi/chatMessage.cpp
@@ -73,29 +73,58 @@ void ChatMessage::updateToolTip()
     delete auxUserId_64;
 }
 
-void ChatMessage::showRichLinkData()
+void ChatMessage::showContainsMetaData()
 {
-    QString text = tr("[Contains-metadata msg]");
     const MegaChatContainsMeta *containsMeta = mMessage->getContainsMeta();
-    if (containsMeta && containsMeta->getType() == megachat::MegaChatContainsMeta::CONTAINS_META_RICH_PREVIEW)
+    assert(containsMeta);
+    QString text = tr("[Contains-metadata msg]");
+    if (containsMeta)
     {
-        const MegaChatRichPreview *richPreview = containsMeta->getRichPreview();
-        text.append(tr("\nSubtype: rich-link"))
-            .append(tr("\nOriginal content: "))
-            .append(richPreview->getText())
-            .append(tr("\nURL: "))
-            .append(richPreview->getUrl())
-            .append(tr("\nDomain Name: "))
-            .append(richPreview->getDomainName())
-            .append(tr("\nTitle: "))
-            .append(richPreview->getTitle())
-            .append(tr("\nDescription: "))
-            .append(richPreview->getDescription())
-            .append(tr("\nHas icon: "))
-            .append(richPreview->getIcon() ? "yes" : "no")
-            .append(tr("\nHas image: "))
-            .append(richPreview->getImage() ? "yes" : "no");
+        switch (containsMeta->getType()) {
+            case  megachat::MegaChatContainsMeta::CONTAINS_META_RICH_PREVIEW:
+            {
+                const MegaChatRichPreview *richPreview = containsMeta->getRichPreview();
+                text.append(tr("\nSubtype: rich-link"))
+                    .append(tr("\nOriginal content: "))
+                    .append(richPreview->getText())
+                    .append(tr("\nURL: "))
+                    .append(richPreview->getUrl())
+                    .append(tr("\nDomain Name: "))
+                    .append(richPreview->getDomainName())
+                    .append(tr("\nTitle: "))
+                    .append(richPreview->getTitle())
+                    .append(tr("\nDescription: "))
+                    .append(richPreview->getDescription())
+                    .append(tr("\nHas icon: "))
+                    .append(richPreview->getIcon() ? "yes" : "no")
+                    .append(tr("\nHas image: "))
+                    .append(richPreview->getImage() ? "yes" : "no");
+                break;
+            }
+            case  megachat::MegaChatContainsMeta::CONTAINS_META_GEOLOCATION:
+            {
+                const MegaChatGeolocation *geolocation = containsMeta->getGeolocation();
+                text.append(tr("\nSubtype: Geolocation"))
+                    .append(tr("\nText content: "))
+                    .append(containsMeta->getTextMessage())
+                    .append(tr("\nLongitude: "))
+                    .append(QString::number(geolocation->getLongitude()))
+                    .append(tr("\nLatitude: "))
+                    .append(QString::number(geolocation->getLatitude()))
+                    .append(tr("\nHas image: "))
+                    .append(geolocation->getImage() ? "yes" : "no");
+                break;
+            }
+            default:
+            {
+                text.append(tr("\nSubtype: unkown"))
+                    .append(tr("\nText content: "))
+                    .append(containsMeta->getTextMessage());
+                break;
+            }
+        }
     }
+
     ui->mMsgDisplay->setText(text);
     ui->mMsgDisplay->setStyleSheet("background-color: rgba(213,245,160,128)\n");
     ui->mAuthorDisplay->setStyleSheet("color: rgba(0,0,0,128)\n");
@@ -204,7 +233,7 @@ void ChatMessage::updateContent()
             }
             case megachat::MegaChatMessage::TYPE_CONTAINS_META:
             {
-                showRichLinkData();
+                showContainsMetaData();
                 break;
             }
             case megachat::MegaChatMessage::TYPE_INVALID:

--- a/examples/qtmegachatapi/chatMessage.h
+++ b/examples/qtmegachatapi/chatMessage.h
@@ -22,7 +22,7 @@ class ChatMessage: public QWidget
         megachat::MegaChatApi* megaChatApi;
         QListWidgetItem * mListWidgetItem;
         void updateToolTip();
-        void showRichLinkData();
+        void showContainsMetaData();
         void setMessageContent(const char * content);
         ChatWindow *mChatWindow;
         friend class ChatWindow;

--- a/examples/qtmegachatapi/chatWindow.cpp
+++ b/examples/qtmegachatapi/chatWindow.cpp
@@ -761,6 +761,11 @@ void ChatWindow::on_mAttachBtn_clicked()
     delete parent;
 }
 
+void ChatWindow::on_mGeoLocationBtn_clicked()
+{
+    mMegaChatApi->sendGeolocation(mChatRoom->getChatId(), -122.3316393, 47.5951518, NULL);
+}
+
 void ChatWindow::on_mCancelTransfer(QAbstractButton*)
 {
     mMegaApi->cancelTransfers(::mega::MegaTransfer::TYPE_UPLOAD);

--- a/examples/qtmegachatapi/chatWindow.h
+++ b/examples/qtmegachatapi/chatWindow.h
@@ -93,6 +93,7 @@ class ChatWindow : public QDialog,
         void onTruncateChat();
         void onMembersBtn(bool);
         void on_mAttachBtn_clicked();
+        void on_mGeoLocationBtn_clicked();
         void on_mCancelTransfer(QAbstractButton *);
         void onArchiveClicked(bool);
 

--- a/examples/qtmegachatapi/chatWindow.ui
+++ b/examples/qtmegachatapi/chatWindow.ui
@@ -222,7 +222,7 @@
         <property name="styleSheet">
          <string notr="true"/>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,1,0,0,0,0">
+        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,1,0,0,0,0,0">
          <property name="spacing">
           <number>6</number>
          </property>
@@ -447,19 +447,19 @@ border-image: url(':/groupchat-members-hover.svg')
            </property>
           </widget>
          </item>
-		 <item>
-				  <widget class="QToolButton" name="mSettingsBtn">
-				   <property name="enabled">
-				    <bool>true</bool>
-				   </property>
-				   <property name="minimumSize">
-				    <size>
-				     <width>30</width>
-				     <height>20</height>
-				    </size>
-				   </property>
-				   <property name="styleSheet">
-				    <string notr="true">QToolButton
+         <item>
+          <widget class="QToolButton" name="mSettingsBtn">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>30</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">QToolButton
 				{
 				border-image: url(':/settings.svg')
 				}
@@ -468,14 +468,12 @@ border-image: url(':/groupchat-members-hover.svg')
 				border-image: url(':/settings-hover.svg')
 				}
 				</string>
-				   </property>
-				   <property name="text">
-				    <string/>
-				   </property>
-				  </widget>
-				 </item>
-
-
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>
@@ -556,7 +554,7 @@ border-image: url(':/groupchat-members-hover.svg')
             </property>
            </widget>
            <widget class="QWidget" name="layoutWidget">
-            <layout class="QHBoxLayout" name="typeAndSend" stretch="1,0">
+            <layout class="QHBoxLayout" name="typeAndSend" stretch="0,0,0,0">
              <property name="spacing">
               <number>0</number>
              </property>
@@ -576,13 +574,13 @@ border-image: url(':/groupchat-members-hover.svg')
                </property>
                <property name="minimumSize">
                 <size>
-                 <width>80</width>
+                 <width>40</width>
                  <height>0</height>
                 </size>
                </property>
                <property name="maximumSize">
                 <size>
-                 <width>80</width>
+                 <width>40</width>
                  <height>16777215</height>
                 </size>
                </property>
@@ -607,6 +605,31 @@ border-image: url(':/groupchat-members-hover.svg')
               </widget>
              </item>
              <item>
+              <widget class="QPushButton" name="mGeoLocationBtn">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>40</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>40</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>Loc</string>
+               </property>
+              </widget>
+             </item>
+             <item>
               <widget class="MsgInputBox" name="mMessageEdit">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
@@ -621,13 +644,13 @@ border-image: url(':/groupchat-members-hover.svg')
                 <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.Helvetica Neue DeskInterface'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'.Helvetica Neue DeskInterface'; font-size:13pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
               </widget>
              </item>
              <item>
-              <layout class="QVBoxLayout" name="verticalLayout" stretch="1">
+              <layout class="QVBoxLayout" name="verticalLayout" stretch="0">
                <property name="spacing">
                 <number>0</number>
                </property>

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2157,7 +2157,7 @@ void Chat::requestRichLink(Message &message)
                     return;
                 }
 
-                updateText.insert(updateText.begin(), Message::ContainstMetaSubType::kRichLink);
+                updateText.insert(updateText.begin(), Message::ContainsMetaSubType::kRichLink);
                 updateText.insert(updateText.begin(), Message::kMsgContainsMeta - Message::kMsgOffset);
                 updateText.insert(updateText.begin(), 0x0);
                 std::string::size_type size = updateText.size();

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1921,7 +1921,7 @@ void Chat::requestRichLink(Message &message)
                     return;
                 }
 
-                updateText.insert(updateText.begin(), 0x0);
+                updateText.insert(updateText.begin(), Message::ContainstMetaSubType::kRichLink);
                 updateText.insert(updateText.begin(), Message::kMsgContainsMeta - Message::kMsgOffset);
                 updateText.insert(updateText.begin(), 0x0);
                 std::string::size_type size = updateText.size();

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -655,6 +655,14 @@ public:
                     || type == kMsgContainsMeta)
                 );
     }
+    ContainsMetaSubType containMetaSubtype() const
+    {
+        return (type == kMsgContainsMeta && dataSize() > 2) ? ((ContainsMetaSubType)*(buf()+2)) : ContainsMetaSubType::kInvalid;
+    }
+    std::string containsMetaJson() const
+    {
+        return (type == kMsgContainsMeta && dataSize() > 3) ? std::string(buf()+3, dataSize() - 3) : "";
+    }
 
     /** @brief Convert attachment etc. special messages to text */
     std::string toText() const

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -397,6 +397,13 @@ public:
         kMsgContact           = 0x67,   // Old value  kMsgContact           = 0x12
         kMsgContainsMeta      = 0x68    // Old value  kMsgContainsMeta      = 0x13
     };
+
+    enum ContainstMetaSubType: uint8_t
+    {
+        kRichLink             = 0x00,
+        kGeoLocation          = 0x01
+    };
+
     enum Status
     {
         kSending, //< Message has not been sent or is not yet confirmed by the server

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -406,8 +406,9 @@ public:
         kMsgContainsMeta      = 0x68    // Old value  kMsgContainsMeta      = 0x13
     };
 
-    enum ContainstMetaSubType: uint8_t
+    enum ContainsMetaSubType: uint8_t
     {
+        kInvalid              = 0xff,
         kRichLink             = 0x00,
         kGeoLocation          = 0x01
     };

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -518,6 +518,11 @@ void MegaChatApi::attachNodes(MegaChatHandle chatid, MegaNodeList *nodes, MegaCh
     pImpl->attachNodes(chatid, nodes, listener);
 }
 
+MegaChatMessage * MegaChatApi::sendGeolocation(MegaChatHandle chatid, float longitude, float latitude, const char *img)
+{
+    return pImpl->sendGeolocation(chatid, longitude, latitude, img);
+}
+
 void MegaChatApi::revokeAttachment(MegaChatHandle chatid, MegaChatHandle nodeHandle, MegaChatRequestListener *listener)
 {
     pImpl->revokeAttachment(chatid, nodeHandle, listener);
@@ -1512,12 +1517,42 @@ int MegaChatContainsMeta::getType() const
     return MegaChatContainsMeta::CONTAINS_META_INVALID;
 }
 
+const char *MegaChatContainsMeta::getTextMessage() const
+{
+    return NULL;
+}
+
 const MegaChatRichPreview *MegaChatContainsMeta::getRichPreview() const
 {
     return NULL;
 }
 
+const MegaChatGeolocation *MegaChatContainsMeta::getGeolocation() const
+{
+    return NULL;
+}
+
 const char *MegaChatRichPreview::getDomainName() const
+{
+    return NULL;
+}
+
+MegaChatGeolocation *MegaChatGeolocation::copy() const
+{
+    return NULL;
+}
+
+float MegaChatGeolocation::getLongitude() const
+{
+    return 0;
+}
+
+float MegaChatGeolocation::getLatitude() const
+{
+    return 0;
+}
+
+const char *MegaChatGeolocation::getImage() const
 {
     return NULL;
 }

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -703,6 +703,43 @@ public:
 };
 
 /**
+ * @brief This class store geolocation data
+ *
+ * This class contains the data for geolocation.
+ */
+class MegaChatGeolocation
+{
+public:
+    virtual ~MegaChatGeolocation() {}
+    virtual MegaChatGeolocation *copy() const;
+
+    /**
+      * @brief Returns geolocation longitude
+      *
+      * @return Geolocation logitude value
+      */
+    virtual float getLongitude() const;
+
+    /**
+      * @brief Returns geolocation latitude
+      *
+      * @return Geolocation latitude value
+      */
+    virtual float getLatitude() const;
+
+    /**
+      * @brief Returns preview from shared geolocation
+      *
+      * The MegaChatGeolocation retains the ownership of the returned string. It will
+      * be only valid until the MegaChatGeolocation is deleted.
+      * It can be NULL
+      *
+      * @return Preview from geolocation as a byte array encoded in Base64URL, or NULL if not available.
+      */
+    virtual const char *getImage() const;
+};
+
+/**
  * @brief This class represents meta contained
  *
  * This class includes pointer to differents kind of meta contained, like MegaChatRichPreview.
@@ -716,6 +753,7 @@ public:
     {
       CONTAINS_META_INVALID         = -1,   /// Unknown type of meta contained
       CONTAINS_META_RICH_PREVIEW    = 0,    /// Rich-preview type for meta contained
+      CONTAINS_META_GEOLOCATION     = 1,    /// Geolocation type for meta contained
     };
 
     virtual ~MegaChatContainsMeta() {}
@@ -731,9 +769,25 @@ public:
      *  - MegaChatContainsMeta::CONTAINS_META_RICH_PREVIEW   = 0
      * Meta contained is from rich preview type
      *
+     *  - MegaChatContainsMeta::CONTAINS_META_GEOLOCATION  = 1
+     * Meta contained is from geolocation type
+     *
      * @return Type from meta contained of the message
      */
     virtual int getType() const;
+
+    /**
+     * @brief Returns a string to be shown when app can't parse the meta contained
+     *
+     * This string has to be included in all contains meta messages.
+     * It has to be show when app can't parse that kind of messages.
+     *
+     * The MegaChatContainsMeta retains the ownership of the returned string. It will
+     * be only valid until the MegaChatContainsMeta is deleted.
+     *
+     * @return String to be shown when app can't parse the meta contained
+     */
+    virtual const char *getTextMessage() const;
 
     /**
      * @brief Returns data about rich-links
@@ -748,6 +802,20 @@ public:
      * @return MegaChatRichPreview with details about rich-link.
      */
     virtual const MegaChatRichPreview *getRichPreview() const;
+
+    /**
+     * @brief Returns data about geolocation
+     *
+     * @note This function only returns a valid object in case the function
+     * \c MegaChatContainsMeta::getType returns MegaChatContainsMeta::CONTAINS_META_GEOLOCATION.
+     * Otherwise, it returns NULL.
+     *
+     * The SDK retains the ownership of the returned value. It will be valid until
+     * the MegaChatContainsMeta object is deleted.
+     *
+     * @return MegaChatGeolocation with details about geolocation.
+     */
+    virtual const MegaChatGeolocation *getGeolocation() const;
 };
 
 class MegaChatMessage
@@ -928,10 +996,8 @@ public:
      * The SDK retains the ownership of the returned value. It will be valid until
      * the MegaChatMessage object is deleted.
      *
-     * @note If message is of type MegaChatMessage::TYPE_CONTAINS_META and the type of meta
-     * is MegaChatContainsMeta::CONTAINS_META_RICH_PREVIEW, for convenience this function
-     * will return the original content of the message, the same than
-     * MegaChatRichPreview::getText
+     * @note If message is of type MegaChatMessage::TYPE_CONTAINS_META, for convenience this function
+     * will return the contain of field 'textMessage' in the json
      *
      * @return Content of the message. If message was deleted, it returns NULL.
      */
@@ -3009,6 +3075,31 @@ public:
      * @param listener MegaChatRequestListener to track this request
      */
      void attachNodes(MegaChatHandle chatid, mega::MegaNodeList *nodes, MegaChatRequestListener *listener = NULL);
+
+    /**
+     * @brief Share a geolocation in the specified chatroom
+     *
+     * The MegaChatMessage object returned by this function includes a message transaction id,
+     * That id is not the definitive id, which will be assigned by the server. You can obtain the
+     * temporal id with MegaChatMessage::getTempId()
+     *
+     * When the server confirms the reception of the message, the MegaChatRoomListener::onMessageUpdate
+     * is called, including the definitive id and the new status: MegaChatMessage::STATUS_SERVER_RECEIVED.
+     * At this point, the app should refresh the message identified by the temporal id and move it to
+     * the final position in the history, based on the reported index in the callback.
+     *
+     * If the message is rejected by the server, the message will keep its temporal id and will have its
+     * a message id set to MEGACHAT_INVALID_HANDLE.
+     *
+     * You take the ownership of the returned value.
+     *
+     * @param chatid MegaChatHandle that identifies the chat room
+     * @param longitude from shared geolocation
+     * @param latitude from shared geolocation
+     * @param img Preview as a byte array encoded in Base64URL. It can be NULL
+     * @return MegaChatMessage that will be sent. The message id is not definitive, but temporal.
+     */
+     MegaChatMessage *sendGeolocation(MegaChatHandle chatid, float longitude, float latitude, const char *img = NULL);
 
     /**
      * @brief Revoke the access to a node in the specified chatroom

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -619,6 +619,9 @@ public:
       * be only valid until the MegaChatRichPreview is deleted.
       *
       * @return Text from rich preview
+      *
+      * @deprecated use MegaChatContainsMeta::getTextMessage instead, it contains the same
+      * value. This function will eventually be removed in future versions of MEGAchat.
       */
     virtual const char *getText() const;
 

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -778,10 +778,11 @@ public:
     virtual int getType() const;
 
     /**
-     * @brief Returns a string to be shown when app can't parse the meta contained
+     * @brief Returns a generic message to be shown when app does not support the type of the contained meta
      *
-     * This string has to be included in all contains meta messages.
-     * It has to be show when app can't parse that kind of messages.
+     * This string is always available for all messages of MegaChatMessage::TYPE_CONTAINS_META.
+     * When the app does not support yet the sub-type of contains-meta, this string
+     * can be shown as alternative.
      *
      * The MegaChatContainsMeta retains the ownership of the returned string. It will
      * be only valid until the MegaChatContainsMeta is deleted.
@@ -998,7 +999,7 @@ public:
      * the MegaChatMessage object is deleted.
      *
      * @note If message is of type MegaChatMessage::TYPE_CONTAINS_META, for convenience this function
-     * will return the contain of field 'textMessage' in the json
+     * will return the same content than MegaChatContainsMeta::getTextMessage
      *
      * @return Content of the message. If message was deleted, it returns NULL.
      */
@@ -2973,7 +2974,7 @@ public:
      *
      * The MegaChatMessage object returned by this function includes a message transaction id,
      * That id is not the definitive id, which will be assigned by the server. You can obtain the
-     * temporal id with MegaChatMessage::getTempId()
+     * temporal id with MegaChatMessage::getTempId
      *
      * When the server confirms the reception of the message, the MegaChatRoomListener::onMessageUpdate
      * is called, including the definitive id and the new status: MegaChatMessage::STATUS_SERVER_RECEIVED.
@@ -3002,7 +3003,7 @@ public:
      *
      * The MegaChatMessage object returned by this function includes a message transaction id,
      * That id is not the definitive id, which will be assigned by the server. You can obtain the
-     * temporal id with MegaChatMessage::getTempId()
+     * temporal id with MegaChatMessage::getTempId
      *
      * When the server confirms the reception of the message, the MegaChatRoomListener::onMessageUpdate
      * is called, including the definitive id and the new status: MegaChatMessage::STATUS_SERVER_RECEIVED.
@@ -3025,7 +3026,7 @@ public:
      *
      * The MegaChatMessage object returned by this function includes a message transaction id,
      * That id is not the definitive id, which will be assigned by the server. You can obtain the
-     * temporal id with MegaChatMessage::getTempId()
+     * temporal id with MegaChatMessage::getTempId
      *
      * When the server confirms the reception of the message, the MegaChatRoomListener::onMessageUpdate
      * is called, including the definitive id and the new status: MegaChatMessage::STATUS_SERVER_RECEIVED.
@@ -3082,7 +3083,7 @@ public:
      *
      * The MegaChatMessage object returned by this function includes a message transaction id,
      * That id is not the definitive id, which will be assigned by the server. You can obtain the
-     * temporal id with MegaChatMessage::getTempId()
+     * temporal id with MegaChatMessage::getTempId
      *
      * When the server confirms the reception of the message, the MegaChatRoomListener::onMessageUpdate
      * is called, including the definitive id and the new status: MegaChatMessage::STATUS_SERVER_RECEIVED.

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -2975,16 +2975,15 @@ MegaChatMessage *MegaChatApiImpl::removeRichLink(MegaChatHandle chatid, MegaChat
     {
         Chat &chat = chatroom->chat();
         Message *originalMsg = findMessage(chatid, msgid);
-        if (!originalMsg || originalMsg->type != Message::kMsgContainsMeta || originalMsg->size() < 3)
+        if (!originalMsg || originalMsg->containMetaSubtype() != Message::ContainsMetaSubType::kRichLink)
         {
             sdkMutex.unlock();
             return NULL;
         }
 
-        std::string msgText = originalMsg->toText();
-        uint8_t type = msgText.c_str()[0];
-        const char *jsonBegin = msgText.c_str() + 1;
-        const MegaChatContainsMeta *containsMeta = JSonUtils::parseContainsMeta(jsonBegin, type);
+        uint8_t containsMetaType = originalMsg->containMetaSubtype();
+        std::string containsMetaJson = originalMsg->containsMetaJson();
+        const MegaChatContainsMeta *containsMeta = JSonUtils::parseContainsMeta(containsMetaJson.c_str(), containsMetaType);
         if (!containsMeta || containsMeta->getType() != MegaChatContainsMeta::CONTAINS_META_RICH_PREVIEW)
         {
             delete containsMeta;

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -43,6 +43,7 @@
 #include <logger.h>
 
 #include "net/websocketsIO.h"
+#include <rapidjson/document.h>
 
 #include <stdint.h>
 
@@ -985,6 +986,7 @@ public:
     MegaChatMessage *forwardContact(MegaChatHandle sourceChatid, MegaChatHandle msgid, MegaChatHandle targetChatId);
     void attachNodes(MegaChatHandle chatid, mega::MegaNodeList *nodes, MegaChatRequestListener *listener = NULL);
     void attachNode(MegaChatHandle chatid, MegaChatHandle nodehandle, MegaChatRequestListener *listener = NULL);
+    MegaChatMessage *sendGeolocation(MegaChatHandle chatid, float longitude, float latitude, const char *img = NULL);
     void revokeAttachment(MegaChatHandle chatid, MegaChatHandle handle, MegaChatRequestListener *listener = NULL);
     bool isRevoked(MegaChatHandle chatid, MegaChatHandle nodeHandle);
     MegaChatMessage *editMessage(MegaChatHandle chatid, MegaChatHandle msgid, const char* msg);
@@ -1110,6 +1112,24 @@ protected:
     std::string mDomainName;
 };
 
+class MegaChatGeolocationPrivate : public MegaChatGeolocation
+{
+public:
+    MegaChatGeolocationPrivate(float longitude, float latitude, const std::string &image);
+    MegaChatGeolocationPrivate(const MegaChatGeolocationPrivate *geolocation);
+    virtual ~MegaChatGeolocationPrivate() {}
+    virtual MegaChatGeolocation *copy() const;
+
+    virtual float getLongitude() const;
+    virtual float getLatitude() const;
+    virtual const char *getImage() const;
+
+protected:
+    float mLongitude;
+    float mLatitude;
+    std::string mImage;
+};
+
 class MegaChatContainsMetaPrivate : public MegaChatContainsMeta
 {
 public:
@@ -1119,14 +1139,20 @@ public:
     virtual MegaChatContainsMeta *copy() const;
 
     virtual int getType() const;
+    virtual const char *getTextMessage() const;
     virtual const MegaChatRichPreview *getRichPreview() const;
+    virtual const MegaChatGeolocation *getGeolocation() const;
 
     // This function take the property from memory that it receives as parameter
     void setRichPreview(MegaChatRichPreview *richPreview);
+    void setGeolocation(MegaChatGeolocation *geolocation);
+    void setTextMessage(const std::string &text);
 
 protected:
     int mType = MegaChatContainsMeta::CONTAINS_META_INVALID;
+    std::string mText;
     MegaChatRichPreview *mRichPreview = NULL;
+    MegaChatGeolocation *mGeolocation = NULL;
 };
 
 class DataTranslation
@@ -1169,8 +1195,9 @@ public:
      * by ASCII character '0x01'
      */
     static std::string getLastMessageContent(const std::string &content, uint8_t type);
-    static const MegaChatContainsMeta *parseContainsMeta(const char* json);
-    static MegaChatRichPreview *parseRichPreview(const char* json);
+    static const MegaChatContainsMeta *parseContainsMeta(const char* json, uint8_t type);
+    static MegaChatRichPreview *parseRichPreview(rapidjson::Document &document);
+    static MegaChatGeolocation *parseGeolocation(rapidjson::Document &document);
 
 private:
     static std::string getImageFormat(const char* imagen);

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -1225,8 +1225,8 @@ public:
      * by ASCII character '0x01'
      */
     static std::string getLastMessageContent(const std::string &content, uint8_t type);
-    static const MegaChatContainsMeta *parseContainsMeta(const char* json, uint8_t type);
-    static MegaChatRichPreview *parseRichPreview(rapidjson::Document &document);
+    static const MegaChatContainsMeta *parseContainsMeta(const char* json, uint8_t type, bool onlyTextMessage = false);
+    static MegaChatRichPreview *parseRichPreview(rapidjson::Document &document, std::string &textMessage);
     static MegaChatGeolocation *parseGeolocation(rapidjson::Document &document);
 
 private:


### PR DESCRIPTION
Geolocation is sent as contains meta sub type. The structure of the message is:
<0><kMsgContainsMeta><ContainstMetaSubType::kGeoLocation>{"textMessage":"www.maps.google.com/api=1?query:....","extra":[{"la":"...","lng":"...","img":"B64url encoded image"}]}
`textMessage` field at json will be mandatory for all contains meta subtype