### PR TITLE
Fix retrieval of usernames in preview mode

### DIFF
--- a/bindings/Objective-C/MEGAChatSdk.mm
+++ b/bindings/Objective-C/MEGAChatSdk.mm
@@ -520,20 +520,20 @@ static DelegateMEGAChatLoggerListener *externalLogger = NULL;
     self.megaChatApi->getUserEmail(userHandle);
 }
 
-- (void)userFirstnameByUserHandle:(uint64_t)userHandle delegate:(id<MEGAChatRequestDelegate>)delegate {
-    self.megaChatApi->getUserFirstname(userHandle, [self createDelegateMEGAChatRequestListener:delegate singleListener:YES]);
+- (void)userFirstnameByUserHandle:(uint64_t)userHandle authorizationToken:(NSString *)authorizationToken delegate:(id<MEGAChatRequestDelegate>)delegate {
+    self.megaChatApi->getUserFirstname(userHandle, authorizationToken.UTF8String, [self createDelegateMEGAChatRequestListener:delegate singleListener:YES]);
 }
 
-- (void)userFirstnameByUserHandle:(uint64_t)userHandle {
-    self.megaChatApi->getUserFirstname(userHandle);
+- (void)userFirstnameByUserHandle:(uint64_t)userHandle authorizationToken:(NSString *)authorizationToken {
+    self.megaChatApi->getUserFirstname(userHandle, authorizationToken.UTF8String);
 }
 
-- (void)userLastnameByUserHandle:(uint64_t)userHandle delegate:(id<MEGAChatRequestDelegate>)delegate {
-    self.megaChatApi->getUserLastname(userHandle, [self createDelegateMEGAChatRequestListener:delegate singleListener:YES]);
+- (void)userLastnameByUserHandle:(uint64_t)userHandle authorizationToken:(NSString *)authorizationToken delegate:(id<MEGAChatRequestDelegate>)delegate {
+    self.megaChatApi->getUserLastname(userHandle, authorizationToken.UTF8String, [self createDelegateMEGAChatRequestListener:delegate singleListener:YES]);
 }
 
-- (void)userLastnameByUserHandle:(uint64_t)userHandle {
-    self.megaChatApi->getUserLastname(userHandle);
+- (void)userLastnameByUserHandle:(uint64_t)userHandle authorizationToken:(NSString *)authorizationToken {
+    self.megaChatApi->getUserLastname(userHandle, authorizationToken.UTF8String);
 }
 
 - (NSString *)contacEmailByHandle:(uint64_t)userHandle {

--- a/bindings/java/nz/mega/sdk/MegaChatApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaChatApiJava.java
@@ -1151,8 +1151,8 @@ public class MegaChatApiJava {
      * @param userhandle Handle of the user whose name is requested.
      * @param listener MegaChatRequestListener to track this request
      */
-    public void getUserFirstname(long userhandle, MegaChatRequestListenerInterface listener){
-        megaChatApi.getUserFirstname(userhandle, createDelegateRequestListener(listener));
+    public void getUserFirstname(long userhandle, String cauth, MegaChatRequestListenerInterface listener){
+        megaChatApi.getUserFirstname(userhandle, cauth, createDelegateRequestListener(listener));
     }
 
     /**
@@ -1173,8 +1173,8 @@ public class MegaChatApiJava {
      * @param userhandle Handle of the user whose name is requested.
      * @param listener MegaChatRequestListener to track this request
      */
-    public void getUserLastname(long userhandle, MegaChatRequestListenerInterface listener){
-        megaChatApi.getUserLastname(userhandle, createDelegateRequestListener(listener));
+    public void getUserLastname(long userhandle, String cauth, MegaChatRequestListenerInterface listener){
+        megaChatApi.getUserLastname(userhandle, cauth, createDelegateRequestListener(listener));
     }
 
     /**

--- a/examples/megaclc/megaclc.cpp
+++ b/examples/megaclc/megaclc.cpp
@@ -874,7 +874,7 @@ void exec_getuserfirstname(ac::ACState& s)
         }
     });
 
-    g_chatApi->getUserFirstname(userhandle, &g_chatListener);
+    g_chatApi->getUserFirstname(userhandle, NULL, &g_chatListener);
 }
 
 
@@ -890,7 +890,7 @@ void exec_getuserlastname(ac::ACState& s)
         }
     });
 
-    g_chatApi->getUserLastname(userhandle, &g_chatListener);
+    g_chatApi->getUserLastname(userhandle, NULL, &g_chatListener);
 }
 
 void exec_getuseremail(ac::ACState& s)

--- a/examples/qtmegachatapi/MainWindow.cpp
+++ b/examples/qtmegachatapi/MainWindow.cpp
@@ -1016,7 +1016,7 @@ void MainWindow::onChatPresenceConfigUpdate(MegaChatApi *, MegaChatPresenceConfi
 
 void MainWindow::onChatPresenceLastGreen(MegaChatApi */*api*/, MegaChatHandle userhandle, int lastGreen)
 {
-    const char *firstname = mApp->getFirstname(userhandle);
+    const char *firstname = mApp->getFirstname(userhandle, NULL);
     if (!firstname)
     {
         firstname = mMegaApi->userHandleToBase64(userhandle);

--- a/examples/qtmegachatapi/MegaChatApplication.cpp
+++ b/examples/qtmegachatapi/MegaChatApplication.cpp
@@ -262,7 +262,7 @@ void MegaChatApplication::onChatNotification(MegaChatApi *, MegaChatHandle chati
     delete [] msgid;
 }
 
-const char *MegaChatApplication::getFirstname(MegaChatHandle uh)
+const char *MegaChatApplication::getFirstname(MegaChatHandle uh, const char *authorizationToken)
 {
     if (uh == mMegaChatApi->getMyUserHandle())
     {
@@ -282,7 +282,7 @@ const char *MegaChatApplication::getFirstname(MegaChatHandle uh)
 
     if (!mFirstnameFetching[uh])
     {
-        mMegaChatApi->getUserFirstname(uh);
+        mMegaChatApi->getUserFirstname(uh, authorizationToken);
         mFirstnameFetching[uh] = true;
     }
 

--- a/examples/qtmegachatapi/MegaChatApplication.h
+++ b/examples/qtmegachatapi/MegaChatApplication.h
@@ -42,7 +42,7 @@ class MegaChatApplication : public QApplication,
         virtual void onUsersUpdate(::mega::MegaApi *api, ::mega::MegaUserList *userList);
         virtual void onChatNotification(megachat::MegaChatApi *api, megachat::MegaChatHandle chatid, megachat::MegaChatMessage *msg);
 
-        const char *getFirstname(megachat::MegaChatHandle uh);
+        const char *getFirstname(megachat::MegaChatHandle uh, const char *authorizationToken);
 
         bool isStagingEnabled();
         void enableStaging(bool enable);

--- a/examples/qtmegachatapi/chatItemWidget.cpp
+++ b/examples/qtmegachatapi/chatItemWidget.cpp
@@ -120,7 +120,7 @@ void ChatItemWidget::updateToolTip(const megachat::MegaChatListItem *item, const
         else
         {
             const char *msgAuthor = getLastMessageSenderName(lastMessageSender);
-            if (msgAuthor || (msgAuthor = mMainWin->mApp->getFirstname(lastMessageSender)))
+            if (msgAuthor || (msgAuthor = mMainWin->mApp->getFirstname(lastMessageSender, NULL)))
             {
                 mLastMsgAuthor.assign(msgAuthor);
             }

--- a/examples/qtmegachatapi/chatItemWidget.cpp
+++ b/examples/qtmegachatapi/chatItemWidget.cpp
@@ -120,7 +120,8 @@ void ChatItemWidget::updateToolTip(const megachat::MegaChatListItem *item, const
         else
         {
             const char *msgAuthor = getLastMessageSenderName(lastMessageSender);
-            if (msgAuthor || (msgAuthor = mMainWin->mApp->getFirstname(lastMessageSender, NULL)))
+            const char *autorizationToken = chatRoom->getAuthorizationToken();
+            if (msgAuthor || (msgAuthor = mMainWin->mApp->getFirstname(lastMessageSender, autorizationToken)))
             {
                 mLastMsgAuthor.assign(msgAuthor);
             }
@@ -129,6 +130,7 @@ void ChatItemWidget::updateToolTip(const megachat::MegaChatListItem *item, const
                 mLastMsgAuthor = "Loading firstname...";
             }
             delete [] msgAuthor;
+            delete [] autorizationToken;
         }
     }
     switch (lastMessageType)

--- a/examples/qtmegachatapi/chatMessage.cpp
+++ b/examples/qtmegachatapi/chatMessage.cpp
@@ -449,7 +449,7 @@ void ChatMessage::setAuthor(const char *author)
         megachat::MegaChatRoom *chatRoom = megaChatApi->getChatRoom(mChatId);
         const char *msgAuthor = chatRoom->getPeerFirstnameByHandle(mMessage->getUserHandle());
         const char *autorizationToken = chatRoom->getAuthorizationToken();
-        if (msgAuthor)
+        if (msgAuthor && strlen(msgAuthor) > 0)
         {
             ui->mAuthorDisplay->setText(tr(msgAuthor));
         }

--- a/examples/qtmegachatapi/chatMessage.cpp
+++ b/examples/qtmegachatapi/chatMessage.cpp
@@ -448,11 +448,12 @@ void ChatMessage::setAuthor(const char *author)
     {
         megachat::MegaChatRoom *chatRoom = megaChatApi->getChatRoom(mChatId);
         const char *msgAuthor = chatRoom->getPeerFirstnameByHandle(mMessage->getUserHandle());
+        const char *autorizationToken = chatRoom->getAuthorizationToken();
         if (msgAuthor)
         {
             ui->mAuthorDisplay->setText(tr(msgAuthor));
         }
-        else if ((msgAuthor = mChatWindow->mMainWin->mApp->getFirstname(uh)))
+        else if ((msgAuthor = mChatWindow->mMainWin->mApp->getFirstname(uh, autorizationToken)))
         {
             ui->mAuthorDisplay->setText(tr(msgAuthor));
             delete [] msgAuthor;
@@ -462,6 +463,7 @@ void ChatMessage::setAuthor(const char *author)
             ui->mAuthorDisplay->setText(tr("Loading firstname..."));
         }
         delete chatRoom;
+        delete []autorizationToken;
     }
 }
 

--- a/examples/qtmegachatapi/contactItemWidget.cpp
+++ b/examples/qtmegachatapi/contactItemWidget.cpp
@@ -22,7 +22,7 @@ ContactItemWidget::ContactItemWidget(QWidget *parent, MainWindow *mainWin, megac
     ui->mName->setText(contactEmail);
     ui->mAvatar->setText(QString(text[0].toUpper()));
 
-    const char *firstname = mMainWin->mApp->getFirstname(contact->getHandle());
+    const char *firstname = mMainWin->mApp->getFirstname(contact->getHandle(), NULL);
     if (firstname)
     {
         updateTitle(firstname);

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1909,6 +1909,7 @@ void GroupChatRoom::initWithChatd(bool isPublic, std::shared_ptr<std::string> un
     }
 
     createChatdChat(users, isPublic, unifiedKey, isUnifiedKeyEncrypted, ph);
+    mChadChatInitialized = true;
 }
 
 void GroupChatRoom::connect(const char *url)
@@ -3275,7 +3276,7 @@ GroupChatRoom::Member::Member(GroupChatRoom& aRoom, const uint64_t& user, chatd:
         {
             self->mRoom.makeTitleFromMemberNames();
         }
-    });
+    }, false, mRoom.mChadChatInitialized ? mRoom.chat().getPublicHandle() : karere::Id::inval().val);
 
     if (!mRoom.parent.mKarereClient.anonymousMode())
     {

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1616,6 +1616,11 @@ ApiPromise ChatRoom::requestRevokeAccess(mega::MegaNode *node, mega::MegaHandle 
     return parent.mKarereClient.api.call(&::mega::MegaApi::removeAccessInChat, chatid(), node, userHandle);
 }
 
+bool ChatRoom::isChatdChatInitialized()
+{
+    return mChat;
+}
+
 strongvelope::ProtocolHandler* Client::newStrongvelope(karere::Id chatid, bool isPublic,
         std::shared_ptr<std::string> unifiedKey, int isUnifiedKeyEncrypted, karere::Id ph)
 {
@@ -3130,11 +3135,6 @@ void GroupChatRoom::initChatTitle(const std::string &title, int isTitleEncrypted
 
         makeTitleFromMemberNames();
     });
-}
-
-bool GroupChatRoom::isChatdChatInitialized()
-{
-    return mChat;
 }
 
 void GroupChatRoom::clearTitle()

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1909,7 +1909,6 @@ void GroupChatRoom::initWithChatd(bool isPublic, std::shared_ptr<std::string> un
     }
 
     createChatdChat(users, isPublic, unifiedKey, isUnifiedKeyEncrypted, ph);
-    mChadChatInitialized = true;
 }
 
 void GroupChatRoom::connect(const char *url)
@@ -3133,6 +3132,11 @@ void GroupChatRoom::initChatTitle(const std::string &title, int isTitleEncrypted
     });
 }
 
+bool GroupChatRoom::isChatdChatInitialized()
+{
+    return mChat;
+}
+
 void GroupChatRoom::clearTitle()
 {
     makeTitleFromMemberNames();
@@ -3276,7 +3280,7 @@ GroupChatRoom::Member::Member(GroupChatRoom& aRoom, const uint64_t& user, chatd:
         {
             self->mRoom.makeTitleFromMemberNames();
         }
-    }, false, mRoom.mChadChatInitialized ? mRoom.chat().getPublicHandle() : karere::Id::inval().val);
+    }, false, mRoom.isChatdChatInitialized() ? mRoom.chat().getPublicHandle() : karere::Id::inval().val);
 
     if (!mRoom.parent.mKarereClient.anonymousMode())
     {

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -319,7 +319,6 @@ protected:
     std::string mEncryptedTitle; //holds the last encrypted title (the "ct" from API)
     IApp::IGroupChatListItem* mRoomGui;
     promise::Promise<void> mMemberNamesResolved;
-    bool mChadChatInitialized = false;
 
     int mNumPeers = 0; //Only for public chats in preview mode
 
@@ -341,6 +340,7 @@ protected:
     virtual void connect(const char *url = NULL);
     promise::Promise<void> memberNamesResolved() const;
     void initChatTitle(const std::string &title, int isTitleEncrypted, bool saveToDb = false);
+    bool isChatdChatInitialized();
 
     friend class ChatRoomList;
     friend class Member;

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -80,6 +80,7 @@ protected:
     void onMessageTimestamp(uint32_t ts);
     ApiPromise requestGrantAccess(mega::MegaNode *node, mega::MegaHandle userHandle);
     ApiPromise requestRevokeAccess(mega::MegaNode *node, mega::MegaHandle userHandle);
+    bool isChatdChatInitialized();
 
 public:
     virtual bool previewMode() const { return false; }
@@ -340,7 +341,6 @@ protected:
     virtual void connect(const char *url = NULL);
     promise::Promise<void> memberNamesResolved() const;
     void initChatTitle(const std::string &title, int isTitleEncrypted, bool saveToDb = false);
-    bool isChatdChatInitialized();
 
     friend class ChatRoomList;
     friend class Member;

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -319,6 +319,7 @@ protected:
     std::string mEncryptedTitle; //holds the last encrypted title (the "ct" from API)
     IApp::IGroupChatListItem* mRoomGui;
     promise::Promise<void> mMemberNamesResolved;
+    bool mChadChatInitialized = false;
 
     int mNumPeers = 0; //Only for public chats in preview mode
 

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -777,7 +777,7 @@ protected:
     // last text message stuff
     LastTextMsgState mLastTextMsg;
     // crypto stuff
-    ICrypto* mCrypto;
+    ICrypto* mCrypto = NULL;
     /** If crypto can't decrypt immediately, we set this flag and only the plaintext
      * path of further messages to be sent is written to db, without calling encrypt().
      * Once encryption is finished, this flag is cleared, and all queued unencrypted

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -402,14 +402,14 @@ int MegaChatApi::getBackgroundStatus()
     return pImpl->getBackgroundStatus();
 }
 
-void MegaChatApi::getUserFirstname(MegaChatHandle userhandle, MegaChatRequestListener *listener)
+void MegaChatApi::getUserFirstname(MegaChatHandle userhandle, const char *authorizationToken, MegaChatRequestListener *listener)
 {
-    pImpl->getUserFirstname(userhandle, listener);
+    pImpl->getUserFirstname(userhandle, authorizationToken, listener);
 }
 
-void MegaChatApi::getUserLastname(MegaChatHandle userhandle, MegaChatRequestListener *listener)
+void MegaChatApi::getUserLastname(MegaChatHandle userhandle, const char *authorizationToken, MegaChatRequestListener *listener)
 {
-    pImpl->getUserLastname(userhandle, listener);
+    pImpl->getUserLastname(userhandle, authorizationToken, listener);
 }
 
 void MegaChatApi::getUserEmail(MegaChatHandle userhandle, MegaChatRequestListener *listener)

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2618,15 +2618,17 @@ public:
      * The associated request type with this request is MegaChatRequest::TYPE_GET_FIRSTNAME
      * Valid data in the MegaChatRequest object received on callbacks:
      * - MegaChatRequest::getUserHandle - Returns the handle of the user
+     * - MegaChatRequest::getLink - Returns the authorization token
      *
      * Valid data in the MegaChatRequest object received in onRequestFinish when the error code
      * is MegaError::ERROR_OK:
      * - MegaChatRequest::getText - Returns the firstname of the user
      *
      * @param userhandle Handle of the user whose name is requested.
+     * @param authorizationToken Authorization token for the chatroom or NULL if chatroom doesn't have authorization token
      * @param listener MegaChatRequestListener to track this request
      */
-    void getUserFirstname(MegaChatHandle userhandle, MegaChatRequestListener *listener = NULL);
+    void getUserFirstname(MegaChatHandle userhandle, const char *authorizationToken, MegaChatRequestListener *listener = NULL);
 
     /**
      * @brief Returns the current lastname of the user
@@ -2637,15 +2639,17 @@ public:
      * The associated request type with this request is MegaChatRequest::TYPE_GET_LASTNAME
      * Valid data in the MegaChatRequest object received on callbacks:
      * - MegaChatRequest::getUserHandle - Returns the handle of the user
+     * - MegaChatRequest::getLink - Returns the authorization token
      *
      * Valid data in the MegaChatRequest object received in onRequestFinish when the error code
      * is MegaError::ERROR_OK:
      * - MegaChatRequest::getText - Returns the lastname of the user
      *
      * @param userhandle Handle of the user whose name is requested.
+     * @param authorizationToken Authorization token for the chatroom or NULL if chatroom doesn't have authorization token
      * @param listener MegaChatRequestListener to track this request
      */
-    void getUserLastname(MegaChatHandle userhandle, MegaChatRequestListener *listener = NULL);
+    void getUserLastname(MegaChatHandle userhandle, const char *authorizationToken, MegaChatRequestListener *listener = NULL);
 
     /**
      * @brief Returns the current email address of the contact

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2618,7 +2618,8 @@ public:
      * The associated request type with this request is MegaChatRequest::TYPE_GET_FIRSTNAME
      * Valid data in the MegaChatRequest object received on callbacks:
      * - MegaChatRequest::getUserHandle - Returns the handle of the user
-     * - MegaChatRequest::getLink - Returns the authorization token
+     * - MegaChatRequest::getLink - Returns the authorization token. Previewers of chatlinks are not allowed
+     * to retrieve user attributes like firstname or lastname, unless they provide a valid authorization token.
      *
      * Valid data in the MegaChatRequest object received in onRequestFinish when the error code
      * is MegaError::ERROR_OK:
@@ -2639,7 +2640,8 @@ public:
      * The associated request type with this request is MegaChatRequest::TYPE_GET_LASTNAME
      * Valid data in the MegaChatRequest object received on callbacks:
      * - MegaChatRequest::getUserHandle - Returns the handle of the user
-     * - MegaChatRequest::getLink - Returns the authorization token
+     * - MegaChatRequest::getLink - Returns the authorization token. Previewers of chatlinks are not allowed
+     * to retrieve user attributes like firstname or lastname, unless they provide a valid authorization token.
      *
      * Valid data in the MegaChatRequest object received in onRequestFinish when the error code
      * is MegaError::ERROR_OK:

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2625,7 +2625,7 @@ public:
      * - MegaChatRequest::getText - Returns the firstname of the user
      *
      * @param userhandle Handle of the user whose name is requested.
-     * @param authorizationToken Authorization token for the chatroom or NULL if chatroom doesn't have authorization token
+     * @param authorizationToken This value can be obtained with MegaChatRoom::getAuthorizationToken
      * @param listener MegaChatRequestListener to track this request
      */
     void getUserFirstname(MegaChatHandle userhandle, const char *authorizationToken, MegaChatRequestListener *listener = NULL);
@@ -2646,7 +2646,7 @@ public:
      * - MegaChatRequest::getText - Returns the lastname of the user
      *
      * @param userhandle Handle of the user whose name is requested.
-     * @param authorizationToken Authorization token for the chatroom or NULL if chatroom doesn't have authorization token
+     * @param authorizationToken This value can be obtained with MegaChatRoom::getAuthorizationToken
      * @param listener MegaChatRequestListener to track this request
      */
     void getUserLastname(MegaChatHandle userhandle, const char *authorizationToken, MegaChatRequestListener *listener = NULL);

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1082,7 +1082,7 @@ void MegaChatApiImpl::sendPendingRequests()
         {
             MegaChatHandle uh = request->getUserHandle();
             const char* publicHandle = request->getLink();
-            MegaChatHandle ph = publicHandle ? karere::Id(publicHandle).val : MEGACHAT_INVALID_HANDLE;
+            MegaChatHandle ph = publicHandle ? karere::Id(publicHandle, strlen(publicHandle)).val : MEGACHAT_INVALID_HANDLE;
 
             mClient->userAttrCache().getAttr(uh, MegaApi::USER_ATTR_FIRSTNAME, ph)
             .then([request, this](Buffer *data)
@@ -1105,7 +1105,7 @@ void MegaChatApiImpl::sendPendingRequests()
         {
             MegaChatHandle uh = request->getUserHandle();
             const char* publicHandle = request->getLink();
-            MegaChatHandle ph = publicHandle ? karere::Id(publicHandle).val : MEGACHAT_INVALID_HANDLE;
+            MegaChatHandle ph = publicHandle ? karere::Id(publicHandle, strlen(publicHandle)).val : MEGACHAT_INVALID_HANDLE;
 
             mClient->userAttrCache().getAttr(uh, MegaApi::USER_ATTR_LASTNAME, ph)
             .then([request, this](Buffer *data)

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1082,12 +1082,7 @@ void MegaChatApiImpl::sendPendingRequests()
         {
             MegaChatHandle uh = request->getUserHandle();
             const char* publicHandle = request->getLink();
-            MegaChatHandle ph = INVALID_HANDLE;
-            if (publicHandle)
-            {
-                size_t b64len = strlen(publicHandle);
-                base64urldecode(publicHandle, b64len, &ph, sizeof(ph));
-            }
+            MegaChatHandle ph = publicHandle ? karere::Id(publicHandle).val : MEGACHAT_INVALID_HANDLE;
 
             mClient->userAttrCache().getAttr(uh, MegaApi::USER_ATTR_FIRSTNAME, ph)
             .then([request, this](Buffer *data)
@@ -1110,12 +1105,7 @@ void MegaChatApiImpl::sendPendingRequests()
         {
             MegaChatHandle uh = request->getUserHandle();
             const char* publicHandle = request->getLink();
-            MegaChatHandle ph = INVALID_HANDLE;
-            if (publicHandle)
-            {
-                size_t b64len = strlen(publicHandle);
-                base64urldecode(publicHandle, b64len, &ph, sizeof(ph));
-            }
+            MegaChatHandle ph = publicHandle ? karere::Id(publicHandle).val : MEGACHAT_INVALID_HANDLE;
 
             mClient->userAttrCache().getAttr(uh, MegaApi::USER_ATTR_LASTNAME, ph)
             .then([request, this](Buffer *data)

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -6476,7 +6476,7 @@ const char *MegaChatRoomPrivate::getAuthorizationToken() const
 {
     if (mAuthToken.isValid())
     {
-        return strdup(mAuthToken.toString(Id::CHATLINKHANDLE).c_str());
+        return MegaApi::strdup(mAuthToken.toString(Id::CHATLINKHANDLE).c_str());
     }
 
     return NULL;

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1081,8 +1081,15 @@ void MegaChatApiImpl::sendPendingRequests()
         case MegaChatRequest::TYPE_GET_FIRSTNAME:
         {
             MegaChatHandle uh = request->getUserHandle();
+            const char* publicHandle = request->getLink();
+            MegaChatHandle ph = INVALID_HANDLE;
+            if (publicHandle)
+            {
+                size_t b64len = strlen(publicHandle);
+                base64urldecode(publicHandle, b64len, &ph, sizeof(ph));
+            }
 
-            mClient->userAttrCache().getAttr(uh, MegaApi::USER_ATTR_FIRSTNAME)
+            mClient->userAttrCache().getAttr(uh, MegaApi::USER_ATTR_FIRSTNAME, ph)
             .then([request, this](Buffer *data)
             {
                 MegaChatErrorPrivate *megaChatError = new MegaChatErrorPrivate(MegaChatError::ERROR_OK);
@@ -1102,8 +1109,15 @@ void MegaChatApiImpl::sendPendingRequests()
         case MegaChatRequest::TYPE_GET_LASTNAME:
         {
             MegaChatHandle uh = request->getUserHandle();
+            const char* publicHandle = request->getLink();
+            MegaChatHandle ph = INVALID_HANDLE;
+            if (publicHandle)
+            {
+                size_t b64len = strlen(publicHandle);
+                base64urldecode(publicHandle, b64len, &ph, sizeof(ph));
+            }
 
-            mClient->userAttrCache().getAttr(uh, MegaApi::USER_ATTR_LASTNAME)
+            mClient->userAttrCache().getAttr(uh, MegaApi::USER_ATTR_LASTNAME, ph)
             .then([request, this](Buffer *data)
             {
                 MegaChatErrorPrivate *megaChatError = new MegaChatErrorPrivate(MegaChatError::ERROR_OK);
@@ -2525,18 +2539,20 @@ int MegaChatApiImpl::getBackgroundStatus()
     return status;
 }
 
-void MegaChatApiImpl::getUserFirstname(MegaChatHandle userhandle, MegaChatRequestListener *listener)
+void MegaChatApiImpl::getUserFirstname(MegaChatHandle userhandle, const char *authorizationToken, MegaChatRequestListener *listener)
 {
     MegaChatRequestPrivate *request = new MegaChatRequestPrivate(MegaChatRequest::TYPE_GET_FIRSTNAME, listener);
     request->setUserHandle(userhandle);
+    request->setLink(authorizationToken);
     requestQueue.push(request);
     waiter->notify();
 }
 
-void MegaChatApiImpl::getUserLastname(MegaChatHandle userhandle, MegaChatRequestListener *listener)
+void MegaChatApiImpl::getUserLastname(MegaChatHandle userhandle, const char *authorizationToken, MegaChatRequestListener *listener)
 {
     MegaChatRequestPrivate *request = new MegaChatRequestPrivate(MegaChatRequest::TYPE_GET_LASTNAME, listener);
     request->setUserHandle(userhandle);
+    request->setLink(authorizationToken);
     requestQueue.push(request);
     waiter->notify();
 }

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -1046,8 +1046,8 @@ public:
     void setBackgroundStatus(bool background, MegaChatRequestListener *listener = NULL);
     int getBackgroundStatus();
 
-    void getUserFirstname(MegaChatHandle userhandle, MegaChatRequestListener *listener = NULL);
-    void getUserLastname(MegaChatHandle userhandle, MegaChatRequestListener *listener = NULL);
+    void getUserFirstname(MegaChatHandle userhandle, const char *authorizationToken, MegaChatRequestListener *listener = NULL);
+    void getUserLastname(MegaChatHandle userhandle, const char *authorizationToken, MegaChatRequestListener *listener = NULL);
     void getUserEmail(MegaChatHandle userhandle, MegaChatRequestListener *listener = NULL);
     char *getContactEmail(MegaChatHandle userhandle);
     MegaChatHandle getUserHandleByEmail(const char *email);

--- a/src/strongvelope/strongvelope.cpp
+++ b/src/strongvelope/strongvelope.cpp
@@ -1137,7 +1137,7 @@ promise::Promise<Message*> ProtocolHandler::handleManagementMessage(
 
 void ProtocolHandler::fetchUserKeys(karere::Id userid)
 {
-    mUserAttrCache.getAttr(userid, ::mega::MegaApi::USER_ATTR_ED25519_PUBLIC_KEY, nullptr, nullptr, mPh);
+    mUserAttrCache.getAttr(userid, ::mega::MegaApi::USER_ATTR_ED25519_PUBLIC_KEY, nullptr, nullptr, false, mPh);
 
     if (!previewMode())
     {

--- a/src/strongvelope/strongvelope.h
+++ b/src/strongvelope/strongvelope.h
@@ -409,11 +409,7 @@ protected:
     chatd::Message* legacyMsgDecrypt(const std::shared_ptr<ParsedMessage>& parsedMsg,
         chatd::Message* msg, const SendKey& key);
 
-
-    /**
-     * @brief Load public attributes when we are in preview mode.
-     */
-    void prefetchAnonymousAttributes(karere::Id userId);
+    void fetchUserKeys(karere::Id userid);
 
 // legacy RSA encryption methods
     promise::Promise<std::shared_ptr<Buffer>>

--- a/src/userAttrCache.cpp
+++ b/src/userAttrCache.cpp
@@ -185,7 +185,7 @@ UserAttrCache::~UserAttrCache()
 
 void UserAttrCache::dbWrite(UserAttrPair key, const Buffer& data)
 {
-    if (key.mPh.inval())  // Don't insert elements in attribute cache at preview mode
+    if (key.mPh.isValid())  // Don't insert elements in attribute cache at preview mode
     {
         return;
     }
@@ -198,7 +198,7 @@ void UserAttrCache::dbWrite(UserAttrPair key, const Buffer& data)
 
 void UserAttrCache::dbWriteNull(UserAttrPair key)
 {
-    if (key.mPh.inval())  // Don't insert elements in attribute cache at preview mode
+    if (key.mPh.isValid())  // Don't insert elements in attribute cache at preview mode
     {
         return;
     }

--- a/src/userAttrCache.cpp
+++ b/src/userAttrCache.cpp
@@ -185,6 +185,11 @@ UserAttrCache::~UserAttrCache()
 
 void UserAttrCache::dbWrite(UserAttrPair key, const Buffer& data)
 {
+    if (key.mPh.inval())  // Don't insert elements in attribute cache at preview mode
+    {
+        return;
+    }
+
     mClient.db.query(
         "insert or replace into userattrs(userid, type, data) values(?,?,?)",
         key.user.val, key.attrType, data);
@@ -193,6 +198,11 @@ void UserAttrCache::dbWrite(UserAttrPair key, const Buffer& data)
 
 void UserAttrCache::dbWriteNull(UserAttrPair key)
 {
+    if (key.mPh.inval())  // Don't insert elements in attribute cache at preview mode
+    {
+        return;
+    }
+
     mClient.db.query(
         "insert or replace into userattrs(userid, type, data) values(?,?,NULL)",
         key.user, key.attrType);
@@ -467,9 +477,10 @@ void UserAttrCache::fetchUserFullName(UserAttrPair key, std::shared_ptr<UserAttr
         std::string firstname;
         std::string lastname;
     };
+
     auto ctx = std::make_shared<Context>();
     auto wptr = weakHandle();
-    auto pms1 = getAttr(key.user, ::mega::MegaApi::USER_ATTR_FIRSTNAME)
+    auto pms1 = getAttr(key.user, ::mega::MegaApi::USER_ATTR_FIRSTNAME, key.mPh)
     .then([ctx](Buffer* data)
     {
         if (!data->empty())
@@ -480,7 +491,7 @@ void UserAttrCache::fetchUserFullName(UserAttrPair key, std::shared_ptr<UserAttr
         return _Void();
     });
 
-    auto pms2 = getAttr(key.user, ::mega::MegaApi::USER_ATTR_LASTNAME)
+    auto pms2 = getAttr(key.user, ::mega::MegaApi::USER_ATTR_LASTNAME, key.mPh)
     .then([ctx](Buffer* data)
     {
         if (!data->empty())

--- a/src/userAttrCache.h
+++ b/src/userAttrCache.h
@@ -64,7 +64,9 @@ struct UserAttrPair
     Id mPh; // only valid in anonymous preview mode to retrieve user-attributes without valid session
     bool operator<(const UserAttrPair& other) const
     {
-        if (user == other.user)
+        if (user == other.user && attrType == other.attrType)
+            return mPh < other.mPh;
+        else if (user == other.user)
             return attrType < other.attrType;
         else
             return user < other.user;

--- a/tests/sdk_test/sdk_test.cpp
+++ b/tests/sdk_test/sdk_test.cpp
@@ -988,13 +988,13 @@ void MegaChatApiTest::TEST_GetChatRoomsAndMessages(unsigned int accountIndex)
                 MegaChatHandle uh = chatroom->getPeerHandle(i);
 
                 bool *flagNameReceived = &requestFlagsChat[accountIndex][MegaChatRequest::TYPE_GET_FIRSTNAME]; *flagNameReceived = false; mChatFirstname = "";
-                megaChatApi[accountIndex]->getUserFirstname(uh);
+                megaChatApi[accountIndex]->getUserFirstname(uh, NULL);
                 ASSERT_CHAT_TEST(waitForResponse(flagNameReceived), "Failed to retrieve firstname after " + std::to_string(maxTimeout) + " seconds");
                 ASSERT_CHAT_TEST(!lastErrorChat[accountIndex], "Failed to retrieve firstname. Error: " + lastErrorMsgChat[accountIndex] + " (" + std::to_string(lastErrorChat[accountIndex]) + ")");
                 buffer << "Peer firstname (" << uh << "): " << mChatFirstname << " (len: " << mChatFirstname.length() << ")" << endl;
 
                 flagNameReceived = &requestFlagsChat[accountIndex][MegaChatRequest::TYPE_GET_LASTNAME]; *flagNameReceived = false; mChatLastname = "";
-                megaChatApi[0]->getUserLastname(uh);
+                megaChatApi[0]->getUserLastname(uh, NULL);
                 ASSERT_CHAT_TEST(waitForResponse(flagNameReceived), "Failed to retrieve lastname after " + std::to_string(maxTimeout) + " seconds");
                 ASSERT_CHAT_TEST(!lastErrorChat[accountIndex], "Failed to retrieve lastname. Error: " + lastErrorMsgChat[accountIndex] + " (" + std::to_string(lastErrorChat[accountIndex]) + ")");
                 buffer << "Peer lastname (" << uh << "): " << mChatLastname << " (len: " << mChatLastname.length() << ")" << endl;


### PR DESCRIPTION
In preview mode the unified key is used to encrypt messages, so the public Cu25519 key of senders is not needed, only the public Ed25519 to verify the signature.
(firstname/lastname will be requested at Member's ctor and, for ex-participants, app will request them on demand through MegaChatApi::getUserFirstname/Lastname(userid, ph))