### PR TITLE
Fix update of unread-count upon deletion

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3419,7 +3419,7 @@ void Chat::onMsgUpdated(Message* cipherMsg)
 
             if (msg->isDeleted())
             {
-                if (msg->isOwnMessage(client().myHandle()))
+                if (!msg->isOwnMessage(client().myHandle()))
                 {
                     CALL_LISTENER(onUnreadChanged);
                 }


### PR DESCRIPTION
Deleted messages may update the unread count, but only if the message is
edited by other than own user.