### PR TITLE
Fix race condition between findLastTextMessage and getHistory

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -4532,17 +4532,10 @@ bool Chat::findLastTextMsg()
 
 void Chat::findAndNotifyLastTextMsg()
 {
-    auto wptr = weakHandle();
-    marshallCall([wptr, this]() //prevent re-entrancy
-    {
-        if (wptr.deleted())
-            return;
+    if (!findLastTextMsg())
+        return;
 
-        if (!findLastTextMsg())
-            return;
-
-        notifyLastTextMsg();
-    }, mChatdClient.mKarereClient->appCtx);
+    notifyLastTextMsg();
 }
 
 void Chat::sendTypingNotification()

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -389,9 +389,6 @@ void MegaChatApiTest::TearDown()
 #endif
             megaChatApi[i]->removeChatRequestListener(this);
             megaChatApi[i]->removeChatListener(this);
-
-            delete megaChatApi[i];
-            megaChatApi[i] = NULL;
         }
 
         if (megaApi[i])
@@ -420,6 +417,12 @@ void MegaChatApiTest::TearDown()
             delete megaApi[i];
             megaApi[i] = NULL;
         }
+    }
+
+    for (int i = 0; i < NUM_ACCOUNTS; i++)
+    {
+        delete megaChatApi[i];
+        megaChatApi[i] = NULL;
     }
 
     purgeLocalTree(LOCAL_PATH);
@@ -2979,6 +2982,13 @@ void MegaChatApiTest::makeContact(unsigned int a1, unsigned int a2)
 MegaChatHandle MegaChatApiTest::getGroupChatRoom(unsigned int a1, unsigned int a2,
                                                  MegaChatPeerList *peers, bool create)
 {
+    // --> Ensure MEGAChatApi instances are valid
+    ASSERT_CHAT_TEST(megaChatApi[a1],
+                     "MEGAChatApi instance has been removed for account " + std::to_string(a1+1) + ": " + mAccounts[a1].getEmail());
+
+    ASSERT_CHAT_TEST(megaChatApi[a2],
+                     "MEGAChatApi instance has been removed for account " + std::to_string(a2+1) + ": " + mAccounts[a2].getEmail());
+
     MegaChatRoomList *chats = megaChatApi[a1]->getChatRooms();
 
     bool chatroomExist = false;

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -2979,13 +2979,6 @@ void MegaChatApiTest::makeContact(unsigned int a1, unsigned int a2)
 MegaChatHandle MegaChatApiTest::getGroupChatRoom(unsigned int a1, unsigned int a2,
                                                  MegaChatPeerList *peers, bool create)
 {
-    // --> Ensure MEGAChatApi instances are valid
-    ASSERT_CHAT_TEST(megaChatApi[a1],
-                     "MEGAChatApi instance has been removed for account " + std::to_string(a1+1) + ": " + mAccounts[a1].getEmail());
-
-    ASSERT_CHAT_TEST(megaChatApi[a2],
-                     "MEGAChatApi instance has been removed for account " + std::to_string(a2+1) + ": " + mAccounts[a2].getEmail());
-
     MegaChatRoomList *chats = megaChatApi[a1]->getChatRooms();
 
     bool chatroomExist = false;

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -389,6 +389,9 @@ void MegaChatApiTest::TearDown()
 #endif
             megaChatApi[i]->removeChatRequestListener(this);
             megaChatApi[i]->removeChatListener(this);
+
+            delete megaChatApi[i];
+            megaChatApi[i] = NULL;
         }
 
         if (megaApi[i])
@@ -417,12 +420,6 @@ void MegaChatApiTest::TearDown()
             delete megaApi[i];
             megaApi[i] = NULL;
         }
-    }
-
-    for (int i = 0; i < NUM_ACCOUNTS; i++)
-    {
-        delete megaChatApi[i];
-        megaChatApi[i] = NULL;
     }
 
     purgeLocalTree(LOCAL_PATH);
@@ -4117,10 +4114,7 @@ unsigned int TestChatRoomListener::getMegaChatApiIndex(MegaChatApi *api)
         }
     }
 
-    if (apiIndex == -1)
-    {
-        ASSERT_CHAT_TEST(false, "Instance of MegaChatApi not recognized");
-    }
+    assert(apiIndex != -1); // Instance of MegaChatApi not recognized
     return apiIndex;
 }
 

--- a/tests/sdk_test/sdk_test.h
+++ b/tests/sdk_test/sdk_test.h
@@ -54,7 +54,7 @@ private:
 // do-while is used to forze add semicolon at the end of sentence
 #define ASSERT_CHAT_TEST(a, msg) \
     do { \
-        if (!(a)) \
+        if (!(a) && !this->testHasFailed) \
         { \
             throw ChatTestException(__FILE__, __LINE__, msg); \
         } \
@@ -65,6 +65,7 @@ private:
     do { \
         try \
         { \
+            t.testHasFailed = false; \
             LOG_debug << "Initializing test environment: " << title; \
             t.SetUp(); \
             LOG_debug << "Launching test: " << title; \
@@ -78,6 +79,7 @@ private:
         } \
         catch(ChatTestException e) \
         { \
+            t.testHasFailed = true; \
             std::cout << e.what() << std::endl; \
             if (e.msg()) \
             { \
@@ -204,6 +206,7 @@ public:
 
     unsigned mOKTests;
     unsigned mFailedTests;
+    bool testHasFailed = false;
 
 private:
     int loadHistory(unsigned int accountIndex, megachat::MegaChatHandle chatid, TestChatRoomListener *chatroomListener);


### PR DESCRIPTION
Upon `onJoinComplete()`, the `findLastTextMessage()` marshalls (1) the decission to fetch more old messages if no last-message is available, and that marshall call does a new marshall (2) to fetch messages (send `HIST`). At the same time, the app may attempt to load history, which marshalls (3) another fetch of old messages too (send `HIST`).

The resulting execution order is 1, 3, 2, and that results on the reset of the flag `mServerOldHistCbEnabled` for the `HISTDONE` corresponding to 3 --> the `onHistoryDone()` for 3 is not called, but expected by the app.