### PR TITLE
Report failure upon set background status

### DIFF
--- a/examples/qtmegachatapi/MainWindow.cpp
+++ b/examples/qtmegachatapi/MainWindow.cpp
@@ -503,6 +503,12 @@ void MainWindow::on_bSettings_clicked()
     actUseStaging->setCheckable(true);
     actUseStaging->setChecked(mApp->isStagingEnabled());
 
+    menu.addSeparator();
+    auto actBackground = menu.addAction("Background status");
+    connect(actBackground, SIGNAL(toggled(bool)), this, SLOT(onBackgroundStatusClicked(bool)));
+    actBackground->setCheckable(true);
+    actBackground->setChecked(mMegaChatApi->getBackgroundStatus());
+
     QPoint pos = ui->bSettings->pos();
     pos.setX(pos.x() + ui->bSettings->width());
     pos.setY(pos.y() + ui->bSettings->height());
@@ -1198,4 +1204,9 @@ void MainWindow::onlastGreenVisibleClicked()
 void MainWindow::onUseApiStagingClicked(bool enable)
 {
     mApp->enableStaging(enable);
+}
+
+void MainWindow::onBackgroundStatusClicked(bool status)
+{
+    mMegaChatApi->setBackgroundStatus(status);
 }

--- a/examples/qtmegachatapi/MainWindow.h
+++ b/examples/qtmegachatapi/MainWindow.h
@@ -203,6 +203,7 @@ class MainWindow :
         void onlastGreenVisibleClicked();
         void onReconnect(bool disconnect);
         void onUseApiStagingClicked(bool);
+        void onBackgroundStatusClicked(bool status);
 
     signals:
         void esidLogout();

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -344,6 +344,15 @@ void Client::retryPendingConnections(bool disconnect, bool refreshURL)
     }
 }
 
+promise::Promise<void> Client::notifyUserStatus(bool background)
+{
+    if (mChatdClient)
+    {
+        return mChatdClient->notifyUserStatus(background);
+    }
+    return promise::Error("Chatd client not initialized yet");
+}
+
 promise::Promise<ReqResult> Client::openChatPreview(uint64_t publicHandle)
 {
     auto wptr = weakHandle();
@@ -1302,25 +1311,6 @@ void Client::updateAndNotifyLastGreen(Id userid)
 void Client::onConnStateChange(presenced::Client::ConnState /*state*/)
 {
 
-}
-
-bool Client::notifyUserIdle()
-{
-    if (mChatdClient)
-    {
-        return mChatdClient->notifyUserIdle();
-    }
-
-    return false;
-}
-bool Client::notifyUserActive()
-{
-    if (mChatdClient)
-    {
-        return mChatdClient->notifyUserActive();
-    }
-
-    return false;
 }
 
 void Client::terminate(bool deleteDb)

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1304,19 +1304,23 @@ void Client::onConnStateChange(presenced::Client::ConnState /*state*/)
 
 }
 
-void Client::notifyUserIdle()
+bool Client::notifyUserIdle()
 {
     if (mChatdClient)
     {
-        mChatdClient->notifyUserIdle();
+        return mChatdClient->notifyUserIdle();
     }
+
+    return false;
 }
-void Client::notifyUserActive()
+bool Client::notifyUserActive()
 {
     if (mChatdClient)
     {
-        mChatdClient->notifyUserActive();
+        return mChatdClient->notifyUserActive();
     }
+
+    return false;
 }
 
 void Client::terminate(bool deleteDb)

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -844,15 +844,11 @@ public:
      */
     promise::Promise<void> loginSdkAndInit(const char* sid);
 
-    /** @brief Call this when the app goes into background, so that it notifies
-     * the servers to enable PUSH notifications
+    /** @brief Call this when the app changes the status: foreground <-> background,
+     * so that PUSH notifications are triggered correctly (enabled in background,
+     * disabled in foreground).
      */
-    bool notifyUserIdle();
-
-    /** @brief Call this when the app goes into foreground, so that push notifications
-     * are disabled
-     */
-    bool notifyUserActive();
+    promise::Promise<void> notifyUserStatus(bool background);
 
     void startKeepalivePings();
 

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -847,11 +847,12 @@ public:
     /** @brief Call this when the app goes into background, so that it notifies
      * the servers to enable PUSH notifications
      */
-    void notifyUserIdle();
+    bool notifyUserIdle();
+
     /** @brief Call this when the app goes into foreground, so that push notifications
      * are disabled
      */
