### PR TITLE
Do not wait for session ready in anonymous mode

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -591,6 +591,7 @@ Client::InitState Client::initWithAnonymousSession()
     mMyHandle = Id::null(); // anonymous mode should use ownHandle set to all zeros
     mUserAttrCache.reset(new UserAttrCache(*this));
     mChatdClient.reset(new chatd::Client(this));
+    mSessionReadyPromise.resolve();
 
     return mInitState;
 }
@@ -1025,11 +1026,6 @@ promise::Promise<void> Client::connect(Presence pres, bool isInBackground)
 
     assert(mConnState == kDisconnected);
 
-    if (anonymousMode())
-    {
-        return doConnect(pres, isInBackground);
-    }
-
     auto sessDone = mSessionReadyPromise.done();    // wait for fetchnodes completion
     switch (sessDone)
     {
@@ -1085,8 +1081,6 @@ promise::Promise<void> Client::doConnect(Presence pres, bool isInBackground)
         setConnState(kConnected);
         return ::promise::_Void();
     }
-
-    assert(mSessionReadyPromise.succeeded());
 
     mOwnNameAttrHandle = mUserAttrCache->getAttr(mMyHandle, USER_ATTR_FULLNAME, this,
     [](Buffer* buf, void* userp)


### PR DESCRIPTION
In Anonymous mode there's no login/fetchnodes, so there's no need to wait for the completion of fetchnodes in order to proceed with the connection to chatd.
The assertion in `connect()` was failing due to the unresolved promise, so better to keep it resolved from the scratch, which simplify the code.