### PR TITLE
Keep `ProtocolHandler` alive

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1506,7 +1506,7 @@ Client::createGroupChat(std::vector<std::pair<uint64_t, chatd::Priv>> peers, boo
         if (publicchat)
         {
             createChatPromise = crypto->encryptUnifiedKeyForAllParticipants()
-            .then([wptr, this, sdkPeers, enctitleB64](chatd::KeyCommand *keyCmd) -> ApiPromise
+            .then([wptr, this, crypto, sdkPeers, enctitleB64](chatd::KeyCommand *keyCmd) -> ApiPromise
             {
                 mega::MegaStringMap *userKeyMap;
                 userKeyMap = mega::MegaStringMap::createInstance();


### PR DESCRIPTION
It may happen that encryption of the unified key for all participants require to fetch some keys from API. In that case, where keys are not cached yet, the `encryptUnifiedKeyForAllParticipants()` requires API
requests and, in the meantime, the number of references to the shared pointer `crypto` becomes 0. In result, the encryption's promise fail (due to `throwIfDeleted()`), so does the creation of the chatroom.