### PR TITLE
Skip notification for archived chats, add for inactive ones

### DIFF
--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -980,8 +980,8 @@ void MegaChatApiImpl::sendPendingRequests()
                     // for each chatroom, load all unread messages)
                     for (auto it = mClient->chats->begin(); it != mClient->chats->end(); it++)
                     {
-                        // remove this block when apps start showing inactive chats
-                        if (!it->second->isActive())
+                        // don't want to generate notifications for archived chats
+                        if (it->second->isArchived())
                             continue;
 
                         MegaHandleList *msgids = MegaHandleList::createInstance();


### PR DESCRIPTION
Messages from archived chats should not generate notifications.
However, inactive chats (where the user does not participate any more)
should be taken into account.