### PR TITLE
Adjust types in init stats json

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3995,7 +3995,7 @@ std::string InitStats::toJson()
         mega::dstime elapsed = itStages->second;
 
         // Add stage
-        jsonValue.SetInt64(stage);
+        jsonValue.SetUint(stage);
         jSonStage.AddMember(rapidjson::Value("stg"), jsonValue, jSonDocument.GetAllocator());
 
         std::string tag = stageToString(stage);
@@ -4005,7 +4005,7 @@ std::string InitStats::toJson()
 
         // Add stage elapsed time
         totalElapsed += elapsed;
-        jsonValue.SetInt64(elapsed);
+        jsonValue.SetUint(elapsed);
         jSonStage.AddMember(rapidjson::Value("elap"), jsonValue, jSonDocument.GetAllocator());
         stageArray.PushBack(jSonStage, jSonDocument.GetAllocator());
     }
@@ -4030,25 +4030,25 @@ std::string InitStats::toJson()
                 ShardStats &shardStats = itShard->second;
 
                 // Add stage
-                jsonValue.SetInt(shard);
+                jsonValue.SetUint(shard);
                 jSonShard.AddMember(rapidjson::Value("sh"), jsonValue, jSonDocument.GetAllocator());
 
                 // Add stage elapsed time
-                jsonValue.SetInt(shardStats.elapsed);
+                jsonValue.SetUint(shardStats.elapsed);
                 jSonShard.AddMember(rapidjson::Value("elap"), jsonValue, jSonDocument.GetAllocator());
 
                 // Add stage elapsed time
-                jsonValue.SetInt(shardStats.maxElapsed);
+                jsonValue.SetUint(shardStats.maxElapsed);
                 jSonShard.AddMember(rapidjson::Value("max"), jsonValue, jSonDocument.GetAllocator());
 
                 // Add stage retries
-                jsonValue.SetInt(shardStats.mRetries);
+                jsonValue.SetUint(shardStats.mRetries);
                 jSonShard.AddMember(rapidjson::Value("ret"), jsonValue, jSonDocument.GetAllocator());
                 shardArray.PushBack(jSonShard, jSonDocument.GetAllocator());
             }
         }
 
-        jsonValue.SetInt(stage);
+        jsonValue.SetUint(stage);
         jSonStage.AddMember(rapidjson::Value("stg"), jsonValue, jSonDocument.GetAllocator());
 
         std::string tag = shardStageToString(stage);
@@ -4065,19 +4065,19 @@ std::string InitStats::toJson()
     jSonObject.AddMember(rapidjson::Value("nn"), jsonValue, jSonDocument.GetAllocator());
 
     // Add number of contacts
-    jsonValue.SetInt64(mNumContacts);
+    jsonValue.SetUint(mNumContacts);
     jSonObject.AddMember(rapidjson::Value("ncn"), jsonValue, jSonDocument.GetAllocator());
 
     // Add number of chats
-    jsonValue.SetInt64(mNumChats);
+    jsonValue.SetUint(mNumChats);
     jSonObject.AddMember(rapidjson::Value("nch"), jsonValue, jSonDocument.GetAllocator());
 
     // Add number of contacts
-    jsonValue.SetInt64(mInitState);
+    jsonValue.SetUint(mInitState);
     jSonObject.AddMember(rapidjson::Value("sid"), jsonValue, jSonDocument.GetAllocator());
 
     // Add total elapsed
-    jsonValue.SetInt64(totalElapsed);
+    jsonValue.SetUint(totalElapsed);
     jSonObject.AddMember(rapidjson::Value("telap"), jsonValue, jSonDocument.GetAllocator());
 
     // Add stages array

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3785,9 +3785,9 @@ std::string InitStats::onCompleted(long long numNodes, size_t numChats, size_t n
         mStageStats[kStatsPostFetchNodes] = 0;
     }
 
-    mNumNodes = numNodes;
-    mNumChats = numChats;
-    mNumContacts = numContacts;
+    mNumNodes = static_cast<uint32_t> (numNodes);
+    mNumChats = static_cast<uint32_t> (numChats);
+    mNumContacts = static_cast<uint32_t> (numContacts);
 
     std::string json = toJson();
 
@@ -3991,7 +3991,7 @@ std::string InitStats::toJson()
     for (StageMap::const_iterator itStages = mStageStats.begin(); itStages != mStageStats.end(); itStages++)
     {
         rapidjson::Value jSonStage(rapidjson::kObjectType);
-        uint8_t stage = itStages->first;
+        uint32_t stage = static_cast<uint32_t> (itStages->first);
         mega::dstime elapsed = itStages->second;
 
         // Add stage
@@ -4017,7 +4017,7 @@ std::string InitStats::toJson()
     {
         rapidjson::Value jSonStage(rapidjson::kObjectType);
         rapidjson::Document shardArray(rapidjson::kArrayType);
-        uint8_t stage = itshstgs->first;
+        uint32_t stage = static_cast<uint32_t> (itshstgs->first);
 
         ShardMap *shardMap = &(itshstgs->second);
         if (shardMap)
@@ -4026,7 +4026,7 @@ std::string InitStats::toJson()
             for (itShard = shardMap->begin(); itShard != shardMap->end(); itShard++)
             {
                 rapidjson::Value jSonShard(rapidjson::kObjectType);
-                uint8_t shard = itShard->first;
+                uint32_t shard = static_cast<uint32_t> (itShard->first);
                 ShardStats &shardStats = itShard->second;
 
                 // Add stage
@@ -4061,7 +4061,7 @@ std::string InitStats::toJson()
     }
 
     // Add number of nodes
-    jsonValue.SetInt64(mNumNodes);
+    jsonValue.SetUint(mNumNodes);
     jSonObject.AddMember(rapidjson::Value("nn"), jsonValue, jSonDocument.GetAllocator());
 
     // Add number of contacts

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -690,7 +690,7 @@ private:
         mega::dstime tsStart = 0;
 
         /** @brief Number of retries */
-        unsigned int mRetries = 0;
+        uint32_t mRetries = 0;
     };
 
     typedef std::map<uint8_t, mega::dstime> StageMap;   // maps stage to elapsed time (first it stores tsStart)
@@ -705,19 +705,19 @@ private:
     StageShardMap mStageShardStats;
 
     /** @brief Number of nodes in the account */
-    long long int mNumNodes = 0;
+    uint32_t mNumNodes = 0;
 
     /** @brief Number of chats in the account */
-    long int mNumChats = 0;
+    uint32_t mNumChats = 0;
 
     /** @brief Number of contacts in the account */
-    long int mNumContacts = 0;
+    uint32_t mNumContacts = 0;
 
     /** @brief Flag that indicates whether the stats have already been sent */
     bool mCompleted = false;
 
     /** @brief Indicates the init state with cache */
-    uint8_t mInitState = kInitNewSession;
+    uint32_t mInitState = kInitNewSession;
 
 
     /* Auxiliar methods */


### PR DESCRIPTION
Some variables like total elapsed time are UINT_32 and when json was
generated the variables was represented as a INT_64, wich caused that
the received value was out of range and not corresponds with the
summatory of the rest of the stages.