### PR TITLE
Fix QtApp reorder when we are connected to all chats

### DIFF
--- a/examples/qtmegachatapi/MainWindow.cpp
+++ b/examples/qtmegachatapi/MainWindow.cpp
@@ -707,9 +707,6 @@ void MainWindow::onChatConnectionStateUpdate(MegaChatApi *, MegaChatHandle chati
         // we skip all reorders until we receive this event to avoid app overload
         allowOrder = true;
 
-        //Update chatListItems in chatControllers
-        updateChatControllersItems();
-
         //Reorder chat list in QtApp
         reorderAppChatList();
 


### PR DESCRIPTION
- Remove chatlist cleanup upon onChatConnectionStateUpdate when we are
connected to all chats. If we clean the chat list the reorder will be
slower, and if any chat window is open it will be closed.