### PR TITLE
Fix compilation error

### DIFF
--- a/src/rtcModule/webrtcAdapter.cpp
+++ b/src/rtcModule/webrtcAdapter.cpp
@@ -1,5 +1,5 @@
 #include "webrtcAdapter.h"
-#include <base/ssladapter.h>
+#include <rtc_base/ssladapter.h>
 #include <modules/video_capture/video_capture_factory.h>
 #include <modules/video_capture/video_capture.h>
 #include <media/engine/webrtcvideocapturerfactory.h>


### PR DESCRIPTION
`webrtc/base` is deprecated https://bugs.chromium.org/p/webrtc/issues/detail?id=7634
Depending the webrtc version, using `base/ssladapter.h` would compile or not. The current webrtc version used in the iOS application doesn't have the `base/ssladapter.h` header file, so the compilation fails