### PR TITLE
Fix SESSION_STATUS_INITIAL not being reported

### DIFF
--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -6983,6 +6983,7 @@ void MegaChatSessionHandler::onSessStateChange(uint8_t newState)
     {
         case rtcModule::ISession::kStateWaitSdpOffer:
         case rtcModule::ISession::kStateWaitSdpAnswer:
+        case rtcModule::ISession::kStateWaitLocalSdpAnswer:
         {
             MegaChatCallPrivate* chatCall = callHandler->getMegaChatCall();
             megaChatSession->setState(newState);


### PR DESCRIPTION
Added state kStateWaitLocalSdpAnswer in MegaChatSessionHandler::onSessStateChange(uint8_t newState) to fix initial state not being reported to iOS layer