-    void notifyUserActive();
+    bool notifyUserActive();
 
     void startKeepalivePings();
 

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -229,19 +229,39 @@ Chat& Client::createChat(Id chatid, int shardNo, const std::string& url,
     mChatForChatId.emplace(chatid, std::shared_ptr<Chat>(chat));
     return *chat;
 }
-bool Client::sendKeepalive()
+
+promise::Promise<void> Client::sendKeepalive()
 {
-    bool ret = true;
-    for (auto& conn: mConnections)
+    if (mKeepalivePromise.done())
     {
-        if (conn.second->sendKeepalive(mKeepaliveType) == false)
-        {
-            // if keepalive for any connection fails, return failure
-            ret = false;
-        }
+        assert(mKeepaliveCount == 0);   // TODO: prevent concurrent calls to sendKeepAlive()
+
+        mKeepaliveCount = 0;
+        mKeepaliveSent = true;
+        mKeepalivePromise = Promise<void>();
     }
 
-    return ret;
+    for (auto& conn: mConnections)
+    {
+        mKeepaliveCount++;
+        conn.second->sendKeepalive()
+        .then([this]()
+        {
+            onKeepaliveSent();
+        })
+        .fail([this](const ::promise::Error&)
+        {
+            mKeepaliveSent = false;
+            onKeepaliveSent();
+        });
+    }
+
+    if (mKeepaliveCount == 0)
+    {
+        mKeepalivePromise.resolve();
+    }
+
+    return mKeepalivePromise;
 }
 
 void Client::sendEcho()
@@ -258,6 +278,22 @@ void Client::sendEcho()
 void Client::setKeepaliveType(bool isInBackground)
 {
     mKeepaliveType = isInBackground ? OP_KEEPALIVEAWAY : OP_KEEPALIVE;
+}
+
+void Client::onKeepaliveSent()
+{
+    mKeepaliveCount--;
+    if (mKeepaliveCount == 0)
+    {
+        if (mKeepaliveSent)
+        {
+            mKeepalivePromise.resolve();
+        }
+        else
+        {
+            mKeepalivePromise.reject("Failed to send some keepalives");
+        }
+    }
 }
 
 uint8_t Client::keepaliveType()
@@ -281,13 +317,28 @@ Chat &Client::chats(Id chatid) const
     return *it->second;
 }
 
-bool Client::notifyUserIdle()
+promise::Promise<void> Client::notifyUserStatus(bool background)
 {
-    if (mKeepaliveType == OP_KEEPALIVEAWAY)
-        return true;
+    if (background)
+    {
+        if (mKeepaliveType == OP_KEEPALIVEAWAY)
+        {
+            return promise::_Void();
+        }
 
-    mKeepaliveType = OP_KEEPALIVEAWAY;
-    cancelSeenTimers();
+        cancelSeenTimers(); // avoid to update SEEN pointer when entering background
+    }
+    else    // foreground
+    {
+        if (mKeepaliveType == OP_KEEPALIVE)
+        {
+            return promise::_Void();
+        }
+
+        sendEcho(); // ping to detect dead sockets when returning to foreground
+    }
+
+    mKeepaliveType = background ? OP_KEEPALIVEAWAY: OP_KEEPALIVE;
     return sendKeepalive();
 }
 
@@ -298,17 +349,6 @@ void Client::cancelSeenTimers()
         cancelTimeout(*it, mKarereClient->appCtx);
    }
    mSeenTimers.clear();
-}
-
-bool Client::notifyUserActive()
-{
-    if (mKeepaliveType == OP_KEEPALIVE)
-        return true;
-
-    sendEcho();
-
-    mKeepaliveType = OP_KEEPALIVE;
-    return sendKeepalive();
 }
 
 bool Client::isMessageReceivedConfirmationActive() const
@@ -503,10 +543,12 @@ void Connection::onSocketClose(int errcode, int errtype, const std::string& reas
     }
 }
 
-bool Connection::sendKeepalive(uint8_t opcode)
+promise::Promise<void> Connection::sendKeepalive()
 {
+    uint8_t opcode = mChatdClient.keepaliveType();
     CHATDS_LOG_DEBUG("send %s", Command::opcodeToStr(opcode));
-    return sendBuf(Command(opcode));
+    sendBuf(Command(opcode));
+    return mSendPromise;
 }
 
 void Connection::sendEcho()
