### PR TITLE
Don't allow unaligned memory access for arm64 devices

### DIFF
--- a/src/buffer.h
+++ b/src/buffer.h
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <vector>
 
-#if !defined(__arm__) && !defined(__aarch64__)
+#if !defined(__arm__) && !defined(__aarch64__)
     #define BUFFER_ALLOW_UNALIGNED_MEMORY_ACCESS 1
 #endif
 class BufferRangeError: public std::runtime_error

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <vector>
 
-#ifndef __arm__
+#if !defined(__arm__) && !defined(__aarch64__)
     #define BUFFER_ALLOW_UNALIGNED_MEMORY_ACCESS 1
 #endif
 class BufferRangeError: public std::runtime_error


### PR DESCRIPTION
The Undefined Behavior Sanitizer (UBSan) detects a Misaligned Pointer / Reference. 

![screenshot 2019-01-28 at 11 18 07](https://user-images.githubusercontent.com/3861964/51833171-08b72e80-22f7-11e9-832a-a497206fc902.png)

A misaligned pointer has undefined behavior, and may result in a crash or degraded performance.

The problem is that `__arm__` is defined for 32bit arm, and 32bit arm only. At least. when using `clang`.

This pull request tries to solve this problem for arm64 devices.

