### PR TITLE
Support to refresh the chatd/presenced URLs and reconnect

### DIFF
--- a/bindings/java/nz/mega/sdk/MegaChatApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaChatApiJava.java
@@ -390,6 +390,32 @@ public class MegaChatApiJava {
     }
 
     /**
+     * @brief Refresh URLs and establish fresh connections
+     *
+     * The associated request type with this request is MegaChatRequest::TYPE_RETRY_PENDING_CONNECTIONS
+     *
+     * A disconnect will be forced automatically, followed by a reconnection to the fresh URLs
+     * retrieved from API. This parameter is useful when the URL for the API is changed
+     * via MegaApi::changeApiUrl.
+     *
+     * @param listener MegaChatRequestListener to track this request
+     */
+    public void refreshUrl(MegaChatRequestListenerInterface listener){
+        megaChatApi.refreshUrl(createDelegateRequestListener(listener));
+    }
+
+    /**
+     * @brief Refresh URLs and establish fresh connections
+     *
+     * The associated request type with this request is MegaChatRequest::TYPE_RETRY_PENDING_CONNECTIONS
+     *
+     * A disconnect will be forced automatically, followed by a reconnection to the fresh URLs
+     * retrieved from API. This parameter is useful when the URL for the API is changed
+     * via MegaApi::changeApiUrl.
+     */
+    public void refreshUrl(){ megaChatApi.refreshUrl(); }
+
+    /**
      * Logout of chat servers invalidating the session
      *
      * The associated request type with this request is MegaChatRequest::TYPE_LOGOUT

--- a/examples/megaclc/megaclc.cpp
+++ b/examples/megaclc/megaclc.cpp
@@ -1667,7 +1667,7 @@ void exec_apiurl(ac::ACState& s)
             };
 
             g_megaApi->fetchNodes(listener);
-            g_chatApi->retryPendingConnections(true, true);
+            g_chatApi->refreshUrl();
         }
     }
 }

--- a/examples/megaclc/megaclc.cpp
+++ b/examples/megaclc/megaclc.cpp
@@ -494,6 +494,8 @@ void MegaclcListener::onRequestFinish(m::MegaApi* api, m::MegaRequest *request, 
             conlock(cout) << "Connecting to chat servers" << endl;
             guard.unlock();
             g_chatApi->connect(&g_chatListener);
+
+            setprompt(COMMAND);
         }
         break;
 
@@ -1655,19 +1657,14 @@ void exec_apiurl(ac::ACState& s)
         g_megaApi->changeApiUrl(s.words[1].s.c_str(), s.words.size() > 2 && s.words[2].s == "true");
         if (g_megaApi->isLoggedIn())
         {
-            conlock(cout) << "Re-fetching nodes due to change of APIURL" << endl;
+            conlock(cout) << "Refreshing local cache due to change of APIURL" << endl;
 
             setprompt(NOPROMPT);
 
-            auto listener = new OneShotRequestListener;
-            listener->onRequestFinishFunc = [](m::MegaApi*, m::MegaRequest *, m::MegaError* e) 
-            {
-                conlock(cout) << "Fetchnodes finished: " << e->getErrorString() << endl;
-                setprompt(COMMAND);
-            };
-
-            g_megaApi->fetchNodes(listener);
+            const char *session = g_megaApi->dumpSession();
+            g_megaApi->fastLogin(session);
             g_chatApi->refreshUrl();
+            delete [] session;
         }
     }
 }

--- a/examples/megaclc/megaclc.cpp
+++ b/examples/megaclc/megaclc.cpp
@@ -1667,6 +1667,7 @@ void exec_apiurl(ac::ACState& s)
             };
 
             g_megaApi->fetchNodes(listener);
+            g_chatApi->retryPendingConnections(true, true);
         }
     }
 }

--- a/examples/qtmegachatapi/MainWindow.cpp
+++ b/examples/qtmegachatapi/MainWindow.cpp
@@ -445,7 +445,7 @@ void MainWindow::on_bSettings_clicked()
 
     menu.addSeparator();
     auto actTwoFactCheck = menu.addAction(tr("Enable/Disable 2FA"));
-    connect(actTwoFactCheck, SIGNAL(clicked(bool)), this, SLOT(onTwoFactorCheck(bool)));
+    connect(actTwoFactCheck, SIGNAL(toggled(bool)), this, SLOT(onTwoFactorCheck(bool)));
     actTwoFactCheck->setEnabled(mMegaApi->multiFactorAuthAvailable());
 
     menu.addSeparator();
@@ -471,6 +471,12 @@ void MainWindow::on_bSettings_clicked()
         actlastGreenVisible->setEnabled(false);
     }
     delete presenceConfig;
+
+    menu.addSeparator();
+    auto actUseStaging = menu.addAction("Use API staging");
+    connect(actUseStaging, SIGNAL(toggled(bool)), this, SLOT(onUseApiStagingClicked(bool)));
+    actUseStaging->setCheckable(true);
+    actUseStaging->setChecked(mApp->isStagingEnabled());
 
     QPoint pos = ui->bSettings->pos();
     pos.setX(pos.x() + ui->bSettings->width());
@@ -1036,4 +1042,9 @@ void MainWindow::onlastGreenVisibleClicked()
     MegaChatPresenceConfig *presenceConfig = mMegaChatApi->getPresenceConfig();
     mMegaChatApi->setLastGreenVisible(!presenceConfig->isLastGreenVisible());
     delete presenceConfig;
+}
+
+void MainWindow::onUseApiStagingClicked(bool enable)
+{
+    mApp->enableStaging(enable);
 }

--- a/examples/qtmegachatapi/MainWindow.h
+++ b/examples/qtmegachatapi/MainWindow.h
@@ -195,6 +195,7 @@ class MainWindow :
         void onTwoFactorCheck(bool);
         void on_mLogout_clicked();
         void onlastGreenVisibleClicked();
+        void onUseApiStagingClicked(bool);
 
     signals:
         void esidLogout();

--- a/examples/qtmegachatapi/MegaChatApplication.cpp
+++ b/examples/qtmegachatapi/MegaChatApplication.cpp
@@ -216,6 +216,32 @@ const char *MegaChatApplication::getFirstname(MegaChatHandle uh)
     return NULL;
 }
 
+bool MegaChatApplication::isStagingEnabled()
+{
+    return useStaging;
+}
+
+void MegaChatApplication::enableStaging(bool enable)
+{
+    if (useStaging == enable)
+    {
+        return;
+    }
+
+    useStaging = enable;
+    if (enable)
+    {
+        mMegaApi->changeApiUrl("https://staging.api.mega.co.nz/");
+    }
+    else
+    {
+        mMegaApi->changeApiUrl("https://g.api.mega.co.nz/");
+    }
+
+    // force a reload upon api-url changes
+    mMegaApi->fetchNodes();
+}
+
 const char *MegaChatApplication::sid() const
 {
     return mSid;
@@ -281,7 +307,11 @@ void MegaChatApplication::onRequestFinish(MegaApi *api, MegaRequest *request, Me
                     mSid = mMegaApi->dumpSession();
                     saveSid(mSid);
                 }
-                mMegaChatApi->connect();
+
+                if (mMegaChatApi->getConnectionState() == MegaChatApi::DISCONNECTED)
+                {
+                    mMegaChatApi->connect();
+                }
             }
             else
             {
@@ -360,7 +390,7 @@ void MegaChatApplication::onRequestFinish(MegaChatApi *, MegaChatRequest *reques
          case MegaChatRequest::TYPE_CONNECT:
             if (e->getErrorCode() != MegaChatError::ERROR_OK)
             {
-                QMessageBox::critical(nullptr, tr("Chat Connection"), tr("Error stablishing connection").append(e->getErrorString()));
+                QMessageBox::critical(nullptr, tr("Chat Connection"), tr("Error stablishing connection: ").append(e->getErrorString()));
                 init();
             }
             else

--- a/examples/qtmegachatapi/MegaChatApplication.cpp
+++ b/examples/qtmegachatapi/MegaChatApplication.cpp
@@ -238,9 +238,12 @@ void MegaChatApplication::enableStaging(bool enable)
         mMegaApi->changeApiUrl("https://g.api.mega.co.nz/");
     }
 
-    // force a reload upon api-url changes
-    mMegaApi->fetchNodes();
-    mMegaChatApi->retryPendingConnections(true, true);
+    if (mMegaChatApi->getOnlineStatus() != MegaChatApi::DISCONNECTED)
+    {
+        // force a reload upon api-url changes
+        mMegaApi->fastLogin(mSid);
+        mMegaChatApi->refreshUrl();
+    }
 }
 
 const char *MegaChatApplication::sid() const
@@ -266,7 +269,7 @@ void MegaChatApplication::onRequestFinish(MegaApi *api, MegaRequest *request, Me
         case MegaRequest::TYPE_LOGIN:
             if (e->getErrorCode() == MegaError::API_EMFAREQUIRED)
             {
-                std::string auxcode = this->mMainWin->getAuthCode();
+                std::string auxcode = mMainWin->getAuthCode();
                 if (!auxcode.empty())
                 {
                     QString email(request->getEmail());

--- a/examples/qtmegachatapi/MegaChatApplication.cpp
+++ b/examples/qtmegachatapi/MegaChatApplication.cpp
@@ -240,6 +240,7 @@ void MegaChatApplication::enableStaging(bool enable)
 
     // force a reload upon api-url changes
     mMegaApi->fetchNodes();
+    mMegaChatApi->retryPendingConnections(true, true);
 }
 
 const char *MegaChatApplication::sid() const

--- a/examples/qtmegachatapi/MegaChatApplication.h
+++ b/examples/qtmegachatapi/MegaChatApplication.h
@@ -43,6 +43,9 @@ class MegaChatApplication : public QApplication,
 
         const char *getFirstname(megachat::MegaChatHandle uh);
 
+        bool isStagingEnabled();
+        void enableStaging(bool enable);
+
     protected:
         const char *mSid;
         std::string mAppDir;
@@ -58,6 +61,7 @@ class MegaChatApplication : public QApplication,
     private:
         std::map<megachat::MegaChatHandle, std::string> mFirstnamesMap;
         std::map<megachat::MegaChatHandle, bool> mFirstnameFetching;
+        bool useStaging = false;
 
     public slots:
         void onLoginClicked();

--- a/examples/qtmegachatapi/chatMessage.cpp
+++ b/examples/qtmegachatapi/chatMessage.cpp
@@ -355,20 +355,24 @@ std::string ChatMessage::managementInfoToString() const
         }
         case megachat::MegaChatMessage::TYPE_CALL_ENDED:
         {
-            ret.append("User ").append(userHandle_64)
-               .append(" start a call with: ");
+            ret.append("User ").append(userHandle_64);
+            ret.append(" called user/s: ");
 
             ::mega::MegaHandleList *handleList = mMessage->getMegaHandleList();
             for (unsigned int i = 0; i < handleList->size(); i++)
             {
-                char *participant_64 = this->mChatWindow->mMegaApi->userHandleToBase64(handleList->get(i));
-                ret.append(participant_64).append(" ");
+                char *participant_64 = mChatWindow->mMegaApi->userHandleToBase64(handleList->get(i));
+                ret.append(participant_64).append(", ");
                 delete [] participant_64;
+            }
+            if (handleList->size())
+            {
+                ret = ret.substr(0, ret.size() - 2);
             }
 
             ret.append("\nDuration: ")
                .append(std::to_string(mMessage->getDuration()))
-               .append("secs TermCode: ")
+               .append("s. TermCode: ")
                .append(std::to_string(mMessage->getTermCode()));
             break;
         }

--- a/examples/qtmegachatapi/contactItemWidget.cpp
+++ b/examples/qtmegachatapi/contactItemWidget.cpp
@@ -28,7 +28,7 @@ ContactItemWidget::ContactItemWidget(QWidget *parent, MainWindow *mainWin, megac
     }
     delete [] firstname;
 
-    int status = this->mMegaChatApi->getUserOnlineStatus(mUserHandle);
+    int status = mMegaChatApi->getUserOnlineStatus(mUserHandle);
     updateOnlineIndicator(status);
 }
 
@@ -272,6 +272,11 @@ ContactItemWidget::~ContactItemWidget()
 
 void ContactItemWidget::updateOnlineIndicator(int newState)
 {
+    if (newState == megachat::MegaChatApi::STATUS_INVALID)
+    {
+        newState = 0;
+    }
+
     if (newState >= 0 && newState < NINDCOLORS)
     {
         ui->mOnlineIndicator->setStyleSheet(

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1086,10 +1086,7 @@ promise::Promise<void> Client::connectToPresenced(Presence forcedPres)
         return api.call(&::mega::MegaApi::getChatPresenceURL)
         .then([this, forcedPres](ReqResult result) -> Promise<void>
         {
-            auto url = result->getLink();
-            if (!url)
-                return promise::Error("No presenced URL received from API");
-            mPresencedUrl = url;
+            mPresencedUrl = result->getLink();
             return connectToPresencedWithUrl(mPresencedUrl, forcedPres);
         });
     }

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -291,7 +291,7 @@ Client::~Client()
 #endif
 }
 
-void Client::retryPendingConnections(bool disconnect)
+void Client::retryPendingConnections(bool disconnect, bool refreshURL)
 {
     if (mConnState == kDisconnected)  // already a connection attempt in-progress
     {
@@ -299,10 +299,10 @@ void Client::retryPendingConnections(bool disconnect)
         return;
     }
 
-    mPresencedClient.retryPendingConnection(disconnect);
+    mPresencedClient.retryPendingConnection(disconnect, refreshURL);
     if (mChatdClient)
     {
-        mChatdClient->retryPendingConnections(disconnect);
+        mChatdClient->retryPendingConnections(disconnect, refreshURL);
     }
 }
 

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -774,7 +774,7 @@ public:
      * @brief Retry pending connections to chatd and presenced
      * @return A promise to track the result of the action.
      */
