### PR TITLE
Abort session reconnection when user is disconnected

### DIFF
--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -2068,10 +2068,7 @@ void Call::onClientLeftCall(Id userid, uint32_t clientid)
         if (mSessRetries.find(EndpointId(userid, clientid)) != mSessRetries.end())
         {
             cancelSessionRetryTimer(userid, clientid);
-            if (mSessions.empty() && mSessRetries.empty())
-            {
-                destroy(TermCode::kErrPeerOffline, userid == mChat.client().mKarereClient->myHandle());
-            }
+            destroyIfNoSessionsOrRetries(TermCode::kErrPeerOffline);
         }
     }
     else if (mState >= kStateInProgress)

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -2064,6 +2064,15 @@ void Call::onClientLeftCall(Id userid, uint32_t clientid)
                 return;
             }
         }
+
+        if (mSessRetries.find(EndpointId(userid, clientid)) != mSessRetries.end())
+        {
+            cancelSessionRetryTimer(userid, clientid);
+            if (mSessions.empty() && mSessRetries.empty())
+            {
+                destroy(TermCode::kErrPeerOffline, userid == mChat.client().mKarereClient->myHandle());
+            }
+        }
     }
     else if (mState >= kStateInProgress)
     {


### PR DESCRIPTION
Abort session reconnection when we receive a user is offline. It's possible that webrtc detects a session fail before we receive a ENDCALL from chatd