### PR TITLE
WIP: Reuse chatroom in automatic tests

### DIFF
--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -366,12 +366,19 @@ void MegaChatApiTest::TearDown()
                  uh = megaChatApi[i]->getUserHandleByEmail(mAccounts[a2].getEmail().c_str());
             }
 
+            // If chat to skip does not have peers we'll asume that it's a public chat
+            uint8_t chatMode;
             if (uh != MEGACHAT_INVALID_HANDLE)
             {
                 peers->addPeer(uh, MegaChatPeerList::PRIV_STANDARD);
+                chatMode = PRIVATE;
+            }
+            else
+            {
+                chatMode = PUBLIC;
             }
 
-            chatToSkip = getGroupChatRoom(i, a2, peers, false, PUBLIC_OR_NOT);
+            chatToSkip = getGroupChatRoom(i, a2, peers, false, chatMode);
             delete peers;
             peers = NULL;
             clearAndLeaveChats(i, chatToSkip);

--- a/tests/sdk_test/sdk_test.h
+++ b/tests/sdk_test/sdk_test.h
@@ -36,6 +36,12 @@ static const unsigned int maxTimeout = 600;
 static const unsigned int pollingT = 500000;   // (microseconds) to check if response from server is received
 static const unsigned int NUM_ACCOUNTS = 2;
 
+/** Enum for chat title */
+enum: uint8_t { TITLE_OR_NOT = 0, NO_TITLE = 1, TITLE = 2};
+
+/** Enum for chat mode */
+enum: uint8_t { PUBLIC_OR_NOT = 0, PUBLIC = 1, PRIVATE = 2};
+
 class ChatTestException : public std::exception
 {
 public:
@@ -211,7 +217,7 @@ private:
     int loadHistory(unsigned int accountIndex, megachat::MegaChatHandle chatid, TestChatRoomListener *chatroomListener);
     void makeContact(unsigned int a1, unsigned int a2);
     megachat::MegaChatHandle getGroupChatRoom(unsigned int a1, unsigned int a2,
-                                              megachat::MegaChatPeerList *peers, bool create = true, bool publicChat = false, const char *title = NULL);
+                                              megachat::MegaChatPeerList *peers, bool create = true, uint8_t publicChat = PRIVATE, uint8_t hasTitle = TITLE_OR_NOT);
 
     megachat::MegaChatHandle getPeerToPeerChatRoom(unsigned int a1, unsigned int a2);
 


### PR DESCRIPTION
- Improve teardown method to remove all unused chats in both accounts
- Reuse public chat created by anonymous mode test
- Change tests execution order in order to create a chat that will be
reused by the rest of the tests.