-    void retryPendingConnections(bool disconnect);
+    void retryPendingConnections(bool disconnect, bool refreshURL = false);
 
     /**
      * @brief A convenience method that logs in the Mega SDK and then inits

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -363,15 +363,7 @@ void Chat::connect()
                 return;
             }
 
-            const char* url = result->getLink();
-            if (!url || !url[0])
-            {
-                CHATID_LOG_ERROR("No chatd URL received from API");
-                return;
-            }
-
-            std::string sUrl = url;
-            mConnection.mUrl.parse(sUrl);
+            mConnection.mUrl.parse(result->getLink());
             mConnection.mUrl.path.append("/").append(std::to_string(Client::chatdVersion));
 
             mConnection.reconnect()

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -878,7 +878,7 @@ void Connection::retryPendingConnection(bool disconnect, bool refreshURL)
 
     if (refreshURL || !mUrl.isValid())
     {
-        if (State::kStateFetchingUrl)
+        if (mState == State::kStateFetchingUrl)
         {
             CHATDS_LOG_WARNING("retryPendingConnection: previous fetch of a fresh URL is still in progress");
             return;

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -870,6 +870,12 @@ void Connection::doConnect()
 
 void Connection::retryPendingConnection(bool disconnect, bool refreshURL)
 {
+    if (mState == kStateNew)
+    {
+        CHATDS_LOG_WARNING("retryPendingConnection: no connection to be retried yet. Call connect() first");
+        return;
+    }
+
     if (refreshURL || !mUrl.isValid())
     {
         if (State::kStateFetchingUrl)

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -883,6 +883,7 @@ void Connection::retryPendingConnection(bool disconnect, bool refreshURL)
             CHATDS_LOG_WARNING("retryPendingConnection: previous fetch of a fresh URL is still in progress");
             return;
         }
+        CHATDS_LOG_WARNING("retryPendingConnection: fetch a fresh URL for reconnection!");
 
         // abort and prevent any further reconnection attempt
         setState(kStateDisconnected);

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -878,7 +878,7 @@ void Connection::retryPendingConnection(bool disconnect, bool refreshURL)
 
     if (refreshURL || !mUrl.isValid())
     {
-        if (mState == State::kStateFetchingUrl)
+        if (mState == kStateFetchingUrl)
         {
             CHATDS_LOG_WARNING("retryPendingConnection: previous fetch of a fresh URL is still in progress");
             return;
@@ -892,7 +892,7 @@ void Connection::retryPendingConnection(bool disconnect, bool refreshURL)
 
         // clear existing URL
         mUrl = Url();
-        setState(State::kStateFetchingUrl);
+        setState(kStateFetchingUrl);
 
         assert(mChatIds.size());
 

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -476,7 +476,7 @@ public:
     bool isOnline() const;
     const std::set<karere::Id>& chatIds() const;
     uint32_t clientId() const;
-    void retryPendingConnection(bool disconnect);
+    void retryPendingConnection(bool disconnect, bool refreshURL = false);
     virtual ~Connection();
 
     void heartbeat();
@@ -1388,7 +1388,7 @@ public:
     void leave(karere::Id chatid);
 
     void disconnect();
-    void retryPendingConnections(bool disconnect);
+    void retryPendingConnections(bool disconnect, bool refreshURL = false);
     void heartbeat();
 
     void notifyUserIdle();

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -292,9 +292,14 @@ bool MegaChatApi::areAllChatsLoggedIn()
     return pImpl->areAllChatsLoggedIn();
 }
 
-void MegaChatApi::retryPendingConnections(bool disconnect, bool refreshURL, MegaChatRequestListener *listener)
+void MegaChatApi::retryPendingConnections(bool disconnect, MegaChatRequestListener *listener)
 {
-    pImpl->retryPendingConnections(disconnect, refreshURL, listener);
+    pImpl->retryPendingConnections(disconnect, false, listener);
+}
+
+void MegaChatApi::refreshUrl(MegaChatRequestListener *listener)
+{
+    pImpl->retryPendingConnections(true, true, listener);
 }
 
 void MegaChatApi::logout(MegaChatRequestListener *listener)

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -292,9 +292,9 @@ bool MegaChatApi::areAllChatsLoggedIn()
     return pImpl->areAllChatsLoggedIn();
 }
 
-void MegaChatApi::retryPendingConnections(bool disconnect, MegaChatRequestListener *listener)
+void MegaChatApi::retryPendingConnections(bool disconnect, bool refreshURL, MegaChatRequestListener *listener)
 {
-    pImpl->retryPendingConnections(disconnect, listener);
+    pImpl->retryPendingConnections(disconnect, refreshURL, listener);
 }
 
 void MegaChatApi::logout(MegaChatRequestListener *listener)

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2228,7 +2228,6 @@ public:
      * retrieved from API. This parameter is useful when the URL for the API is changed
      * via MegaApi::changeApiUrl.
      *
-     * @param refreshURL True to discard existing URLs for chatd/presenced and fetch fresh URLs
      * @param listener MegaChatRequestListener to track this request
      */
     void refreshUrl(MegaChatRequestListener *listener = NULL);

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2214,15 +2214,24 @@ public:
      *
      * The associated request type with this request is MegaChatRequest::TYPE_RETRY_PENDING_CONNECTIONS
      *
