### PR TITLE
Groupcalls always enabled (Android bindings)

### DIFF
--- a/bindings/java/nz/mega/sdk/MegaChatApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaChatApiJava.java
@@ -2672,36 +2672,6 @@ public class MegaChatApiJava {
     }
 
     /**
-     * Enable/disable groupcalls
-     *
-     * If groupcalls are disabled, notifications about groupcalls will be skiped, but messages
-     * in the history about group calls will be visible since the call takes place anyway.
-     *
-     * By default, groupcalls are disabled.
-     *
-     * This method should be called after MegaChatApi::init. A MegaChatApi::logout resets its value.
-     *
-     * @param enable True for enable group calls. False to disable them.
-     */
-    public void enableGroupChatCalls(boolean enable){
-        megaChatApi.enableGroupChatCalls(enable);
-    }
-
-    /**
-     * Returns true if groupcalls are enabled
-     *
-     * If groupcalls are disabled, notifications about groupcalls will be skiped, but messages
-     * in the history about group calls will be visible.
-     *
-     * By default, groupcalls are disabled. A MegaChatApi::logout resets its value.
-     *
-     * @return True if group calls are enabled. Otherwise, false.
-     */
-    public boolean areGroupChatCallEnabled(){
-        return megaChatApi.areGroupChatCallEnabled();
-    }
-
-    /**
      * @brief Returns the maximum call participants
      *
      * @return Maximum call participants


### PR DESCRIPTION
Remove the `enableGroupChatCalls(bool)` and `areGroupChatCallEnabled()` methods from Android bindings.