### PR TITLE
Add .fail handler for keepalive upon exit

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -270,7 +270,12 @@ promise::Promise<void> Client::sendKeepalive()
         mKeepalivePromise.resolve();
     }
 
-    return mKeepalivePromise;
+    return mKeepalivePromise
+    .fail([this, wptr](const ::promise::Error&)
+    {
+        if (wptr.deleted())
+            return;
+    });
 }
 
 void Client::sendEcho()


### PR DESCRIPTION
If `MegaApi::setBackgroundStatus()` is called right before a `MegaApi::~MegaApi()`, it may result in a crash due to the `.fail()` associated. This commit aims to avoid propagation of the rejected promiste to the intermediate layer.