### PR TITLE
Avoid notify old messages to apps during login process

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1480,15 +1480,15 @@ HistSource Chat::getHistoryFromDbOrServer(unsigned count)
             return kHistSourceNotLoggedIn;
         }
 
+        if (!isLoggedIn())
+            return kHistSourceNotLoggedIn;
+
         if (mServerFetchState & kHistOldFlag)
         {
             CHATID_LOG_DEBUG("getHistoryFromDbOrServer: Need more history, and server history fetch is already in progress, will get next messages from there");
         }
         else
         {
-            if (!isLoggedIn())
-                return kHistSourceNotLoggedIn;
-
             auto wptr = weakHandle();
             marshallCall([wptr, this, count]()
             {


### PR DESCRIPTION
IOS and Android apps reported that they receive duplicated messages. The issue was that karere is notifying messages at first join and algorithm doesn't handle that case.