### PR TITLE
Feature #11983: Reset clientid

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1281,6 +1281,13 @@ uint64_t Client::getMyIdentityFromDb()
     return result;
 }
 
+void Client::resetClientid()
+{
+    KR_LOG_WARNING("Reset the clientid_seed");
+    uint64_t result = (static_cast<uint64_t>(rand()) << 32) | ::mega::m_time();
+    db.query("insert or replace into vars(name,value) values('clientid_seed', ?)", result);
+}
+
 promise::Promise<void> Client::loadOwnKeysFromApi()
 {
     return api.call(&::mega::MegaApi::getUserAttribute, (int)mega::MegaApi::USER_ATTR_KEYRING)

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -1091,6 +1091,7 @@ public:
     void updateAndNotifyLastGreen(Id userid);
     InitStats &initStats();
     void sendStats();
+    void resetClientid();
 
 protected:
     void heartbeat();

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -1091,7 +1091,8 @@ public:
     void updateAndNotifyLastGreen(Id userid);
     InitStats &initStats();
     void sendStats();
-    void resetClientid();
+    void resetMyIdentity();
+    uint64_t initMyIdentity();
 
 protected:
     void heartbeat();

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -277,6 +277,11 @@ int MegaChatApi::init(const char *sid)
     return pImpl->init(sid);
 }
 
+void MegaChatApi::resetClientid()
+{
+   pImpl->resetClientid();
+}
+
 int MegaChatApi::initAnonymous()
 {
     return pImpl->initAnonymous();

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2186,12 +2186,12 @@ public:
     int init(const char *sid);
 
     /**
-     * @brief Reset the clientid
+     * @brief Reset the Client Id for chatd
      *
      * When the app is running and another instance is launched i.e (share-extension in iOS),
-     * chatd drops the connection if detects that the clientid already exists.
+     * chatd closes the connection if a new connection is established with the same Client Id.
      *
-     * The purpose of this function is reset the clientid in order to avoid that chatd drop
+     * The purpose of this function is reset the Client Id in order to avoid that chatd closes
      * the other connections.
      *
      * This function should be called after MegaChatApi::init.

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2186,6 +2186,19 @@ public:
     int init(const char *sid);
 
     /**
+     * @brief Reset the clientid
+     *
+     * When the app is running and another instance is launched i.e (share-extension in iOS),
+     * chatd drops the connection if detects that the clientid already exists.
+     *
+     * The purpose of this function is reset the clientid in order to avoid that chatd drop
+     * the other connections.
+     *
+     * This function should be called after MegaChatApi::init.
+     */
+    void resetClientid();
+
+    /**
      * @brief Initializes karere in anonymous mode for preview of chat-links
      *
      * The initialization state will be MegaChatApi::INIT_ANONYMOUS if successful. In

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1811,7 +1811,7 @@ void MegaChatApiImpl::resetClientid()
     sdkMutex.lock();
     if (mClient)
     {
-        mClient->resetClientid();
+        mClient->resetMyIdentity();
     }
     sdkMutex.unlock();
 }

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -1806,6 +1806,16 @@ int MegaChatApiImpl::init(const char *sid)
     return MegaChatApiImpl::convertInitState(state);
 }
 
+void MegaChatApiImpl::resetClientid()
+{
+    sdkMutex.lock();
+    if (mClient)
+    {
+        mClient->resetClientid();
+    }
+    sdkMutex.unlock();
+}
+
 void MegaChatApiImpl::createKarereClient()
 {
     if (!mClient)

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -952,6 +952,7 @@ public:
     int init(const char *sid);
     int initAnonymous();
     void createKarereClient();
+    void resetClientid();
     int getInitState();
 
     MegaChatRoomHandler* getChatRoomHandler(MegaChatHandle chatid);


### PR DESCRIPTION
When the app is running and another instance is launched i.e (share-extension in iOS),
chatd drops the connection if detects that the clientid already exists.