@@ -641,6 +683,10 @@ void Connection::setState(State state)
             mChatdClient.mRtcHandler->stopCallsTimers(mShardNo);
         }
 #endif
+        if (!mSendPromise.done())
+        {
+            mSendPromise.reject("Failed to send. Socket was closed");
+        }
     }
     else if (mState == kStateConnected)
     {
@@ -842,7 +888,7 @@ Promise<void> Connection::reconnect()
                 sendCommand(Command(OP_CLIENTID)+mChatdClient.mKarereClient->myIdentity());
                 mTsLastRecv = time(NULL);   // data has been received right now, since connection is established
                 mHeartbeatEnabled = true;
-                sendKeepalive(mChatdClient.mKeepaliveType);
+                sendKeepalive();
                 rejoinExistingChats();
             });
         }, wptr, mChatdClient.mKarereClient->appCtx, nullptr, 0, 0, KARERE_RECONNECT_DELAY_MAX, KARERE_RECONNECT_DELAY_INITIAL));
@@ -1043,8 +1089,20 @@ bool Connection::sendBuf(Buffer&& buf)
     if (!isOnline())
         return false;
 
+    // if several data are written to the output buffer to be sent all together, wait for all of them
+    if (mSendPromise.done())
+    {
+        mSendPromise = Promise<void>();
+    }
+
     bool rc = wsSendMessage(buf.buf(), buf.dataSize());
     buf.free();
+
+    if (!rc)
+    {
+        mSendPromise.reject("Failed to send data. Socket is not ready");
+    }
+
     return rc;
 }
 
@@ -1717,6 +1775,12 @@ void Connection::wsHandleMsgCb(char *data, size_t len)
     execCommand(StaticBuffer(data, len));
 }
 
+void Connection::wsSendMsgCb(const char *, size_t)
+{
+    assert(!mSendPromise.done());
+    mSendPromise.resolve();
+}
+
 // inbound command processing
 // multiple commands can appear as one WebSocket frame, but commands never cross frame boundaries
 // CHECK: is this assumption correct on all browsers and under all circumstances?
@@ -1741,7 +1805,7 @@ void Connection::execCommand(const StaticBuffer& buf)
             case OP_KEEPALIVE:
             {
                 CHATDS_LOG_DEBUG("recv KEEPALIVE");
-                sendKeepalive(mChatdClient.mKeepaliveType);
+                sendKeepalive();
                 break;
             }
             case OP_BROADCAST:

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -1095,6 +1095,10 @@ bool Connection::sendBuf(Buffer&& buf)
     if (mSendPromise.done())
     {
         mSendPromise = Promise<void>();
+        mSendPromise.fail([this](const promise::Error& err)
+        {
+           CHATDS_LOG_ERROR("Failed to send data. Error: %s", err.what());
+        });
     }
 
     bool rc = wsSendMessage(buf.buf(), buf.dataSize());
@@ -1102,7 +1106,7 @@ bool Connection::sendBuf(Buffer&& buf)
 
     if (!rc)
     {
-        mSendPromise.reject("Failed to send data. Socket is not ready");
+        mSendPromise.reject("Socket is not ready");
     }
 
     return rc;

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -1361,7 +1361,7 @@ protected:
 
     bool onMsgAlreadySent(karere::Id msgxid, karere::Id msgid);
     void msgConfirm(karere::Id msgxid, karere::Id msgid);
-    void sendKeepalive();
+    bool sendKeepalive();
     void sendEcho();
 
 public:
@@ -1412,8 +1412,8 @@ public:
     void retryPendingConnections(bool disconnect, bool refreshURL = false);
     void heartbeat();
 
-    void notifyUserIdle();
-    void notifyUserActive();
+    bool notifyUserIdle();
+    bool notifyUserActive();
 
     /** Changes the Rtc handler, returning the old one */
     IRtcHandler* setRtcHandler(IRtcHandler* handler);

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -1365,7 +1365,7 @@ protected:
 
     uint8_t mKeepaliveType = OP_KEEPALIVE;
     int mKeepaliveCount = 0;                    // number of keepalives to be sent (one per connection)
-    bool mKeepaliveSent = false;                // false if any pending keepalive failed to send
+    bool mKeepaliveFailed = false;              // true means any pending keepalive failed to send
     promise::Promise<void> mKeepalivePromise;   // resolved when all keepalive have been sent (or failed)
     void onKeepaliveSent();
 

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -454,11 +454,15 @@ protected:
 
     /** Handler of the timeout for the connection establishment */
     megaHandle mConnectTimer = 0;
