### PR TITLE
Avoid ringing in again after reject a call

### DIFF
--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -7024,7 +7024,7 @@ void MegaChatCallHandler::onStateChange(uint8_t newState)
                 assert(call);
                 chatCall->setCaller(call->caller());
                 state = MegaChatCall::CALL_STATUS_RING_IN;
-                mHasBeenNotifiedRingin = true;
+                mHasBeenNotifiedRinging = true;
                 break;
             case rtcModule::ICall::kStateJoining:
                 state = MegaChatCall::CALL_STATUS_JOINING;
@@ -7257,9 +7257,9 @@ int64_t MegaChatCallHandler::getInitialTimeStamp()
     return chatCall->getInitialTimeStamp();
 }
 
-bool MegaChatCallHandler::hasBeenNotifiedRingin() const
+bool MegaChatCallHandler::hasBeenNotifiedRinging() const
 {
-    return mHasBeenNotifiedRingin;
+    return mHasBeenNotifiedRinging;
 }
 
 rtcModule::ICall *MegaChatCallHandler::getCall()

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -4587,7 +4587,6 @@ MegaChatCallPrivate::MegaChatCallPrivate(const MegaChatCallPrivate &call)
     this->participants = call.participants;
 
     this->termCode = call.termCode;
-    this->ignored = call.ignored;
     this->localTermCode = call.localTermCode;
     this->ringing = call.ringing;
 }
@@ -7025,6 +7024,7 @@ void MegaChatCallHandler::onStateChange(uint8_t newState)
                 assert(call);
                 chatCall->setCaller(call->caller());
                 state = MegaChatCall::CALL_STATUS_RING_IN;
+                mHasBeenNotifiedRingin = true;
                 break;
             case rtcModule::ICall::kStateJoining:
                 state = MegaChatCall::CALL_STATUS_JOINING;
@@ -7255,6 +7255,11 @@ int64_t MegaChatCallHandler::getInitialTimeStamp()
 {
     assert(chatCall);
     return chatCall->getInitialTimeStamp();
+}
+
+bool MegaChatCallHandler::hasBeenNotifiedRingin() const
+{
+    return mHasBeenNotifiedRingin;
 }
 
 rtcModule::ICall *MegaChatCallHandler::getCall()

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -564,7 +564,7 @@ public:
     virtual void setCallId(karere::Id callid);
     virtual void setInitialTimeStamp(int64_t timeStamp);
     virtual int64_t getInitialTimeStamp();
-    virtual bool hasBeenNotifiedRingin() const;
+    virtual bool hasBeenNotifiedRinging() const;
 
     rtcModule::ICall *getCall();
     MegaChatCallPrivate *getMegaChatCall();
@@ -573,7 +573,7 @@ private:
     MegaChatApiImpl *megaChatApi;
     rtcModule::ICall *call = NULL;
     MegaChatCallPrivate *chatCall = NULL;
-    bool mHasBeenNotifiedRingin = false;
+    bool mHasBeenNotifiedRinging = false;
 
     rtcModule::IVideoRenderer *localVideoReceiver;
 };

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -564,6 +564,7 @@ public:
     virtual void setCallId(karere::Id callid);
     virtual void setInitialTimeStamp(int64_t timeStamp);
     virtual int64_t getInitialTimeStamp();
+    virtual bool hasBeenNotifiedRingin() const;
 
     rtcModule::ICall *getCall();
     MegaChatCallPrivate *getMegaChatCall();
@@ -572,6 +573,7 @@ private:
     MegaChatApiImpl *megaChatApi;
     rtcModule::ICall *call = NULL;
     MegaChatCallPrivate *chatCall = NULL;
+    bool mHasBeenNotifiedRingin = false;
 
     rtcModule::IVideoRenderer *localVideoReceiver;
 };

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -379,7 +379,7 @@ void RtcModule::handleCallData(Chat &chat, Id chatid, Id userid, uint32_t client
             auto itCallHandler = mCallHandlers.find(chatid);
             // itCallHandler is created at updatePeerAvState
             assert(itCallHandler != mCallHandlers.end());
-            if (!itCallHandler->second->isParticipating(mKarereClient.myHandle()))
+            if (!itCallHandler->second->isParticipating(mKarereClient.myHandle()) && !itCallHandler->second->hasBeenNotifiedRingin())
             {
                 handleCallDataRequest(chat, userid, clientid, callid, avFlagsRemote);
             }

--- a/src/rtcModule/webrtc.h
+++ b/src/rtcModule/webrtc.h
@@ -218,6 +218,8 @@ public:
 
     virtual void setInitialTimeStamp(int64_t timeStamp) = 0;
     virtual int64_t getInitialTimeStamp() = 0;
+
+    virtual bool hasBeenNotifiedRingin() const = 0;
 };
 class IGlobalHandler
 {

--- a/src/rtcModule/webrtc.h
+++ b/src/rtcModule/webrtc.h
@@ -219,7 +219,7 @@ public:
     virtual void setInitialTimeStamp(int64_t timeStamp) = 0;
     virtual int64_t getInitialTimeStamp() = 0;
 
-    virtual bool hasBeenNotifiedRingin() const = 0;
+    virtual bool hasBeenNotifiedRinging() const = 0;
 };
 class IGlobalHandler
 {


### PR DESCRIPTION
The issue is: in a group with A, B and C
- A starts a call in the group chatroom
- B rejects the call
- C answers the call
Issue: B starts ringing again