### PR TITLE
Fix presenced::onSocketClose()

### DIFF
--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -76,7 +76,7 @@ void Client::onSocketClose(int errcode, int errtype, const std::string& reason)
     usingipv6 = !usingipv6;
     mTargetIp.clear();
 
-    if (oldState == kConnected)
+    if (oldState >= kConnected)
     {
         PRESENCED_LOG_DEBUG("Socket close at state kLoggedIn");
 


### PR DESCRIPTION
The higher state of the connection-state is `kLoggedIn`. If the socket
is closed at that state, the `assert(mRetryCtrl)` a few lines below (in
the `else` block) will systematically fail, since the RetryController is
deleted as soon as the connection reaches the state `kConnected`.