### PR TITLE
Drive peerlist for presenced only from API

### DIFF
--- a/examples/qtmegachatapi/MainWindow.cpp
+++ b/examples/qtmegachatapi/MainWindow.cpp
@@ -709,13 +709,6 @@ void MainWindow::onChatConnectionStateUpdate(MegaChatApi *, MegaChatHandle chati
 
         //Reorder chat list in QtApp
         reorderAppChatList();
-
-        megachat::MegaChatPresenceConfig *presenceConfig = mMegaChatApi->getPresenceConfig();
-        if (presenceConfig)
-        {
-            onChatPresenceConfigUpdate(mMegaChatApi, presenceConfig);
-        }
-        delete presenceConfig;
         return;
     }
 
@@ -784,7 +777,7 @@ void MainWindow::onChatOnlineStatusUpdate(MegaChatApi *, MegaChatHandle userhand
         status = 0;
     }
 
-    if (this->mMegaChatApi->getMyUserHandle() == userhandle && !inProgress)
+    if (mMegaChatApi->getMyUserHandle() == userhandle && !inProgress)
     {
         ui->bOnlineStatus->setText(kOnlineSymbol_Set);
         if (status >= 0 && status < NINDCOLORS)

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2005,7 +2005,9 @@ void Client::onChatsUpdate(::mega::MegaApi*, ::mega::MegaTextChatList* rooms)
 {
     if (!rooms)
     {
-        KR_LOG_DEBUG("Chatrooms up to date with API. scsn: %s", api.sdk.getSequenceNumber());
+        const char *scsn = api.sdk.getSequenceNumber();
+        KR_LOG_DEBUG("Chatrooms up to date with API. scsn: %s", scsn);
+        delete [] scsn;
         return;
     }
 

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -3830,11 +3830,6 @@ void MegaChatApiImpl::removeGroupChatItem(IGroupChatListItem &item)
         IGroupChatListItem *itemHandler = (*it);
         if (itemHandler == &item)
         {
-//            TODO: Redmine ticket #5693
-//            MegaChatListItemPrivate *listItem = new MegaChatListItemPrivate((*it)->getChatRoom());
-//            listItem->setClosed();
-//            fireOnChatListItemUpdate(listItem);
-
             delete (itemHandler);
             chatGroupListItemHandler.erase(it);
             return;
@@ -3852,11 +3847,6 @@ void MegaChatApiImpl::removePeerChatItem(IPeerChatListItem &item)
         IPeerChatListItem *itemHandler = (*it);
         if (itemHandler == &item)
         {
-//            TODO: Redmine ticket #5693
-//            MegaChatListItemPrivate *listItem = new MegaChatListItemPrivate((*it)->getChatRoom());
-//            listItem->setClosed();
-//            fireOnChatListItemUpdate(listItem);
-
             delete (itemHandler);
             chatPeerListItemHandler.erase(it);
             return;

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -187,19 +187,25 @@ bool Client::setAutoaway(bool enable, time_t timeout)
 
 bool Client::autoAwayInEffect()
 {
-    return mConfig.mPresence.isValid() && mConfig.mAutoawayActive;
+    return mConfig.mPresence.isValid() && mConfig.mAutoawayActive && mConfig.mPresence == Presence::kOnline;
 }
 
 void Client::signalActivity()
 {
-    if (!mConfig.mPresence.isValid())
+    if (!autoAwayInEffect())
     {
-        PRESENCED_LOG_DEBUG("signalActivity(): the current configuration is yet received, cannot be changed");
-        return;
-    }
-    if (!mConfig.mAutoawayActive)
-    {
-        PRESENCED_LOG_WARNING("signalActivity(): autoaway is disabled, no need to signal user's activity");
+        if (!mConfig.mPresence.isValid())
+        {
+            PRESENCED_LOG_DEBUG("signalActivity(): the current configuration is not yet received, cannot be changed");
+        }
+        else if (!mConfig.mAutoawayActive)
+        {
+            PRESENCED_LOG_WARNING("signalActivity(): autoaway is disabled, no need to signal user's activity");
+        }
+        else if (mConfig.mPresence != Presence::kOnline)
+        {
+            PRESENCED_LOG_WARNING("signalActivity(): configured status is not online, autoaway shouldn't be used");
+        }
         return;
     }
 

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -533,11 +533,16 @@ void Client::onUsersUpdate(mega::MegaApi *api, mega::MegaUserList *usersUpdated)
             uint64_t userid = user->getHandle();
             int newVisibility = user->getVisibility();
 
+            if (userid == mKarereClient->myHandle())
+            {
+                continue;
+            }
+
             auto it = mContacts.find(userid);
             if (it == mContacts.end())  // new contact
             {
                 addPeer(userid);
-                assert(newVisibility != ::mega::MegaUser::VISIBILITY_VISIBLE);
+                assert(newVisibility == ::mega::MegaUser::VISIBILITY_VISIBLE);
                 mContacts[userid] = newVisibility;
             }
             else    // existing (ex)contact

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -30,13 +30,14 @@ namespace presenced
 Client::Client(MyMegaApi *api, karere::Client *client, Listener& listener, uint8_t caps)
 : mApi(api), mKarereClient(client), mListener(&listener), mCapabilities(caps),
   mDNScache(mKarereClient->websocketIO->mDnsCache)
-{}
+{
+    mApi->sdk.addGlobalListener(this);
+}
 
 ::promise::Promise<void>
-Client::connect(const std::string& url, IdRefMap&& currentPeers, const Config& config)
+Client::connect(const std::string& url, const Config& config)
 {
     mConfig = config;
-    mCurrentPeers = std::move(currentPeers);
     mUrl.parse(url);
 
     if (mConnState == kConnNew)
@@ -52,14 +53,24 @@ Client::connect(const std::string& url, IdRefMap&& currentPeers, const Config& c
 
 void Client::pushPeers()
 {
-    std::vector<karere::Id> peers;
-
-    for (auto& peer: mCurrentPeers)
+    if (!mLastScsn.isValid())
     {
-        peers.push_back(peer.first);
+        PRESENCED_LOG_WARNING("pushPeers: still not catch-up with API");
+        return;
     }
 
-    updatePeers(peers, OP_SNSETPEERS);
+    size_t numPeers = mCurrentPeers.size();
+    size_t totalSize = sizeof(uint64_t) + sizeof(uint32_t) + sizeof(uint64_t) * numPeers;
+
+    Command cmd(OP_SNSETPEERS, totalSize);
+    cmd.append<uint64_t>(mLastScsn.val);
+    cmd.append<uint32_t>(numPeers);
+    for (auto it = mCurrentPeers.begin(); it != mCurrentPeers.end(); it++)
+    {
+        cmd.append<uint64_t>(it->first);
+    }
+
+    sendCommand(std::move(cmd));
 }
 
 void Client::wsConnectCb()
@@ -384,32 +395,245 @@ bool Client::sendKeepalive(time_t now)
     return sendCommand(Command(OP_KEEPALIVE));
 }
 
-void Client::updatePeers(const vector<Id> &peers, uint8_t command)
+bool Client::isExContact(uint64_t userid)
 {
-    assert(command == OP_SNADDPEERS || command == OP_SNDELPEERS || command == OP_SNSETPEERS);
-
-    if ((command == OP_SNADDPEERS || command == OP_SNDELPEERS) && peers.empty())
+    auto it = mContacts.find(userid);
+    if (it == mContacts.end() || (it != mContacts.end() && it->second != mega::MegaUser::VISIBILITY_HIDDEN))
     {
-        PRESENCED_LOG_DEBUG("updatePeers: no peers to update the list");
+        return false;
+    }
+
+    return true;
+}
+
+void Client::onChatsUpdate(mega::MegaApi *api, mega::MegaTextChatList *roomsUpdated)
+{
+    const char *buf = api->getSequenceNumber();
+    Id scsn(buf, strlen(buf));
+    delete [] buf;
+
+    if (!roomsUpdated)
+    {
+        PRESENCED_LOG_DEBUG("Chatroom list up to date. scsn: %s", scsn.toString().c_str());
         return;
     }
 
-    assert(peers.size());
-    const char *buf = mApi->sdk.getSequenceNumber();
+    std::shared_ptr<::mega::MegaTextChatList> rooms(roomsUpdated->copy());
+    auto wptr = weakHandle();
+    marshallCall([wptr, this, rooms, scsn]()
+    {
+        if (wptr.deleted())
+        {
+            return;
+        }
+
+        if (!mLastScsn.isValid())
+        {
+            PRESENCED_LOG_DEBUG("onChatsUpdate: still catching-up with actionpackets");
+            return;
+        }
+
+        mLastScsn = scsn;
+
+        for (int i = 0; i < rooms->size(); i++)
+        {
+            const ::mega::MegaTextChat *room = rooms->get(i);
+            uint64_t chatid = room->getHandle();
+            const ::mega::MegaTextChatPeerList *peerList = room->getPeerList();
+
+            auto it = mChatMembers.find(chatid);
+            if (it == mChatMembers.end())  // new room
+            {
+                if (!peerList)
+                {
+                    continue;   // no peers in this chatroom
+                }
+
+                for (int j = 0; j < peerList->size(); j++)
+                {
+                    uint64_t userid = peerList->getPeerHandle(j);
+                    if (!isExContact(userid))
+                    {
+                        addPeer(userid);
+                        mChatMembers[chatid].insert(userid);
+                    }
+                }
+            }
+            else    // existing room
+            {
+                SetOfIds oldPeerList = mChatMembers[chatid];
+                SetOfIds newPeerList;
+                if (peerList)
+                {
+                    for (int j = 0; j < peerList->size(); j++)
+                    {
+                        newPeerList.insert(peerList->getPeerHandle(j));
+                    }
+                }
+
+                // check for removals
+                for (auto oldIt = oldPeerList.begin(); oldIt != oldPeerList.end(); oldIt++)
+                {
+                    uint64_t userid = *oldIt;
+                    if (!newPeerList.has(userid))
+                    {
+                        removePeer(userid);
+                        mChatMembers[chatid].erase(userid);
+                    }
+                }
+
+                // check for additions
+                for (auto newIt = newPeerList.begin(); newIt != newPeerList.end(); newIt++)
+                {
+                    uint64_t userid = *newIt;
+                    if (!isExContact(userid) && !oldPeerList.has(userid))
+                    {
+                        addPeer(userid);
+                        mChatMembers[chatid].insert(userid);
+                    }
+                }
+            }
+        }
+
+    }, mKarereClient->appCtx);
+}
+
+void Client::onUsersUpdate(mega::MegaApi *api, mega::MegaUserList *usersUpdated)
+{
+    const char *buf = api->getSequenceNumber();
     Id scsn(buf, strlen(buf));
     delete [] buf;
-    size_t numPeers = peers.size();
-    size_t totalSize = sizeof(uint64_t) + sizeof(uint32_t) + sizeof(uint64_t) * numPeers;
 
-    Command cmd(command, totalSize);
-    cmd.append<uint64_t>(scsn.val);
-    cmd.append<uint32_t>(numPeers);
-    for (unsigned int i = 0; i < numPeers; i++)
+    if (!usersUpdated)
     {
-        cmd.append<uint64_t>(peers[i].val);
+        PRESENCED_LOG_DEBUG("User list up to date. scsn: %s", scsn.toString().c_str());
+        return;
     }
 
-    sendCommand(std::move(cmd));
+    std::shared_ptr<::mega::MegaUserList> users(usersUpdated->copy());
+    auto wptr = weakHandle();
+    marshallCall([wptr, this, users, scsn]()
+    {
+        if (wptr.deleted())
+        {
+            return;
+        }
+
+        if (!mLastScsn.isValid())
+        {
+            PRESENCED_LOG_DEBUG("onUsersUpdate: still catching-up with actionpackets");
+            return;
+        }
+
+        mLastScsn = scsn;
+
+        for (int i = 0; i < users->size(); i++)
+        {
+            ::mega::MegaUser *user = users->get(i);
+            uint64_t userid = user->getHandle();
+            int newVisibility = user->getVisibility();
+
+            auto it = mContacts.find(userid);
+            if (it == mContacts.end())  // new contact
+            {
+                addPeer(userid);
+                assert(newVisibility != ::mega::MegaUser::VISIBILITY_VISIBLE);
+                mContacts[userid] = newVisibility;
+            }
+            else    // existing (ex)contact
+            {
+                int oldVisibility = it->second;
+                it->second = newVisibility;
+
+                if (newVisibility == ::mega::MegaUser::VISIBILITY_INACTIVE) // user cancelled the account
+                {
+                    removePeer(userid, true);
+                    mContacts.erase(it);
+                }
+                else if (oldVisibility == ::mega::MegaUser::VISIBILITY_VISIBLE && newVisibility == ::mega::MegaUser::VISIBILITY_HIDDEN)
+                {
+                    removePeer(userid, true);
+                }
+                else if (oldVisibility == ::mega::MegaUser::VISIBILITY_HIDDEN && newVisibility == ::mega::MegaUser::VISIBILITY_VISIBLE)
+                {
+                    addPeer(userid);
+                }
+            }
+        }
+
+    }, mKarereClient->appCtx);
+}
+
+void Client::onEvent(mega::MegaApi *api, mega::MegaEvent *event)
+{
+    if (event->getType() == ::mega::MegaEvent::EVENT_NODES_CURRENT)
+    {
+        // Prepare list of peers to subscribe to its presence now, when catch-up phase is completed
+        std::shared_ptr<::mega::MegaUserList> contacts(api->getContacts());
+        std::shared_ptr<::mega::MegaTextChatList> chats(api->getChatList());
+        const char *buf = api->getSequenceNumber();
+        Id scsn(buf, strlen(buf));
+        delete [] buf;
+
+        auto wptr = weakHandle();
+        marshallCall([wptr, this, contacts, chats, scsn]()
+        {
+            if (wptr.deleted())
+            {
+                return;
+            }
+
+            assert(!mLastScsn.isValid());
+            assert(mCurrentPeers.empty());
+            assert(mContacts.empty());
+            assert(mChatMembers.empty());
+
+            mLastScsn = scsn;
+            mCurrentPeers.clear();
+            mContacts.clear();
+            mChatMembers.clear();
+
+            // initialize the list of contacts
+            for (int i = 0; i < contacts->size(); i++)
+            {
+                ::mega::MegaUser *user = contacts->get(i);
+                uint64_t userid = user->getHandle();
+                int visibility = user->getVisibility();
+
+                mContacts[userid] = visibility; // add ex-contacts to identify them
+                if (visibility == ::mega::MegaUser::VISIBILITY_VISIBLE)
+                {
+                    mCurrentPeers.insert(userid);
+                }
+            }
+
+            // initialize chatroom's peers
+            for (int i = 0; i < chats->size(); i++)
+            {
+                const ::mega::MegaTextChat *chat = chats->get(i);
+                uint64_t chatid = chat->getHandle();
+                const ::mega::MegaTextChatPeerList *peerlist = chat->getPeerList();
+                if (!peerlist)
+                {
+                    continue;   // no peers in this chatroom
+                }
+
+                for (int j = 0; j < peerlist->size(); j++)
+                {
+                    uint64_t userid = peerlist->getPeerHandle(j);
+                    if (!isExContact(userid))
+                    {
+                        mCurrentPeers.insert(userid);
+                        mChatMembers[chatid].insert(userid);
+                    }
+                }
+            }
+
+            // finally send to presenced the initial set of peers
+            pushPeers();
+
+        }, mKarereClient->appCtx);
+    }
 }
 
 void Client::heartbeat()
@@ -710,8 +934,11 @@ void Client::login()
         sendPrefs();
     }
 
-    // send the list of peers allowed to see the own presence's status
-    pushPeers();
+    if (mLastScsn.isValid())
+    {
+        // send the list of peers allowed to see the own presence's status
+        pushPeers();
+    }
 }
 
 bool Client::sendUserActive(bool active, bool force)
@@ -774,6 +1001,8 @@ uint16_t Config::toCode() const
 
 Client::~Client()
 {
+    mApi->sdk.removeGlobalListener(this);
+
     disconnect();
     CALL_LISTENER(onDestroy); //we don't delete because it may have its own idea of its lifetime (i.e. it could be a GUI class)
 }
@@ -974,26 +1203,37 @@ void Client::setConnState(ConnState newState)
 }
 void Client::addPeer(karere::Id peer)
 {
+    assert(mLastScsn.isValid());
+
     int result = mCurrentPeers.insert(peer);
     if (result == 1) //refcount = 1, wasnt there before
     {
-        std::vector<karere::Id> peers;
-        peers.push_back(peer);
-        updatePeers(peers, OP_SNADDPEERS);
+        size_t totalSize = sizeof(uint64_t) + sizeof(uint32_t) + sizeof(uint64_t);
+
+        Command cmd(OP_SNADDPEERS, totalSize);
+        cmd.append<uint64_t>(mLastScsn.val);
+        cmd.append<uint32_t>(1);
+        cmd.append<uint64_t>(peer.val);
+
+        sendCommand(std::move(cmd));
     }
 }
+
 void Client::removePeer(karere::Id peer, bool force)
 {
+    assert(mLastScsn.isValid());
+
     auto it = mCurrentPeers.find(peer);
     if (it == mCurrentPeers.end())
     {
-        PRESENCED_LOG_DEBUG("removePeer: Unknown peer %s", peer.toString().c_str());
+        PRESENCED_LOG_WARNING("removePeer: Unknown peer %s", peer.toString().c_str());
         return;
     }
     if (--it->second > 0)
     {
         if (!force)
         {
+            PRESENCED_LOG_DEBUG("removePeer: decremented number of references for peer %s", peer.toString().c_str());
             return;
         }
         else
@@ -1007,8 +1247,14 @@ void Client::removePeer(karere::Id peer, bool force)
     }
 
     mCurrentPeers.erase(it);
-    std::vector<karere::Id> peers;
-    peers.push_back(peer);
-    updatePeers(peers, OP_SNDELPEERS);
+
+    size_t totalSize = sizeof(uint64_t) + sizeof(uint32_t) + sizeof(uint64_t);
+
+    Command cmd(OP_SNDELPEERS, totalSize);
+    cmd.append<uint64_t>(mLastScsn.val);
+    cmd.append<uint32_t>(1);
+    cmd.append<uint64_t>(peer.val);
+
+    sendCommand(std::move(cmd));
 }
 }

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -386,9 +386,7 @@ protected:
      * (currently, it includes contacts and any user in our groupchats, except ex-contacts) */
     IdRefMap mCurrentPeers;
 
-    /** Map of chatids (key) and the list of peers (value) in every chat (updated only from API)
-     * @note: peers who are ex-contacts are not included
-     */
+    /** Map of chatids (key) and the list of peers (value) in every chat (updated only from API) */
     std::map<uint64_t, karere::SetOfIds> mChatMembers;
 
     /** Map of userid of contacts (key) and their visibility (value) (updated only from API)

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -311,7 +311,8 @@ struct IdRefMap: public std::map<karere::Id, int>
 
 class Listener;
 
-class Client: public karere::DeleteTrackable, public WebsocketsClient
+class Client: public karere::DeleteTrackable, public WebsocketsClient,
+        public ::mega::MegaGlobalListener
 {
 public:
     enum ConnState
@@ -385,6 +386,19 @@ protected:
      * (currently, it includes contacts and any user in our groupchats, except ex-contacts) */
     IdRefMap mCurrentPeers;
 
+    /** Map of chatids (key) and the list of peers (value) in every chat (updated only from API)
+     * @note: peers who are ex-contacts are not included
+     */
+    std::map<uint64_t, karere::SetOfIds> mChatMembers;
+
+    /** Map of userid of contacts (key) and their visibility (value) (updated only from API)
+     * @note: ex-contacts are included.
+     */
+    std::map<uint64_t, int> mContacts;
+
+    /** Sequence-number for the list of peers and contacts above (initialized upon completion of catch-up phase) */
+    karere::Id mLastScsn = karere::Id::inval();
+
     void setConnState(ConnState newState);
 
     virtual void wsConnectCb();
@@ -396,19 +410,28 @@ protected:
     void abortRetryController();
     void handleMessage(const StaticBuffer& buf); // Destroys the buffer content
     bool sendCommand(Command&& cmd);
-    bool sendCommand(const Command& cmd);
-    void login();
+    bool sendCommand(const Command& cmd);    
     bool sendBuf(Buffer&& buf);
     void logSend(const Command& cmd);
+
+    void login();
     bool sendUserActive(bool active, bool force=false);
-    bool sendPrefs();
-    void setOnlineConfig(Config Config);
-    void pingWithPresence();
-    void pushPeers();
-    void configChanged();
-    std::string prefsString() const;
     bool sendKeepalive(time_t now=0);
-    void updatePeers(const std::vector<karere::Id> &peers, uint8_t command);
+
+    // config management
+    bool sendPrefs();
+    void configChanged();
+
+    // peers management
+    void addPeer(karere::Id peer);
+    void removePeer(karere::Id peer, bool force=false);
+    void pushPeers();
+    bool isExContact(uint64_t userid);
+
+    // mega::MegaGlobalListener interface, called by worker thread
+    virtual void onChatsUpdate(::mega::MegaApi*, ::mega::MegaTextChatList* rooms);
+    virtual void onUsersUpdate(::mega::MegaApi*, ::mega::MegaUserList* users);
+    virtual void onEvent(::mega::MegaApi* api, ::mega::MegaEvent* event);
     
 public:
     Client(MyMegaApi *api, karere::Client *client, Listener& listener, uint8_t caps);
@@ -430,7 +453,7 @@ public:
     // connection's management
     bool isOnline() const { return (mConnState >= kConnected); }
     promise::Promise<void>
-    connect(const std::string& url, IdRefMap&& peers, const Config& Config);
+    connect(const std::string& url, const Config& Config);
     void disconnect();
     void doConnect();
     void retryPendingConnection(bool disconnect);
@@ -443,9 +466,6 @@ public:
     /** Tells presenced that there's user's activity (notified by the app) */
     void signalActivity();
 
-    // peers management
-    void addPeer(karere::Id peer);
-    void removePeer(karere::Id peer, bool force=false);
     ~Client();
 };
 


### PR DESCRIPTION
- Avoid to update the list of peers for presenced from chatd JOINs.
- Avoid to send `SETPEERS` before catch-up phase (actionpackets received
after first `wsc`).
- Update peerlist (`ADDPEER`/`DELPEER`) only after catch-up phase.
- Register a `MegaGlobalListener` to receive changes in contact-list,
chats-peer-list and also the catch-up event.