-    
+
+    /** This promise is resolved when output data is written to the sockets */
+    promise::Promise<void> mSendPromise;
+
     // ---- callbacks called from libwebsocketsIO ----
     virtual void wsConnectCb();
     virtual void wsCloseCb(int errcode, int errtype, const char *preason, size_t reason_len);
     virtual void wsHandleMsgCb(char *data, size_t len);
+    virtual void wsSendMsgCb(const char *data, size_t len);
 
     void onSocketClose(int ercode, int errtype, const std::string& reason);
     promise::Promise<void> reconnect();
@@ -473,7 +477,7 @@ protected:
     void hist(karere::Id chatid, long count);
     bool sendCommand(Command&& cmd); // used internally only for OP_HELLO
     void execCommand(const StaticBuffer& buf);
-    bool sendKeepalive(uint8_t opcode);
+    promise::Promise<void> sendKeepalive();
     void sendEcho();
     void sendCallReqDeclineNoSupport(karere::Id chatid, karere::Id callid);
     friend class Client;
@@ -1359,9 +1363,15 @@ protected:
     // to track changes in the richPreview's user-attribute
     karere::UserAttrCache::Handle mRichPrevAttrCbHandle;
 
+    uint8_t mKeepaliveType = OP_KEEPALIVE;
+    int mKeepaliveCount = 0;                    // number of keepalives to be sent (one per connection)
+    bool mKeepaliveSent = false;                // false if any pending keepalive failed to send
+    promise::Promise<void> mKeepalivePromise;   // resolved when all keepalive have been sent (or failed)
+    void onKeepaliveSent();
+
     bool onMsgAlreadySent(karere::Id msgxid, karere::Id msgid);
     void msgConfirm(karere::Id msgxid, karere::Id msgid);
-    bool sendKeepalive();
+    promise::Promise<void> sendKeepalive();
     void sendEcho();
 
 public:
@@ -1386,8 +1396,7 @@ public:
 
     MyMegaApi *mApi;
     karere::Client *mKarereClient;
-    IRtcHandler* mRtcHandler = nullptr;
-    uint8_t mKeepaliveType = OP_KEEPALIVE;
+    IRtcHandler *mRtcHandler = nullptr;
 
     /* --- getters --- */
     const karere::Id myHandle() const;
@@ -1412,8 +1421,7 @@ public:
     void retryPendingConnections(bool disconnect, bool refreshURL = false);
     void heartbeat();
 
-    bool notifyUserIdle();
-    bool notifyUserActive();
+    promise::Promise<void> notifyUserStatus(bool background);
 
     /** Changes the Rtc handler, returning the old one */
     IRtcHandler* setRtcHandler(IRtcHandler* handler);

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2586,9 +2586,15 @@ public:
      * background. The app should define its status in order to receive notifications
      * from server when the app is in background.
      *
-     * This function doesn't have any effect until MEGAchat is fully initialized. It means that
+     * This function doesn't have any effect until MEGAchat is fully initialized (meaning that
      * MegaChatApi::getInitState returns the value MegaChatApi::INIT_OFFLINE_SESSION or
