### PR TITLE
WIP: #13492. Store url and dns in local cache

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -487,6 +487,19 @@ void Client::loadContactListFromApi()
     loadContactListFromApi(*contacts);
 }
 
+void Client::loadDnsCacheFromDb()
+{
+    SqliteStmt stmt(db, "select * from dns_cache");
+
+    while (stmt.step())
+        websocketIO->mDnsCache.set(stmt.stringCol(0), stmt.stringCol(1), stmt.stringCol(2));
+}
+
+void Client::saveDnsCacheToDb(const std::string& host, const std::string& ipv4, const std::string& ipv6)
+{
+    db.query("insert or replace into dns_cache(host, ipv4, ipv6) values(?,?,?)", host, ipv4, ipv6);
+}
+
 void Client::loadContactListFromApi(::mega::MegaUserList& contacts)
 {
 #ifndef NDEBUG
@@ -631,6 +644,7 @@ void Client::initWithDbSession(const char* sid)
         });
 
         loadOwnKeysFromDb();
+        loadDnsCacheFromDb();
         contactList->loadFromDb();
         mContactsLoaded = true;
         mChatdClient.reset(new chatd::Client(this));

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -854,6 +854,7 @@ public:
 
     void dumpChatrooms(::mega::MegaTextChatList& chatRooms);
     void dumpContactList(::mega::MegaUserList& clist);
+    void saveDnsCacheToDb(const std::string& host, const std::string& ipv4, const std::string& ipv6);
 
     bool isChatRoomOpened(Id chatid);
 
@@ -878,6 +879,7 @@ protected:
     void loadOwnKeysFromDb();
     void loadContactListFromApi();
     void loadContactListFromApi(::mega::MegaUserList& contactList);
+    void loadDnsCacheFromDb();
 
     strongvelope::ProtocolHandler* newStrongvelope(karere::Id chatid);
 

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -221,7 +221,8 @@ protected:
     friend class ChatRoomList;
     PeerChatRoom(ChatRoomList& parent, const uint64_t& chatid,
             unsigned char shard, chatd::Priv ownPriv, const uint64_t& peer,
-            chatd::Priv peerPriv, uint32_t ts, bool aIsArchived);
+            chatd::Priv peerPriv, uint32_t ts, bool aIsArchived,
+            const std::string& url);
     PeerChatRoom(ChatRoomList& parent, const mega::MegaTextChat& room);
     ~PeerChatRoom();
 
@@ -335,7 +336,7 @@ public:
     GroupChatRoom(ChatRoomList& parent, const mega::MegaTextChat& chat);
     GroupChatRoom(ChatRoomList& parent, const uint64_t& chatid,
                   unsigned char aShard, chatd::Priv aOwnPriv, uint32_t ts,
-                  bool aIsArchived, const std::string& title);
+                  bool aIsArchived, const std::string& title, const std::string& url);
     ~GroupChatRoom();
 public:
 //chatd::Listener

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -454,6 +454,8 @@ public:
 
     int shardNo() const;
     promise::Promise<void> sendSync();
+
+    bool updateDnsCache(const std::vector<std::string>& ipsv4, const std::vector<std::string>& ipsv6);
 };
 
 enum ServerHistFetchState

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -370,7 +370,7 @@ public:
     };
 
 protected:
-    Connection(Client& chatdClient, int shardNo);
+    Connection(Client& chatdClient, int shardNo, const std::string& url);
 
     Client& mChatdClient;
 
@@ -455,6 +455,9 @@ public:
     int shardNo() const;
     promise::Promise<void> sendSync();
 
+    promise::Promise<void> connect();
+    promise::Promise<void> fetchUrl();
+    void setUrl(const std::string& url);
     bool updateDnsCache(const std::vector<std::string>& ipsv4, const std::vector<std::string>& ipsv6);
 };
 
@@ -1353,6 +1356,8 @@ public:
 
     // True if clients send confirmation to chatd when they receive a new message
     bool isMessageReceivedConfirmationActive() const;
+
+    std::string getUrlByShard(int shardNo) const;
 
     friend class Connection;
     friend class Chat;

--- a/src/dbSchema.sql
+++ b/src/dbSchema.sql
@@ -38,3 +38,4 @@ CREATE TABLE node_history(idx int not null, chatid int64 not null, msgid int64 n
     userid int64, keyid int not null, type tinyint, updated smallint, ts int,
     is_encrypted tinyint, data blob, backrefid int64 not null, UNIQUE(chatid,msgid), UNIQUE(chatid,idx));
 
+CREATE TABLE dns_cache(host text primary key, ipv4 text, ipv6 text);

