### PR TITLE
#13141. Avoid conflict in 1to1 calls when two clients answer at same time

### DIFF
--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -1056,9 +1056,7 @@ void Call::handleMessage(RtMessage& packet)
     switch (packet.type)
     {
         case RTCMD_CALL_TERMINATE:
-            // It's only used in case of two clients from same user answer in 1to1
-            // chatroom and one of both is finished by the caller
-            msgTerminate(packet);
+            // This message can be received from old clients. It can be ignored
             return;
         case RTCMD_SESSION:
             msgSession(packet);
@@ -1392,7 +1390,7 @@ void Call::msgJoin(RtMessage& packet)
     }
     else if (!packet.chat.isGroup() && hasSessionWithUser(packet.userid))
     {
-        mManager.cmdEndpoint(RTCMD_CALL_TERMINATE, packet, mId, TermCode::kAnsElsewhere);
+        mManager.cmdEndpoint(RTCMD_CALL_REQ_CANCEL, packet, mId, TermCode::kAnsElsewhere);
         SUB_LOG_WARNING("Ignore a JOIN from our in 1to1 chatroom, we have a session or have sent a session request");
         return;
     }

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -1358,18 +1358,6 @@ void Call::msgSdpOffer(RtMessage& packet)
     sess->veryfySdpOfferSendAnswer();
 }
 
-void Call::msgTerminate(RtMessage &packet)
-{
-    TermCode code = static_cast<TermCode>(packet.payload.read<uint8_t>(8));
-    if (code != TermCode::kAnsElsewhere && mState != Call::kStateJoining)
-    {
-        SUB_LOG_ERROR("Unexpected RTCMD_CALL_TERMINATE with invalid termCode or state");
-        return;
-    }
-
-    destroy(static_cast<TermCode>(code| TermCode::kPeer), false);
-}
-
 void Call::handleReject(RtMessage& packet)
 {
     if (packet.callid != mId)

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -2392,24 +2392,9 @@ void Call::onClientLeftCall(Id userid, uint32_t clientid)
         {
             mManager.launchCallRetry(mChat.chatId(), sentAv(), false);
         }
-    }
-    else if (mState >= kStateInProgress)
-    {
-        if (userid == mManager.mKarereClient.myHandle())
-        {
-            SUB_LOG_DEBUG("Discard ENDCALL received for ourselves but with other client in 1to1 chatroom");
-            return;
-        }
 
-        EndpointId pointId(userid, clientid);
-        bool hasSessionWihtOtherClient = (mSentSessions.find(pointId) == mSentSessions.end());
-        if (hasSessionWihtOtherClient)
-        {
-            SUB_LOG_DEBUG("Discard ENDCALL received for other client from the peer that we have session");
-            return;
-        }
-
-        destroy(TermCode::kErrPeerOffline, userid == mChat.client().mKarereClient->myHandle());
+        cancelSessionRetryTimer(userid, clientid);
+        destroyIfNoSessionsOrRetries(TermCode::kErrPeerOffline);
     }
 }
 bool Call::changeLocalRenderer(IVideoRenderer* renderer)

--- a/src/rtcModule/webrtcPrivate.h
+++ b/src/rtcModule/webrtcPrivate.h
@@ -167,6 +167,7 @@ protected:
     void msgCallReqDecline(RtMessage& packet);
     void msgCallReqCancel(RtMessage& packet);
     void msgSdpOffer(RtMessage& packet);
+    void msgTerminate(RtMessage& packet);
     void handleReject(RtMessage& packet);
     void handleBusy(RtMessage& packet);
     void getLocalStream(karere::AvFlags av, std::string& errors);
@@ -203,6 +204,7 @@ protected:
     uint8_t convertTermCodeToCallDataCode();
     bool cancelSessionRetryTimer(karere::Id userid, uint32_t clientid);
     void monitorCallSetupTimeout();
+    bool hasSessionWithUser(karere::Id userId);
     friend class RtcModule;
     friend class Session;
 public:

--- a/src/rtcModule/webrtcPrivate.h
+++ b/src/rtcModule/webrtcPrivate.h
@@ -169,7 +169,6 @@ protected:
     void msgCallReqDecline(RtMessage& packet);
     void msgCallReqCancel(RtMessage& packet);
     void msgSdpOffer(RtMessage& packet);
-    void msgTerminate(RtMessage& packet);
     void handleReject(RtMessage& packet);
     void handleBusy(RtMessage& packet);
     void getLocalStream(karere::AvFlags av, std::string& errors);


### PR DESCRIPTION
If two clients answer an incoming call roughly at same time, a session is established between the 2 clients of the same user (apart from the sessions between the 2 clients and the caller). I could result on the wrong streams being received by the other peer. In example, User A sees video from user B (client 1: B1), but user B in client 2 (B2) sees the video from B1.

**Risk area/s:**
- 1on1 calls answered at two clients at the same time (only one client should success answering the call).
- Group calls answered at two clients of the same user, which is allowed.