### PR TITLE
Fix removeSession, remove session at the end of the function

### DIFF
--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -1599,8 +1599,6 @@ void Call::stopIncallPingTimer(bool endCall)
 
 void Call::removeSession(Session& sess, TermCode reason)
 {
-    mSessions.erase(sess.mSid);
-
     if (mState == kStateTerminating)
     {
         return;


### PR DESCRIPTION
`mSessions.erase(sess.mSid)` was duplicated. We remove the session at the end of the function to avoid access an invalid reference `Session& sess`