### PR TITLE
Bug #12183 Protect against invalid JSON for rich-links

### DIFF
--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -9013,11 +9013,10 @@ MegaChatRichPreview *JSonUtils::parseRichPreview(rapidjson::Document &document, 
             imagePointer = imagePointer + imageFormat.size() + 1; // remove format.size() + ':'
 
             // Check if the image format in B64 is valid
-            std::string imgBuf;
-            int actualSize = Base64::atob(std::string(imagePointer), imgBuf);
-            int expectedSize = (strlen(imagePointer) * 3) / 4;
-            int difference = expectedSize - actualSize;
-            if (difference >= 0  && difference <= 2)    // considering padding: each set of 3 bytes is converted into 4 chars
+            std::string imgBin, imgB64(imagePointer);
+            size_t binSize = Base64::atob(imgB64, imgBin);
+            size_t paddingSize = std::count(imgB64.begin(), imgB64.end(), '=');
+            if (binSize == (imgB64.size() * 3) / 4 - paddingSize)
             {
                 rapidjson::SizeType sizeImage = iteratorImage->value.GetStringLength() - (imageFormat.size() + 1);
                 image = std::string(imagePointer, sizeImage);
@@ -9039,12 +9038,11 @@ MegaChatRichPreview *JSonUtils::parseRichPreview(rapidjson::Document &document, 
             iconFormat = getImageFormat(iconPointer);
             iconPointer = iconPointer + iconFormat.size() + 1; // remove format.size() + ':'
 
-            // Check if the icon format in B64 is valid
-            std::string iconBuf;
-            int actualSize = Base64::atob(std::string(iconPointer), iconBuf);
-            int expectedSize = (strlen(iconPointer) * 3) / 4;
-            int difference = expectedSize - actualSize;
-            if (difference >= 0  && difference <= 2)    // considering padding: each set of 3 bytes is converted into 4 chars
+            // Check if the image format in B64 is valid
+            std::string iconBin, iconB64(iconPointer);
+            size_t binSize = Base64::atob(iconB64, iconBin);
+            size_t paddingSize = std::count(iconB64.begin(), iconB64.end(), '=');
+            if (binSize == (iconB64.size() * 3) / 4 - paddingSize)
             {
                 rapidjson::SizeType sizeIcon = iteratorIcon->value.GetStringLength() - (iconFormat.size() + 1);
                 icon = std::string(iconPointer, sizeIcon);

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -9013,21 +9013,18 @@ MegaChatRichPreview *JSonUtils::parseRichPreview(rapidjson::Document &document, 
             imagePointer = imagePointer + imageFormat.size() + 1; // remove format.size() + ':'
 
             // Check if the image format in B64 is valid
-            std::string dest, source;
-            source = std::string(imagePointer);
-            int size = Base64::atob(source, dest);
-            int auxSize = (source.size() * 3) / 4;
-
-            // The size diference between the value calculated above and the returned by the function, can't be bigger than 2 (considering the padding ==)
-            uint32_t diference = static_cast<uint32_t> (auxSize - size);
-            if (diference > 2)
-            {
-                API_LOG_ERROR("Parse rich link: \"i\" field has a invalid format");
-            }
-            else
+            std::string imgBuf;
+            int actualSize = Base64::atob(std::string(imagePointer), imgBuf);
+            int expectedSize = (strlen(imagePointer) * 3) / 4;
+            int difference = expectedSize - actualSize;
+            if (difference >= 0  && difference <= 2)    // considering padding: each set of 3 bytes is converted into 4 chars
             {
                 rapidjson::SizeType sizeImage = iteratorImage->value.GetStringLength() - (imageFormat.size() + 1);
                 image = std::string(imagePointer, sizeImage);
+            }
+            else
+            {
+                API_LOG_ERROR("Parse rich link: \"i\" field has a invalid format");
             }
         }
         else
@@ -9043,21 +9040,18 @@ MegaChatRichPreview *JSonUtils::parseRichPreview(rapidjson::Document &document, 
             iconPointer = iconPointer + iconFormat.size() + 1; // remove format.size() + ':'
 
             // Check if the icon format in B64 is valid
-            std::string dest, source;
-            source = std::string(iconPointer);
-            int size = Base64::atob(source, dest);
-            int auxSize = (source.size() * 3) / 4;
-
-            // The size diference between the value calculated above and the returned by the function, can't be bigger than 2 (considering the padding ==)
-            uint32_t diference = static_cast<uint32_t> (auxSize - size);
-            if (diference > 2)
-            {
-                API_LOG_ERROR("Parse rich link: \"ic\" field has a invalid format");
-            }
-            else
+            std::string iconBuf;
+            int actualSize = Base64::atob(std::string(iconPointer), iconBuf);
+            int expectedSize = (strlen(iconPointer) * 3) / 4;
+            int difference = expectedSize - actualSize;
+            if (difference >= 0  && difference <= 2)    // considering padding: each set of 3 bytes is converted into 4 chars
             {
                 rapidjson::SizeType sizeIcon = iteratorIcon->value.GetStringLength() - (iconFormat.size() + 1);
                 icon = std::string(iconPointer, sizeIcon);
+            }
+            else
+            {
+                API_LOG_ERROR("Parse rich link: \"ic\" field has a invalid format");
             }
         }
         else

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -9011,8 +9011,28 @@ MegaChatRichPreview *JSonUtils::parseRichPreview(rapidjson::Document &document, 
             const char *imagePointer = iteratorImage->value.GetString();
             imageFormat = getImageFormat(imagePointer);
             imagePointer = imagePointer + imageFormat.size() + 1; // remove format.size() + ':'
-            rapidjson::SizeType sizeImage = iteratorImage->value.GetStringLength() - (imageFormat.size() + 1);
-            image = std::string(imagePointer, sizeImage);
+
+            // Check if the image format in B64 is valid
+            std::string dest, source;
+            source = std::string(imagePointer);
+            int size = Base64::atob(source, dest);
+            int auxSize = (source.size() * 3) / 4;
+
+            // The size diference between the value calculated above and the returned by the function, can't be bigger than 2 (considering the padding ==)
+            uint32_t diference = static_cast<uint32_t> (auxSize - size);
+            if (diference > 2)
+            {
+                API_LOG_ERROR("Parse rich link: \"i\" field has a invalid format");
+            }
+            else
+            {
+                rapidjson::SizeType sizeImage = iteratorImage->value.GetStringLength() - (imageFormat.size() + 1);
+                image = std::string(imagePointer, sizeImage);
+            }
+        }
+        else
+        {
+            API_LOG_ERROR("Parse rich link: invalid JSON struct - \"i\" field not found");
         }
 
         rapidjson::Value::ConstMemberIterator iteratorIcon = richPreview.FindMember("ic");
@@ -9021,8 +9041,28 @@ MegaChatRichPreview *JSonUtils::parseRichPreview(rapidjson::Document &document, 
             const char *iconPointer = iteratorIcon->value.GetString();
             iconFormat = getImageFormat(iconPointer);
             iconPointer = iconPointer + iconFormat.size() + 1; // remove format.size() + ':'
-            rapidjson::SizeType sizeIcon = iteratorIcon->value.GetStringLength() - (iconFormat.size() + 1);
-            icon = std::string(iconPointer, sizeIcon);
+
+            // Check if the icon format in B64 is valid
+            std::string dest, source;
+            source = std::string(iconPointer);
+            int size = Base64::atob(source, dest);
+            int auxSize = (source.size() * 3) / 4;
+
+            // The size diference between the value calculated above and the returned by the function, can't be bigger than 2 (considering the padding ==)
+            uint32_t diference = static_cast<uint32_t> (auxSize - size);
+            if (diference > 2)
+            {
+                API_LOG_ERROR("Parse rich link: \"ic\" field has a invalid format");
+            }
+            else
+            {
+                rapidjson::SizeType sizeIcon = iteratorIcon->value.GetStringLength() - (iconFormat.size() + 1);
+                icon = std::string(iconPointer, sizeIcon);
+            }
+        }
+        else
+        {
+            API_LOG_ERROR("Parse rich link: invalid JSON struct - \"ic\" field not found");
         }
 
         rapidjson::Value::ConstMemberIterator iteratorURL = richPreview.FindMember("url");


### PR DESCRIPTION
The `i` and/or `ic` fields in the json returned by api could have an
invalid B64 format. In order to fix it we check the expected length
after convert it to binary, and check that the difference with the
returned value of atob is under 2 (considering the padding ==)