### PR TITLE
Fix Init MEGAchat request tag

### DIFF
--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -103,6 +103,7 @@ void MegaChatApiImpl::init(MegaChatApi *chatApi, MegaApi *megaApi)
     this->terminating = false;
     this->waiter = new MegaChatWaiter();
     this->websocketsIO = new MegaWebsocketsIO(&sdkMutex, waiter, megaApi, this);
+    this->reqtag = 0;
 
     //Start blocking thread
     threadExit = 0;


### PR DESCRIPTION
In MegaChatApiImpl ctor the request tag was not initialized so request
tag could contain a random number.