### PR TITLE
Added protection for potential issue with pending KeyCommand for already confirmed keys

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3497,6 +3497,10 @@ Idx Chat::msgConfirm(Id msgxid, Id msgid)
     // add message to history
     push_forward(msg);
     auto idx = mIdToIndexMap[msgid] = highnum();
+    if (msg->type == Message::kMsgAttachment)
+    {
+        mAttachmentNodes->addMessage(*msg, true, false);
+    }
     CALL_DB(addMsgToHistory, *msg, idx);
 
     assert(msg->backRefId);
@@ -3562,11 +3566,6 @@ Idx Chat::msgConfirm(Id msgxid, Id msgid)
         {
             manageRichLinkMessage(*msg);
         }
-    }
-
-    if (msg->type == Message::kMsgAttachment)
-    {
-        mAttachmentNodes->addMessage(*msg, true, false);
     }
 
     return idx;
@@ -4352,6 +4351,10 @@ void Chat::msgIncomingAfterDecrypt(bool isNew, bool isLocal, Message& msg, Idx i
         }
 
         verifyMsgOrder(msg, idx);
+        if (msg.type == Message::Type::kMsgAttachment)
+        {
+            mAttachmentNodes->addMessage(msg, isNew, false);
+        }
         CALL_DB(addMsgToHistory, msg, idx);
 
         if (mChatdClient.isMessageReceivedConfirmationActive() && !isGroup() &&
@@ -4421,11 +4424,6 @@ void Chat::msgIncomingAfterDecrypt(bool isNew, bool isLocal, Message& msg, Idx i
           //onLastTextMessageUpdated() with it
             notifyLastTextMsg();
         }
-    }
-
-    if (msg.type == Message::Type::kMsgAttachment)
-    {
-        mAttachmentNodes->addMessage(msg, isNew, false);
     }
 }
 

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3600,6 +3600,8 @@ void Chat::keyConfirm(KeyId keyxid, KeyId keyid)
         if (msg->keyid == localKeyid)
         {
             msg->keyid = keyid;
+            delete item.keyCmd;
+            item.keyCmd = NULL;
             count++;
         }
     }

--- a/src/chatdDb.h
+++ b/src/chatdDb.h
@@ -109,7 +109,9 @@ public:
 
     virtual int updateSendingItemsKeyid(chatd::KeyId localkeyid, chatd::KeyId keyid)
     {
-        mDb.query("update sending set keyid = ? where keyid = ? and chatid = ?", keyid, localkeyid, mChat.chatId());
+        mDb.query("update sending set keyid = ?, key_cmd = ? where keyid = ? and chatid = ?",
+                  keyid, StaticBuffer(nullptr, 0), localkeyid, mChat.chatId());
+
         return sqlite3_changes(mDb);
     }
 


### PR DESCRIPTION
This PR solve two issues:
 - Avoid discontinuity at node history. Add a message to node history as soon as possible just before adding to history table at data base
 - Added protection for potential issue with pending KeyCommand for already confirmed keys. Remove keyCommand from RAM and data base  when key is confirmed