### PR TITLE
Chatd connection improvements in automatic tests

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2035,7 +2035,7 @@ promise::Promise<void> GroupChatRoom::decryptTitle()
 
     buf.setDataSize(decLen);
     auto wptr = getDelTracker();
-    return this->chat().crypto()->decryptChatTitle(buf)
+    return chat().crypto()->decryptChatTitle(buf)
     .then([wptr, this](const std::string& title)
     {
         wptr.throwIfDeleted();

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -2478,6 +2478,12 @@ Message* Chat::msgSubmit(const char* msg, size_t msglen, unsigned char type, voi
         return NULL;
     }
 
+    if (mOwnPrivilege == PRIV_NOTPRESENT)
+    {
+        CHATID_LOG_WARNING("msgSubmit: Denying sending message because we don't participate in the chat");
+        return NULL;
+    }
+
     // write the new message to the message buffer and mark as in sending state
     auto message = new Message(makeRandomId(), client().myHandle(), time(NULL),
         0, msg, msglen, true, CHATD_KEYID_INVALID, type, userp);

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -476,7 +476,7 @@ public:
         public:
         karere::Id callid;
         uint8_t termCode = 0;
-        uint32_t duration = 0;
+        uint32_t duration = 0;  // duration of call if established or period of time ringing (if never established: missed/cancelled)
         std::vector<karere::Id> participants;
 
         static CallEndedInfo *fromBuffer(const char *buffer, size_t len)

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -1415,7 +1415,12 @@ void MegaChatApiTest::TEST_OfflineMode(unsigned int a1, unsigned int a2)
     peers->addPeer(uh, MegaChatPeerList::PRIV_STANDARD);
 
     MegaChatHandle chatid = getGroupChatRoom(a1, a2, peers);
-    MegaChatRoom *chatRoom = megaChatApi[a1]->getChatRoom(chatid);
+    ASSERT_CHAT_TEST((megaChatApi[a1]->getChatConnectionState(chatid) == MegaChatApi::CHAT_CONNECTION_ONLINE),
+                             "Not connected to chatd for account " + std::to_string(a1+1) + ": " + mAccounts[a1].getEmail());
+    ASSERT_CHAT_TEST((megaChatApi[a2]->getChatConnectionState(chatid) == MegaChatApi::CHAT_CONNECTION_ONLINE),
+                             "Not connected to chatd for account " + std::to_string(a2+1) + ": " + mAccounts[a2].getEmail());
+
+    MegaChatRoom *chatRoom = megaChatApi[a1]->getChatRoom(chatid);    
     ASSERT_CHAT_TEST(chatRoom && (chatid != MEGACHAT_INVALID_HANDLE), "Can't get a chatroom");
     delete peers;
     peers = NULL;
@@ -1509,7 +1514,6 @@ void MegaChatApiTest::TEST_OfflineMode(unsigned int a1, unsigned int a2)
     delete msgSent; msgSent = NULL;
     delete chatroomListener;
     chatroomListener = NULL;
-
 
     delete [] sessionPrimary;
     delete [] sessionSecondary;

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -1186,8 +1186,8 @@ void MegaChatApiTest::TEST_GroupChatManagement(unsigned int a1, unsigned int a2)
     ASSERT_CHAT_TEST(waitForResponse(flagInviteToChatRoom), "Failed to invite a new peer after " + std::to_string(maxTimeout) + " seconds");
     ASSERT_CHAT_TEST(lastErrorChat[a1] == MegaChatError::ERROR_EXIST, "Invitation should have failed, but it succeed");
 
-    // --> Set title -> Add aleatory substring. We don't use full timestamp because we exceed title length
-    string title = "My groupchat with title " + dateToString().substr(dateToString().length() - 5, 5);
+    // --> Set title
+    string title = "Title " + std::to_string(time(NULL));
     bool *flagChatRoomName = &requestFlagsChat[a1][MegaChatRequest::TYPE_EDIT_CHATROOM_NAME]; *flagChatRoomName = false;
     bool *titleItemChanged0 = &titleUpdated[a1]; *titleItemChanged0 = false;
     bool *titleItemChanged1 = &titleUpdated[a2]; *titleItemChanged1 = false;
@@ -2106,7 +2106,7 @@ void MegaChatApiTest::TEST_GroupLastMessage(unsigned int a1, unsigned int a2)
 
 
     // --> Set title
-    std::string title = "My groupchat with title 2";
+    std::string title = "Title " + std::to_string(time(NULL));
     bool *flagChatRoomName = &requestFlagsChat[a1][MegaChatRequest::TYPE_EDIT_CHATROOM_NAME]; *flagChatRoomName = false;
     bool *titleItemChanged0 = &titleUpdated[a1]; *titleItemChanged0 = false;
     bool *titleItemChanged1 = &titleUpdated[a2]; *titleItemChanged1 = false;
@@ -2123,7 +2123,7 @@ void MegaChatApiTest::TEST_GroupLastMessage(unsigned int a1, unsigned int a2)
     ASSERT_CHAT_TEST(waitForResponse(titleChanged1), "Timeout expired for receiving chatroom title update for auxiliar account");
     ASSERT_CHAT_TEST(waitForResponse(mngMsgRecv), "Timeout expired for receiving management");
     ASSERT_CHAT_TEST(!strcmp(title.c_str(), msgContent->c_str()),
-                     "Title name has not changed correctly. Name establishes by a1: " + title + "Name received in a2: " + *msgContent);
+                     "Title name has not changed correctly.\nName established by a1: " + title + "\nName received in a2: " + *msgContent);
     MegaChatHandle managementMsg1 = chatroomListener->msgId[a1].back();
     MegaChatHandle managementMsg2 = chatroomListener->msgId[a2].back();
 

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -2966,7 +2966,11 @@ int MegaChatApiTest::loadHistory(unsigned int accountIndex, MegaChatHandle chati
         {
             break;  // no more history or cannot retrieve it
         }
-        ASSERT_CHAT_TEST(waitForResponse(flagHistoryLoaded), "Timeout expired for loading history");
+
+        char *handleB64 = new char[sizeof(handle) * 4 / 3 + 4];
+        Base64::btoa((const byte *)&chatid, sizeof(handle), handleB64);
+        ASSERT_CHAT_TEST(waitForResponse(flagHistoryLoaded), "Timeout expired for loading history from chat: " + std::string(handleB64));
+        delete [] handleB64;
     }
 
     return chatroomListener->msgCount[accountIndex];

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -101,6 +101,11 @@ std::string Account::getPassword() const
 
 MegaChatApiTest::MegaChatApiTest()
 {
+    for (int i = 0; i < NUM_ACCOUNTS; i++)
+    {
+        megaApi[i] = NULL;
+        megaChatApi[i] = NULL;
+    }
 }
 
 MegaChatApiTest::~MegaChatApiTest()
@@ -3010,8 +3015,11 @@ MegaChatHandle MegaChatApiTest::getGroupChatRoom(unsigned int a1, unsigned int a
                     // --> Ensure we are connected to chatd for the chatroom
                     ASSERT_CHAT_TEST((megaChatApi[a1]->getChatConnectionState(targetChatid) == MegaChatApi::CHAT_CONNECTION_ONLINE),
                                      "Not connected to chatd for account " + std::to_string(a1+1) + ": " + mAccounts[a1].getEmail());
-                    ASSERT_CHAT_TEST((megaChatApi[a2]->getChatConnectionState(targetChatid) == MegaChatApi::CHAT_CONNECTION_ONLINE),
+                    if (a2LoggedIn)
+                    {
+                        ASSERT_CHAT_TEST((megaChatApi[a2]->getChatConnectionState(targetChatid) == MegaChatApi::CHAT_CONNECTION_ONLINE),
                                      "Not connected to chatd for account " + std::to_string(a2+1) + ": " + mAccounts[a2].getEmail());
+                    }
                     break;
                 }
             }

--- a/tests/sdk_test/sdk_test.h
+++ b/tests/sdk_test/sdk_test.h
@@ -310,6 +310,7 @@ private:
     bool mVideoRemote[NUM_ACCOUNTS];
     TestChatVideoListener *mLocalVideoListener[NUM_ACCOUNTS];
     TestChatVideoListener *mRemoteVideoListener[NUM_ACCOUNTS];
+    bool mLoggedInAllChats[NUM_ACCOUNTS];
 
 #endif
 

--- a/tests/sdk_test/sdk_test.h
+++ b/tests/sdk_test/sdk_test.h
@@ -185,7 +185,7 @@ public:
     void TEST_GetChatRoomsAndMessages(unsigned int accountIndex);
     void TEST_EditAndDeleteMessages(unsigned int a1, unsigned int a2);
     void TEST_GroupChatManagement(unsigned int a1, unsigned int a2);
-    void TEST_OfflineMode(unsigned int accountIndex);
+    void TEST_OfflineMode(unsigned int a1);
     void TEST_ClearHistory(unsigned int a1, unsigned int a2);
     void TEST_SwitchAccounts(unsigned int a1, unsigned int a2);
     void TEST_SendContact(unsigned int a1, unsigned int a2);

--- a/tests/sdk_test/sdk_test.h
+++ b/tests/sdk_test/sdk_test.h
@@ -185,7 +185,7 @@ public:
     void TEST_GetChatRoomsAndMessages(unsigned int accountIndex);
     void TEST_EditAndDeleteMessages(unsigned int a1, unsigned int a2);
     void TEST_GroupChatManagement(unsigned int a1, unsigned int a2);
-    void TEST_OfflineMode(unsigned int a1);
+    void TEST_OfflineMode(unsigned int a1, unsigned int a2);
     void TEST_ClearHistory(unsigned int a1, unsigned int a2);
     void TEST_SwitchAccounts(unsigned int a1, unsigned int a2);
     void TEST_SendContact(unsigned int a1, unsigned int a2);


### PR DESCRIPTION
We need to ensure that we are connected to chatd for all chats when we make login in every test. On the other hand if we create a new chatroom we need to ensure that we are connected to chatd before continue with the test.