### PR TITLE
Close other sessions at Test's setup

### DIFF
--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -277,6 +277,12 @@ void MegaChatApiTest::SetUp()
         megaChatApi[i]->addChatCallListener(this);
 #endif
 
+        login(i);
+        bool *flagRequest = &requestFlags[i][MegaRequest::TYPE_KILL_SESSION]; *flagRequest = false;
+        megaApi[i]->killSession(INVALID_HANDLE);
+        waitForResponse(flagRequest);
+        logout(i);
+
         for (int j = 0; j < mega::MegaRequest::TOTAL_OF_REQUEST_TYPES; ++j)
         {
             requestFlags[i][j] = false;


### PR DESCRIPTION
In order to avoid interferences with other existing sessions running at
the same time, we enforce no more sessions are valid at the time the
tests start