### PR TITLE
Fix presence autoaway

### DIFF
--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -160,11 +160,9 @@ bool Client::autoAwayInEffect()
 {
     return mConfig.mPresence.isValid()    // don't want to change to away from default status
             && !mConfig.mPersist
-            && mConfig.mPresence != Presence::kOffline
-            && mConfig.mPresence != Presence::kAway
+            && mConfig.mPresence == Presence::kOnline
             && mConfig.mAutoawayTimeout
-            && mConfig.mAutoawayActive
-            && !karereClient->isCallInProgress();
+            && mConfig.mAutoawayActive;
 }
 
 void Client::signalActivity(bool force)
@@ -396,7 +394,7 @@ void Client::heartbeat()
         return;
 
     auto now = time(NULL);
-    if (autoAwayInEffect())
+    if (autoAwayInEffect() && !karereClient->isCallInProgress())
     {
         if (now - mTsLastUserActivity > mConfig.mAutoawayTimeout)
         {


### PR DESCRIPTION
When the app checks if it should signal presence activity (to avoid
becoming automatically away), we had a bug if the client was in a call.