### PR TITLE
Prevent app crashes in logger

### DIFF
--- a/src/base/logger.cpp
+++ b/src/base/logger.cpp
@@ -2,6 +2,7 @@
 	#define LOGGER_SPRINTF_BUF_SIZE 10240
 #endif
 
+#include <iostream>
 #include <stdarg.h>
 #include <string.h>
 #define KRLOGGER_BUILDING //sets DLLIMPEXPs in logger.h to 'export' mode
@@ -191,22 +192,30 @@ void Logger::logString(krLogLevel level, const char* msg, unsigned flags, size_t
         return;
     }
 
-    LockGuard lock(mMutex);
-    if (len == (size_t)-1)
-        len = strlen(msg);
-
-    if (mConsoleLogger && ((flags & krLogNoConsole) == 0))
-        mConsoleLogger->logString(level, msg, flags);
-    if ((mFileLogger) && ((flags & krLogNoFile) == 0))
-        mFileLogger->logString(msg, len, flags);
-    if (!mUserLoggers.empty())
+    try
     {
-        for (auto& logger: mUserLoggers)
+        // This try-catch prevents crashes in app in case that mutex can't be adquire.
+        LockGuard lock(mMutex);
+        if (len == (size_t)-1)
+            len = strlen(msg);
+
+        if (mConsoleLogger && ((flags & krLogNoConsole) == 0))
+            mConsoleLogger->logString(level, msg, flags);
+        if ((mFileLogger) && ((flags & krLogNoFile) == 0))
+            mFileLogger->logString(msg, len, flags);
+        if (!mUserLoggers.empty())
         {
-            ILoggerBackend* backend = logger.second;
-            if(level <= backend->maxLogLevel)
-                backend->log(level, msg, len, flags);
+            for (auto& logger: mUserLoggers)
+            {
+                ILoggerBackend* backend = logger.second;
+                if(level <= backend->maxLogLevel)
+                    backend->log(level, msg, len, flags);
+            }
         }
+    }
+    catch (std::system_error &e)
+    {
+        std::cerr << "Failed to log message: " << e.what() << std::endl;
     }
 }
 


### PR DESCRIPTION
Add try-catch for `recursive_mutex::lock()` in order to capture the exception thrown by
the function. There are crash reports from iOS indicating that the static object `Logger` might be already destroyed when `logString()` is called. Apparently, iOS could be destroying the `Logger` object while the `MegaChatApi` instance is still running and logging messages. Hence, the exception upon trying to `lock()` an invalid instance of the mutex.
Due to the high frequency of calls to this function and the overhead introduced by the exception's handler, we will first check another workaround: iOS to force the destroy of the `MegaChatApi` upon app's termination. If the crash still reproduce, then we will merge this PR.
