### PR TITLE
Update presenced's documentation

### DIFF
--- a/src/presenced.h
+++ b/src/presenced.h
@@ -97,7 +97,10 @@ enum: uint8_t
       * C->S
       * After establishing a connection, the client identifies itself with an OPCODE_HELLO,
       * followed by a byte indicating the version of presenced protocol supported and the
-      * client's capabilities: an OR of push-enabled device (0x40) and/or WebRTC capabilities (0x80).
+      * client's capabilities, which is an OR of the following:
+      *     last-green support (0x20)
+      *     push-enabled device (0x40)
+      *     WebRTC capabilities (0x80)
       *
       * <protocolVersion> + <clientCapabilities>
       *
@@ -144,9 +147,15 @@ enum: uint8_t
       * @brief
       * S->C
       * Server sends own user's status (necessary for synchronization between different clients)
-      * and peers status requested by user
+      * and peers status allowed by other peers (including our user in their peerlist of SETPEERS...)
+      * The status is 8 bit little-endian word:
+      *     bits 0-3 (really bits 0 and 1): presence code
+      *     bits 4-7: flags
       *
-      * <status> <peerHandle>
+      * There is currently only one valid flag:
+      *     bit 7 (0x80): specifies whether any of the user's clients supports audio/video calls (see OP_HELLO)
+      *
+      * <status_and_flags> <peerHandle>
       */
     OP_PEERSTATUS = 6,
 

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -870,7 +870,7 @@ void MegaChatApiTest::TEST_SetOnlineStatus(unsigned int accountIndex)
     ASSERT_CHAT_TEST(waitForResponse(flagStatus), "Online status not received after " + std::to_string(maxTimeout) + " seconds");
 
     // Update autoway timeout to force to send values to the server
-    int64_t autowayTimeout = 60;
+    int64_t autowayTimeout = 5;
     if (megaChatApi[accountIndex]->getPresenceConfig()->getAutoawayTimeout() == autowayTimeout)
     {
         autowayTimeout ++;


### PR DESCRIPTION
Also adjust autoaway's timeout to a lower one. The heartbeat's delay is acceptable, so better to reduce the elapsed time of the test.