-     * If \c refreshURL is true, a disconnect will be forced automatically, followed by a reconnection
-     * to the fresh URLs retrieved from API. This parameter is useful when the URL for the API is changed
+     * @param disconnect False to simply abort any backoff, true to disconnect and reconnect from scratch.
+     * @param listener MegaChatRequestListener to track this request
+     */
+    void retryPendingConnections(bool disconnect = false, MegaChatRequestListener *listener = NULL);
+
+    /**
+     * @brief Refresh URLs and establish fresh connections
+     *
+     * The associated request type with this request is MegaChatRequest::TYPE_RETRY_PENDING_CONNECTIONS
+     *
+     * A disconnect will be forced automatically, followed by a reconnection to the fresh URLs
+     * retrieved from API. This parameter is useful when the URL for the API is changed
      * via MegaApi::changeApiUrl.
      *
-     * @param disconnect False to simply abort any backoff, true to disconnect and reconnect from scratch.
      * @param refreshURL True to discard existing URLs for chatd/presenced and fetch fresh URLs
      * @param listener MegaChatRequestListener to track this request
      */
-    void retryPendingConnections(bool disconnect = false, bool refreshURL = false, MegaChatRequestListener *listener = NULL);
+    void refreshUrl(MegaChatRequestListener *listener = NULL);
 
     /**
      * @brief Logout of chat servers invalidating the session

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2214,10 +2214,15 @@ public:
      *
      * The associated request type with this request is MegaChatRequest::TYPE_RETRY_PENDING_CONNECTIONS
      *
+     * If \c refreshURL is true, a disconnect will be forced automatically, followed by a reconnection
+     * to the fresh URLs retrieved from API. This parameter is useful when the URL for the API is changed
+     * via MegaApi::changeApiUrl.
+     *
      * @param disconnect False to simply abort any backoff, true to disconnect and reconnect from scratch.
+     * @param refreshURL True to discard existing URLs for chatd/presenced and fetch fresh URLs
      * @param listener MegaChatRequestListener to track this request
      */
