### PR TITLE
Adjust deallocation of RtcModule resources

### DIFF
--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -647,6 +647,12 @@ string RtcModule::getDeviceInfo()
     return deviceType + ":" + version;
 }
 
+RtcModule::~RtcModule()
+{
+    mCalls.clear();
+    mWebRtcLogger.reset();
+}
+
 void RtcModule::stopCallsTimers(int shard)
 {
     for (auto callIt = mCalls.begin(); callIt != mCalls.end();)

--- a/src/rtcModule/webrtcPrivate.h
+++ b/src/rtcModule/webrtcPrivate.h
@@ -289,7 +289,7 @@ public:
 //==
     karere::WebRtcLogger *getWebRtcLogger();
     std::string getDeviceInfo();
-    virtual ~RtcModule() {}
+    virtual ~RtcModule();
 protected:
     const char* mStaticIceSever;
     karere::GelbProvider mIceServerProvider;


### PR DESCRIPTION
The dtor of the `Call` object, if called after the GC destroys the `WebRtcLogger` instance, will crash when accessing the logger. This PR aims to fix the segmentation fault.