--- a/src/dbSchema.sql
+++ b/src/dbSchema.sql
@@ -12,7 +12,8 @@ CREATE TABLE vars(name text not null primary key, value blob);
 CREATE TABLE chats(chatid int64 unique primary key, shard tinyint,
     own_priv tinyint, peer int64 default -1, peer_priv tinyint default 0,
     title text, ts_created int64 not null default 0,
-    last_seen int64 default 0, last_recv int64 default 0, archived tinyint);
+    last_seen int64 default 0, last_recv int64 default 0, archived tinyint,
+    url text);
 
 CREATE TABLE contacts(userid int64 PRIMARY KEY, email text, visibility int,
     since int64 not null default 0);

--- a/src/net/websocketsIO.cpp
+++ b/src/net/websocketsIO.cpp
@@ -179,6 +179,21 @@ void WebsocketsClient::wsCloseCbPrivate(int errcode, int errtype, const char *pr
     wsCloseCb(errcode, errtype, preason, reason_len);
 }
 
+const DNScache::DNSrecord* DNScache::set(const std::string &url, const std::vector<std::string> &ipsv4, const std::vector<std::string> &ipsv6)
+{
+    if (!isMatch(url, ipsv4, ipsv6))
+    {
+        DNSrecord record;
+        record.ipv4 = ipsv4.empty() ? "" : ipsv4.front();
+        record.ipv6 = ipsv6.empty() ? "" : ipsv6.front();
+        record.resolveTs = time(NULL);
+
+        return &(mRecords[url] = record);
+    }
+
+    return nullptr;
+}
+
 bool DNScache::set(const std::string &url, const std::string &ipv4, const std::string &ipv6)
 {
     if (!isMatch(url, ipv4, ipv6))

--- a/src/net/websocketsIO.h
+++ b/src/net/websocketsIO.h
@@ -20,17 +20,7 @@ class WebsocketsClientImpl;
 class DNScache
 {
 public:
-    DNScache() {}
-    // returns false if ipv4 and ipv6 for the given url already match the ones in cache, true if not (so they are updated)
-    bool set(const std::string &url, const std::string &ipv4, const std::string &ipv6);
-    void clear(const std::string &url);
-    // returns true if hit in cache, false if there's no record for the given url
-    bool get(const std::string &url, std::string &ipv4, std::string &ipv6);
-    void connectDone(const std::string &url, const std::string &ip);
-    time_t age(const std::string &url);
-    bool isMatch(const std::string &url, const std::vector<std::string> &ipsv4, const std::vector<std::string> &ipsv6);
-    bool isMatch(const std::string &url, const std::string &ipv4, const std::string &ipv6);
-private:
+
     struct DNSrecord
     {
         std::string ipv4;
@@ -39,6 +29,19 @@ private:
         time_t connectIpv4Ts = 0;   // can be used for heuristics based on last successful connection
         time_t connectIpv6Ts = 0;   // can be used for heuristics based on last successful connection
     };
+
+    DNScache() {}
+    // returns false if ipv4 and ipv6 for the given url already match the ones in cache, true if not (so they are updated)
+    bool set(const std::string &url, const std::string &ipv4, const std::string &ipv6);
+    const DNSrecord* set(const std::string &url, const std::vector<std::string> &ipsv4, const std::vector<std::string> &ipsv6);
+    void clear(const std::string &url);
+    // returns true if hit in cache, false if there's no record for the given url
+    bool get(const std::string &url, std::string &ipv4, std::string &ipv6);
+    void connectDone(const std::string &url, const std::string &ip);
+    time_t age(const std::string &url);
+    bool isMatch(const std::string &url, const std::vector<std::string> &ipsv4, const std::vector<std::string> &ipsv6);
+    bool isMatch(const std::string &url, const std::string &ipv4, const std::string &ipv6);
+private:
 
     std::map<std::string, DNSrecord> mRecords;
 };

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -64,6 +64,7 @@ void Url::parse(const std::string& url)
     }
     if (host.empty())
         throw std::runtime_error("Url::parse: Invalid URL '"+url+"', host is empty");
+    originUrl = url;
 }
 
 uint16_t Url::getPortFromProtocol() const

--- a/src/url.h
+++ b/src/url.h
@@ -10,6 +10,7 @@ class Url
 protected:
     uint16_t getPortFromProtocol() const;
 public:
+    std::string originUrl;
     std::string protocol;
     std::string host;
     uint16_t port;


### PR DESCRIPTION
This prerequisite steps for the fast chat connection login in case of incoming call. Basically, we need to persist both URLs and DNS to save latency.