### PR TITLE
Check status of object for `mSendPromise` handlers

### DIFF
--- a/src/chatd.h
+++ b/src/chatd.h
@@ -1335,7 +1335,7 @@ public:
 //===
 };
 
-class Client
+class Client : public karere::DeleteTrackable
 {
 protected:
     karere::Id mMyHandle;


### PR DESCRIPTION
If there is a buf queued for sending, but before sending the client is destroyed, the app may crash. This commit prevents the issue.