### PR TITLE
Skip rejoin if already joining

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2651,7 +2651,15 @@ bool GroupChatRoom::syncWithApi(const mega::MegaTextChat& chat)
                 if (parent.mKarereClient.connected())
                 {
                     KR_LOG_DEBUG("Connecting existing room to chatd after re-join...");
-                    mChat->connect();
+                    if (mChat->onlineState() != ::chatd::ChatState::kChatStateJoining)
+                    {
+                        mChat->connect();
+                    }
+                    else
+                    {
+                        KR_LOG_DEBUG("Skip re-join chatd, since it's already joining right now");
+                        parent.mKarereClient.api.callIgnoreResult(&::mega::MegaApi::sendEvent, 99003, "Skip re-join chatd");
+                    }
                 }
                 KR_LOG_DEBUG("Chatroom[%s]: API event: We were reinvited",  Id(mChatid).toString().c_str());
                 notifyRejoinedChat();


### PR DESCRIPTION
Automated tests failed due to joins/logins into chatd in parellel for
the same chat. In result, the same message can be received as NEWMSG and
OLDMSG, which should never happen.