### PR TITLE
Adjust init stats in anonymous mode

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -917,6 +917,7 @@ void Client::onRequestFinish(::mega::MegaApi* /*apiObj*/, ::mega::MegaRequest *r
                 checkSyncWithSdkDb(scsn, *contactList, *chatList);
                 setInitState(kInitHasOnlineSession);
                 mSessionReadyPromise.resolve();
+                mInitStats.stageEnd(InitStats::kStatsPostFetchNodes);
                 api.sdk.resumeActionPackets();
             }
             else if (state == kInitWaitingNewSession || state == kInitErrNoCache)
@@ -934,6 +935,7 @@ void Client::onRequestFinish(::mega::MegaApi* /*apiObj*/, ::mega::MegaRequest *r
                 {
                     setInitState(kInitHasOnlineSession);
                     mSessionReadyPromise.resolve();
+                    mInitStats.stageEnd(InitStats::kStatsPostFetchNodes);
                     api.sdk.resumeActionPackets();
                 });
             }
@@ -1108,7 +1110,6 @@ promise::Promise<void> Client::connect(Presence pres, bool isInBackground)
 promise::Promise<void> Client::doConnect(Presence pres, bool isInBackground)
 {
     KR_LOG_DEBUG("Connecting to account '%s'(%s)...", SdkString(api.sdk.getMyEmail()).c_str(), mMyHandle.toString().c_str());
-    mInitStats.stageEnd(InitStats::kStatsPostFetchNodes);
     mInitStats.stageStart(InitStats::kStatsConnection);
 
     setConnState(kConnecting);

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -642,20 +642,11 @@ class InitStats
             kStatsLoginChatd        = 3
         };
 
-        void setNumNodes(long long numNodes);
-        void setNumContacts(long numContacts);
-        void setNumChats(long numChats);
-        void onCompleted();
+        std::string onCompleted(long long numNodes, size_t numChats, size_t numContacts);
         bool isCompleted() const;
-
-        /** @brief Returns a string that contains init stats in JSON format */
-        std::string toJson();
 
 
         /*  Stages Methods */
-
-        /** @brief Reset the elapsed time for a stage */
-        void resetStage(uint8_t stage);
 
         /** @brief Obtain initial ts for a stage */
         void stageStart(uint8_t stage);
@@ -739,6 +730,9 @@ private:
 
     /** @brief  Returns a string with the associated tag to the stage **/
     std::string shardStageToString(uint8_t stage);
+
+    /** @brief Returns a string that contains init stats in JSON format */
+    std::string toJson();
 
 };
 


### PR DESCRIPTION
At `stageEnd(kStatsPostFetchNodes)` the assertion fails, since in anonymous mode the stage was not never started, @jgandres. That stage should finish at the right time, in the `onRequestFinish()` of fetchnodes.