### PR TITLE
Bug #11953 create new change type to notify apps when a call is fully operative

### DIFF
--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -210,7 +210,7 @@ public:
         CHANGE_TYPE_CALL_COMPOSITION = 0x40,        /// Call composition has changed (User added or removed from call)
         CHANGE_TYPE_SESSION_NETWORK_QUALITY = 0x80, /// Session network quality has changed
         CHANGE_TYPE_SESSION_AUDIO_LEVEL = 0x100,    /// Session audio level has changed
-        CHANGE_TYPE_SESSION_OPERATIVE = 0x200,      /// Session is fully operative
+        CHANGE_TYPE_SESSION_OPERATIVE = 0x200      /// Session is fully operative
     };
 
     enum

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -209,7 +209,8 @@ public:
         CHANGE_TYPE_SESSION_STATUS = 0x20,          /// Session status has changed
         CHANGE_TYPE_CALL_COMPOSITION = 0x40,        /// Call composition has changed (User added or removed from call)
         CHANGE_TYPE_SESSION_NETWORK_QUALITY = 0x80, /// Session network quality has changed
-        CHANGE_TYPE_SESSION_AUDIO_LEVEL = 0x100     /// Session audio level has changed
+        CHANGE_TYPE_SESSION_AUDIO_LEVEL = 0x100,    /// Session audio level has changed
+        CHANGE_TYPE_CALL_OPERATIVE = 0x200,         /// Call is fully operative
     };
 
     enum

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -210,7 +210,7 @@ public:
         CHANGE_TYPE_CALL_COMPOSITION = 0x40,        /// Call composition has changed (User added or removed from call)
         CHANGE_TYPE_SESSION_NETWORK_QUALITY = 0x80, /// Session network quality has changed
         CHANGE_TYPE_SESSION_AUDIO_LEVEL = 0x100,    /// Session audio level has changed
-        CHANGE_TYPE_CALL_OPERATIVE = 0x200,         /// Call is fully operative
+        CHANGE_TYPE_SESSION_OPERATIVE = 0x200,      /// Session is fully operative
     };
 
     enum

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -8010,7 +8010,12 @@ void MegaChatSessionHandler::onPeerMute(karere::AvFlags av, karere::AvFlags oldA
 
 void MegaChatSessionHandler::onVideoRecv()
 {
+    MegaChatCallPrivate *chatCall = callHandler->getMegaChatCall();
+    chatCall->sessionUpdated(session->peer(), session->peerClient(), MegaChatCall::CHANGE_TYPE_CALL_OPERATIVE);
+    API_LOG_INFO("The call is fully operative. ChatId: %s, callid: %s",
+                 ID_CSTR(chatCall->getChatid()), ID_CSTR(chatCall->getId()));
 
+    megaChatApi->fireOnChatCallUpdate(chatCall);
 }
 
 void MegaChatSessionHandler::onSessionNetworkQualityChange(int currentQuality)

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -8012,8 +8012,9 @@ void MegaChatSessionHandler::onVideoRecv()
 {
     MegaChatCallPrivate *chatCall = callHandler->getMegaChatCall();
     chatCall->sessionUpdated(session->peer(), session->peerClient(), MegaChatCall::CHANGE_TYPE_SESSION_OPERATIVE);
-    API_LOG_INFO("The call is fully operative. ChatId: %s, callid: %s",
-                 ID_CSTR(chatCall->getChatid()), ID_CSTR(chatCall->getId()));
+    API_LOG_INFO("The session is fully operative. ChatId: %s, callid: %s, userid: %s, clientid: %s",
+                 ID_CSTR(chatCall->getChatid()), ID_CSTR(chatCall->getId()),
+                 ID_CSTR(session->peer()), ID_CSTR(session->peerClient()));
 
     megaChatApi->fireOnChatCallUpdate(chatCall);
 }

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -8011,7 +8011,7 @@ void MegaChatSessionHandler::onPeerMute(karere::AvFlags av, karere::AvFlags oldA
 void MegaChatSessionHandler::onVideoRecv()
 {
     MegaChatCallPrivate *chatCall = callHandler->getMegaChatCall();
-    chatCall->sessionUpdated(session->peer(), session->peerClient(), MegaChatCall::CHANGE_TYPE_CALL_OPERATIVE);
+    chatCall->sessionUpdated(session->peer(), session->peerClient(), MegaChatCall::CHANGE_TYPE_SESSION_OPERATIVE);
     API_LOG_INFO("The call is fully operative. ChatId: %s, callid: %s",
                  ID_CSTR(chatCall->getChatid()), ID_CSTR(chatCall->getId()));
 


### PR DESCRIPTION
In mobile apps the "Connecting" label is removed too early, when the
call isn't fully operative so we need to notify apps when the call
is usable.