-     * MegaChatApi::INIT_ONLINE_SESSION.
+     * MegaChatApi::INIT_ONLINE_SESSION).
+     *
+     * If MEGAchat is currently not connected to chatd, the request will fail with a
+     * MegaChatError::ERROR_ACCESS. If that case, when transitioning from foreground to
+     * background, the app should wait for being reconnected (@see MegaChatListener::onChatConnectionStateUpdate)
+     * in order to ensure the server is aware of the new status of the app, specially in iOS where
+     * the OS may kill the connection.
      *
      * The associated request type with this request is MegaChatRequest::TYPE_SET_BACKGROUND_STATUS
      * Valid data in the MegaChatRequest object received on callbacks:

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1297,17 +1297,17 @@ void MegaChatApiImpl::sendPendingRequests()
         case MegaChatRequest::TYPE_SET_BACKGROUND_STATUS:
         {
             bool background = request->getFlag();
-            bool ret;
-            if (background)
+            mClient->notifyUserStatus(background)
+            .then([this, request]()
             {
-                ret = mClient->notifyUserIdle();
-            }
-            else
+                MegaChatErrorPrivate *megaChatError = new MegaChatErrorPrivate(MegaChatError::ERROR_OK);
+                fireOnChatRequestFinish(request, megaChatError);
+            })
+            .fail([this, request](const ::promise::Error& err)
             {
-                ret = mClient->notifyUserActive();
-            }
-            MegaChatErrorPrivate *megaChatError = new MegaChatErrorPrivate(ret ? MegaChatError::ERROR_OK : MegaChatError::ERROR_ACCESS);
-            fireOnChatRequestFinish(request, megaChatError);
+                MegaChatErrorPrivate *megaChatError = new MegaChatErrorPrivate(err.msg(), err.code(), err.type());
+                fireOnChatRequestFinish(request, megaChatError);
+            });
             break;
         }            
         case MegaChatRequest::TYPE_PUSH_RECEIVED:

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1297,15 +1297,16 @@ void MegaChatApiImpl::sendPendingRequests()
         case MegaChatRequest::TYPE_SET_BACKGROUND_STATUS:
         {
             bool background = request->getFlag();
+            bool ret;
             if (background)
             {
-                mClient->notifyUserIdle();
+                ret = mClient->notifyUserIdle();
             }
             else
             {
-                mClient->notifyUserActive();
+                ret = mClient->notifyUserActive();
             }
-            MegaChatErrorPrivate *megaChatError = new MegaChatErrorPrivate(MegaChatError::ERROR_OK);
+            MegaChatErrorPrivate *megaChatError = new MegaChatErrorPrivate(ret ? MegaChatError::ERROR_OK : MegaChatError::ERROR_ACCESS);
             fireOnChatRequestFinish(request, megaChatError);
             break;
         }            

--- a/src/net/libwebsocketsIO.cpp
+++ b/src/net/libwebsocketsIO.cpp
@@ -441,6 +441,7 @@ int LibwebsocketsClient::wsCallback(struct lws *wsi, enum lws_callback_reasons r
             if (len && data)
             {
                 lws_write(wsi, (unsigned char *)data, len, LWS_WRITE_BINARY);
+                client->wsSendMsgCb((const char *)data, len);
                 client->resetOutputBuffer();
             }
             break;

--- a/src/net/websocketsIO.cpp
+++ b/src/net/websocketsIO.cpp
@@ -75,6 +75,13 @@ void WebsocketsClientImpl::wsHandleMsgCb(char *data, size_t len)
     client->wsHandleMsgCb(data, len);
 }
 
+void WebsocketsClientImpl::wsSendMsgCb(const char *data, size_t len)
+{
+    ScopedLock lock(this->mutex);
+    WEBSOCKETS_LOG_DEBUG("Sent %d bytes", len);
+    client->wsSendMsgCb(data, len);
+}
+
 WebsocketsClient::WebsocketsClient()
 {
     ctx = NULL;

--- a/src/net/websocketsIO.h
+++ b/src/net/websocketsIO.h
@@ -94,6 +94,7 @@ public:
     virtual void wsConnectCb() = 0;
     virtual void wsCloseCb(int errcode, int errtype, const char *preason, size_t reason_len) = 0;
     virtual void wsHandleMsgCb(char *data, size_t len) = 0;
+    virtual void wsSendMsgCb(const char *data, size_t len) = 0;
 };
 
 
@@ -110,6 +111,7 @@ public:
     void wsConnectCb();
     void wsCloseCb(int errcode, int errtype, const char *preason, size_t reason_len);
     void wsHandleMsgCb(char *data, size_t len);
+    void wsSendMsgCb(const char *data, size_t len);
     
     virtual bool wsSendMessage(char *msg, size_t len) = 0;
     virtual void wsDisconnect(bool immediate) = 0;

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -419,6 +419,7 @@ protected:
     virtual void wsConnectCb();
     virtual void wsCloseCb(int errcode, int errtype, const char *preason, size_t /*preason_len*/);
     virtual void wsHandleMsgCb(char *data, size_t len);
+    virtual void wsSendMsgCb(const char *, size_t) {}
     
     void onSocketClose(int ercode, int errtype, const std::string& reason);
     promise::Promise<void> reconnect();


### PR DESCRIPTION
If the init was not called yet or if MEGAchat is not connected to all shards, the `MegaChatApi::setBackgroundStatus(true)` will return `ERROR_ACCESS`.
Also, the request will fail if no socket is available to send data.