### PR TITLE
Skip notification about deleted attachments in node history

### DIFF
--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -9124,6 +9124,10 @@ void MegaChatNodeHistoryHandler::onLoaded(Message *msg, Idx idx)
     MegaChatMessagePrivate *message = NULL;
     if (msg)
     {
+        if (msg->isDeleted())
+        {
+            return;
+        }
         message = new MegaChatMessagePrivate(*msg, Message::Status::kServerReceived, idx);
     }
 


### PR DESCRIPTION
When one attachment is loded in the node-history, but it's deleted afterwards, the deleted message is notified in `onAttachmentLoaded()` when it shouldn't. This commit aims to fix that behavior.