-    void retryPendingConnections(bool disconnect = false, MegaChatRequestListener *listener = NULL);
+    void retryPendingConnections(bool disconnect = false, bool refreshURL = false, MegaChatRequestListener *listener = NULL);
 
     /**
      * @brief Logout of chat servers invalidating the session

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -249,7 +249,8 @@ void MegaChatApiImpl::sendPendingRequests()
         case MegaChatRequest::TYPE_RETRY_PENDING_CONNECTIONS:
         {
             bool disconnect = request->getFlag();
-            mClient->retryPendingConnections(disconnect);
+            bool refreshURLs = (bool)(request->getParamType() == 1);
+            mClient->retryPendingConnections(disconnect, refreshURLs);
 
             MegaChatErrorPrivate *megaChatError = new MegaChatErrorPrivate(MegaChatError::ERROR_OK);
             fireOnChatRequestFinish(request, megaChatError);
@@ -1986,10 +1987,11 @@ bool MegaChatApiImpl::areAllChatsLoggedIn()
     return ret;
 }
 
-void MegaChatApiImpl::retryPendingConnections(bool disconnect, MegaChatRequestListener *listener)
+void MegaChatApiImpl::retryPendingConnections(bool disconnect, bool refreshURL, MegaChatRequestListener *listener)
 {
     MegaChatRequestPrivate *request = new MegaChatRequestPrivate(MegaChatRequest::TYPE_RETRY_PENDING_CONNECTIONS, listener);
     request->setFlag(disconnect);
+    request->setParamType(refreshURL ? 1 : 0);
     requestQueue.push(request);
     waiter->notify();
 }

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -990,7 +990,7 @@ public:
     int getChatConnectionState(MegaChatHandle chatid);
     bool areAllChatsLoggedIn();
     static int convertChatConnectionState(chatd::ChatState state);
-    void retryPendingConnections(bool disconnect = false, MegaChatRequestListener *listener = NULL);
+    void retryPendingConnections(bool disconnect = false, bool refreshURL = false, MegaChatRequestListener *listener = NULL);
     void logout(MegaChatRequestListener *listener = NULL);
     void localLogout(MegaChatRequestListener *listener = NULL);
 

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -810,6 +810,12 @@ void Client::doConnect()
 
 void Client::retryPendingConnection(bool disconnect, bool refreshURL)
 {
+    if (mConnState == kConnNew)
+    {
+        PRESENCED_LOG_WARNING("retryPendingConnection: no connection to be retried yet. Call connect() first");
+        return;
+    }
+
     if (refreshURL || !mUrl.isValid())
     {
         if (mConnState == ConnState::kFetchingUrl)

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -818,7 +818,7 @@ void Client::retryPendingConnection(bool disconnect, bool refreshURL)
 
     if (refreshURL || !mUrl.isValid())
     {
-        if (mConnState == ConnState::kFetchingUrl)
+        if (mConnState == kFetchingUrl)
         {
             PRESENCED_LOG_WARNING("retryPendingConnection: previous fetch of a fresh URL is still in progress");
             return;

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -457,7 +457,7 @@ public:
     connect(const std::string& url, const Config& Config);
     void disconnect();
     void doConnect();
-    void retryPendingConnection(bool disconnect);
+    void retryPendingConnection(bool disconnect, bool refreshURL = false);
 
     /** @brief Performs server ping and check for network inactivity.
      * Must be called externally in order to have all clients

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -318,6 +318,7 @@ public:
     enum ConnState
     {
         kConnNew = 0,
+        kFetchingUrl,
         kDisconnected,
         kResolving,
         kConnecting,
@@ -454,7 +455,7 @@ public:
     // connection's management
     bool isOnline() const { return (mConnState >= kConnected); }
     promise::Promise<void>
-    connect(const std::string& url, const Config& Config);
+    connect(const Config& Config);
     void disconnect();
     void doConnect();
     void retryPendingConnection(bool disconnect, bool refreshURL = false);
@@ -510,6 +511,7 @@ static inline const char* connStateToStr(Client::ConnState state)
     case Client::kConnecting: return "Connecting";
     case Client::kConnected: return "Connected";
     case Client::kLoggedIn: return "Logged-in";
+    case Client::kFetchingUrl: return "Fetching URL";
     case Client::kConnNew: return "New";
     default: return "(invalid)";
     }


### PR DESCRIPTION
When API path is changed to staging, not only a full fetchnodes is required, but also the URL for presenced is different, so it needs to be re-fetched and reconnected.