### PR TITLE
Hide presence status for non-contacts

### DIFF
--- a/examples/qtmegachatapi/MainWindow.cpp
+++ b/examples/qtmegachatapi/MainWindow.cpp
@@ -42,6 +42,7 @@ MainWindow::~MainWindow()
 {
     removeListeners();
     delete mChatSettings;
+    delete mSettings;
     clearChatControllers();
     clearContactControllersMap();
     delete ui;

--- a/examples/qtmegachatapi/SettingWindow.cpp
+++ b/examples/qtmegachatapi/SettingWindow.cpp
@@ -28,6 +28,7 @@ SettingWindow::SettingWindow(MegaChatApplication *app) :
 
 SettingWindow::~SettingWindow()
 {
+    delete mPresenceConfig;
     delete ui;
 }
 

--- a/examples/qtmegachatapi/SettingWindow.cpp
+++ b/examples/qtmegachatapi/SettingWindow.cpp
@@ -40,10 +40,15 @@ void SettingWindow::show()
 
 void SettingWindow::onPushNotificationSettingsUpdate()
 {
+    ui->pushNotifications->setEnabled(false);
+
     auto notificationSettings = mApp->getNotificationSettings();
     auto timeZoneDetails = mApp->getTimeZoneDetails();
-    assert(notificationSettings);
-    assert(timeZoneDetails);
+
+    if (!notificationSettings || !timeZoneDetails)
+    {
+        return;
+    }
 
     ::mega::m_time_t now = ::mega::m_time(NULL);
     ui->chats->setChecked(notificationSettings->isChatsEnabled());
@@ -245,8 +250,6 @@ void SettingWindow::savePresenceConfig()
     {
         mApp->megaChatApi()->setLastGreenVisible(showLastGreen);
     }
-
-
 }
 
 void SettingWindow::onClicked(QAbstractButton *button)

--- a/examples/qtmegachatapi/SettingWindow.h
+++ b/examples/qtmegachatapi/SettingWindow.h
@@ -2,6 +2,7 @@
 #define SETTINGWINDOW_H
 
 #include <megaapi.h>
+#include <megachatapi.h>
 #include <mega/types.h>
 #include <QDialog>
 #include <QDialogButtonBox>
@@ -23,6 +24,7 @@ public:
     ~SettingWindow();
     void show();
     void onPushNotificationSettingsUpdate();    // update the UI with new values
+    void onPresenceConfigUpdate();
 
 private:
     Ui::SettingWindow *ui;
@@ -31,13 +33,17 @@ private:
     // notification settings
     ::mega::m_time_t mGlobalDifference = -1;
     QStandardItemModel mNotificationSettingsPerChat;
-
     void savePushNotificationSettings();
+
+    // presence config
+    ::megachat::MegaChatPresenceConfig *mPresenceConfig = nullptr;
+    void savePresenceConfig();
 
 private slots:
     void onClicked(QAbstractButton*);
     void onGlobalClicked(bool value);
     void onScheduleEnabled(bool value);
+    void on_autoAwayCheckBox_clicked(bool checked);
 };
 
 #endif // SETTINGWINDOW_H

--- a/examples/qtmegachatapi/SettingWindow.ui
+++ b/examples/qtmegachatapi/SettingWindow.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="pushNotifications">
       <attribute name="title">
@@ -205,6 +205,103 @@
         </layout>
        </item>
       </layout>
+     </widget>
+     <widget class="QWidget" name="presence">
+      <attribute name="title">
+       <string>Presence</string>
+      </attribute>
+      <widget class="QWidget" name="formLayoutWidget">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>951</width>
+         <height>491</height>
+        </rect>
+       </property>
+       <layout class="QFormLayout" name="formLayout">
+        <property name="rowWrapPolicy">
+         <enum>QFormLayout::DontWrapRows</enum>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="statusLabel">
+          <property name="text">
+           <string>Status:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="statusComboBox">
+          <property name="minimumSize">
+           <size>
+            <width>789</width>
+            <height>0</height>
+           </size>
+          </property>
+          <item>
+           <property name="text">
+            <string>Offline</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Away</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Online</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Busy</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="autoAwayLabel">
+          <property name="text">
+           <string>Auto-away:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QCheckBox" name="autoAwayCheckBox"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="autoAwayTimeoutSLabel">
+          <property name="text">
+           <string>Auto-away timeout (s):</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLineEdit" name="autoAwayTimeoutSLineEdit"/>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="showLastGreenLabel">
+          <property name="text">
+           <string>Show last green:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QCheckBox" name="showLastGreenCheckBox"/>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="persistStatusLabel">
+          <property name="text">
+           <string>Persist status:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QCheckBox" name="persistStatusCheckBox"/>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </widget>
    </item>

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -1011,15 +1011,12 @@ public:
     /** @brief Does the actual connection to chatd and presenced. Assumes the
      * Mega SDK is already logged in. This must be called after
      * \c initNewSession() or \c initExistingSession() completes
-     * @param pres The presence which should be set. This is a forced presence,
-     * i.e. it will be preserved even if the client disconnects. To disable
-     * setting such a forced presence and assume whatever presence was last used,
-     * and/or use only dynamic presence, set this param to \c Presence::kClear
      * @param isInBackground In case the app requests to connect from a service in
-     * background, it should not send KEEPALIVE, but KEEPALIVEAWAY. Hence, it will
-     * avoid to tell chatd that the client is active.
+     * background, it should not send KEEPALIVE, but KEEPALIVEAWAY to chatd. Hence, it will
+     * avoid to tell chatd that the client is active. Also, the presenced client will
+     * prevent to send USERACTIVE 1 in background, since the user is not active.
      */
-    promise::Promise<void> connect(Presence pres=Presence::kClear, bool isInBackground = false);
+    promise::Promise<void> connect(bool isInBackground = false);
 
     /**
      * @brief Retry pending connections to chatd and presenced
@@ -1131,7 +1128,7 @@ protected:
      * connect() waits for the mCanConnect promise to be resolved and then calls
      * this method
      */
-    promise::Promise<void> doConnect(Presence pres, bool isInBackground);
+    promise::Promise<void> doConnect(bool isInBackground);
     void setConnState(ConnState newState);
 
     // mega::MegaGlobalListener interface, called by worker thread

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -896,6 +896,8 @@ protected:
     megaHandle mHeartbeatTimer = 0;
     InitStats mInitStats;
 
+    bool mIsInBackground = false;
+
 public:
 
     /**
@@ -1091,6 +1093,8 @@ public:
     void resetMyIdentity();
     uint64_t initMyIdentity();
 
+    bool isInBackground() const;
+
 protected:
     void heartbeat();
     void setInitState(InitState newState);
@@ -1117,7 +1121,7 @@ protected:
             std::shared_ptr<std::string> unifiedKey, int isUnifiedKeyEncrypted, karere::Id ph);
 
     // connection-related methods
-    void connectToChatd(bool isInBackground);
+    void connectToChatd();
     promise::Promise<void> connectToPresenced(Presence pres);
     promise::Promise<int> initializeContactList();
 
@@ -1128,7 +1132,7 @@ protected:
      * connect() waits for the mCanConnect promise to be resolved and then calls
      * this method
      */
-    promise::Promise<void> doConnect(bool isInBackground);
+    promise::Promise<void> doConnect();
     void setConnState(ConnState newState);
 
     // mega::MegaGlobalListener interface, called by worker thread

--- a/src/chatd.h
+++ b/src/chatd.h
@@ -1363,7 +1363,6 @@ protected:
     // to track changes in the richPreview's user-attribute
     karere::UserAttrCache::Handle mRichPrevAttrCbHandle;
 
-    uint8_t mKeepaliveType = OP_KEEPALIVE;
     int mKeepaliveCount = 0;                    // number of keepalives to be sent (one per connection)
     bool mKeepaliveFailed = false;              // true means any pending keepalive failed to send
     promise::Promise<void> mKeepalivePromise;   // resolved when all keepalive have been sent (or failed)
@@ -1422,7 +1421,7 @@ public:
     void retryPendingConnections(bool disconnect, bool refreshURL = false);
     void heartbeat();
 
-    promise::Promise<void> notifyUserStatus(bool background);
+    promise::Promise<void> notifyUserStatus();
 
     /** Changes the Rtc handler, returning the old one */
     IRtcHandler* setRtcHandler(IRtcHandler* handler);

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -1832,8 +1832,8 @@ public:
  * the status is other than online or the user has enabled the persistence of the status.
  * When the autoaway mechanish is enabled, it requires the app calls \c MegaChatApi::signalPresenceActivity
  * in order to prevent becoming MegaChatApi::STATUS_AWAY automatically after the timeout.
- * You can check if the autoaway mechanism is active by calling \c MegaChatApi::isSignalActivityRequired
- * or also by checking \c MegaChatPresenceConfig::isSignalActivityRequired.
+ * You can check if the autoaway mechanism is active by calling \c MegaChatApi::isSignalActivityRequired.
+ * While the is in background status, without user's activity, there is no need tosignal it.
  *
  * - Persist: if enabled, the online status will be preserved, even if user goes offline or closes the app
  *

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -217,7 +217,7 @@ void MegaChatApiImpl::sendPendingRequests()
         {
             bool isInBackground = request->getFlag();
 
-            mClient->connect(karere::Presence::kInvalid, isInBackground)
+            mClient->connect(isInBackground)
             .then([request, this]()
             {
                 MegaChatErrorPrivate *megaChatError = new MegaChatErrorPrivate(MegaChatError::ERROR_OK);

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -2457,7 +2457,7 @@ bool MegaChatApiImpl::isSignalActivityRequired()
 {
     sdkMutex.lock();
 
-    bool enabled = mClient ? mClient->presenced().autoAwayInEffect() : false;
+    bool enabled = mClient ? mClient->presenced().isSignalActivityRequired() : false;
 
     sdkMutex.unlock();
 
@@ -2512,14 +2512,9 @@ void MegaChatApiImpl::setBackgroundStatus(bool background, MegaChatRequestListen
 
 int MegaChatApiImpl::getBackgroundStatus()
 {
-    int status = -1;
-
     sdkMutex.lock();
 
-    if (mClient && mClient->mChatdClient)
-    {
-        status = (mClient->mChatdClient->keepaliveType() == chatd::OP_KEEPALIVE) ? 0 : 1;
-    }
+    int status = mClient ? int(mClient->isInBackground()) : -1;
 
     sdkMutex.unlock();
 
@@ -8184,14 +8179,6 @@ bool MegaChatPresenceConfigPrivate::isPersist() const
 bool MegaChatPresenceConfigPrivate::isPending() const
 {
     return pending;
-}
-
-bool MegaChatPresenceConfigPrivate::isSignalActivityRequired() const
-{
-    return (!persistEnabled
-            && status != MegaChatApi::STATUS_OFFLINE
-            && status != MegaChatApi::STATUS_AWAY
-            && autoawayEnabled && autoawayTimeout);
 }
 
 bool MegaChatPresenceConfigPrivate::isLastGreenVisible() const

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -135,7 +135,6 @@ public:
     virtual int64_t getAutoawayTimeout() const;
     virtual bool isPersist() const;
     virtual bool isPending() const;
-    virtual bool isSignalActivityRequired() const;
     virtual bool isLastGreenVisible() const;
 
 private:

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -1266,6 +1266,10 @@ void Client::handleMessage(const StaticBuffer& buf)
                                     && (!mTsLastUserActivity                    // first connection, signal active if not in background
                                         || ((time(NULL) - mTsLastUserActivity) < mConfig.mAutoawayTimeout));    // check autoaway's timeout
 
+                            if (isActive)
+                            {
+                                mTsLastUserActivity = time(NULL);
+                            }
                             sendUserActive(isActive, true);
                         }
                     }

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -760,7 +760,7 @@ void Client::onEvent(::mega::MegaApi *api, ::mega::MegaEvent *event)
                 for (int j = 0; j < peerlist->size(); j++)
                 {
                     uint64_t userid = peerlist->getPeerHandle(j);
-                    if (isContact(userid))
+                    if (isContact(userid) && !isExContact(userid))
                     {
                         mCurrentPeers.insert(userid);
                         mChatMembers[chatid].insert(userid);

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -1420,11 +1420,10 @@ void Client::removePeer(karere::Id peer, bool force)
 
 void Client::updatePeerPresence(karere::Id peer, karere::Presence pres)
 {
-    assert(!isNeverContact(peer));
     mPeersPresence[peer] = pres;
 
-    // Do not notify if the peer is ex-contact
-    if (!isExContact(peer))
+    // Do not notify if the peer is ex-contact or never has been contact
+    if (!isExContact(peer) || !isNeverContact(peer))
     {
         CALL_LISTENER(onPresenceChange, peer, pres);
     }

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -1400,7 +1400,7 @@ void Client::addPeer(karere::Id peer)
     if (isExContact(peer))
     {
         // Notify presence of non-contact that becomes contact again
-        Presence presence = mPeersPresence[peer];
+        Presence presence = peerPresence(peer);
         if (presence.isValid())
         {
             CALL_LISTENER(onPresenceChange, peer, presence);

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -485,6 +485,10 @@ public:
      * but when the app enters in background mode the user activity is not possible. */
     void signalInactivity();
 
+    /**
+     * Checks the app's state (background or foreground) and signals user's activity or
+     * inactivity accordingly.
+     */
     void notifyUserStatus();
 
     // peers management

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -441,6 +441,7 @@ protected:
     void removePeer(karere::Id peer, bool force=false);
     void pushPeers();
     bool isExContact(uint64_t userid);
+    bool isNeverContact(uint64_t userid);
 
     // mega::MegaGlobalListener interface, called by worker thread
     virtual void onChatsUpdate(::mega::MegaApi*, ::mega::MegaTextChatList* rooms);

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -339,8 +339,6 @@ protected:
     Listener* mListener;
     uint8_t mCapabilities;
 
-    bool mIsInBackground = false;
-
     /** Current state of the connection */
     ConnState mConnState = kConnNew;
 
@@ -467,8 +465,7 @@ public:
 
     // connection's management
     bool isOnline() const { return (mConnState >= kConnected); }
-    promise::Promise<void>
-    connect(bool isInBackground);
+    promise::Promise<void> connect();
     void disconnect();
     void doConnect();
     void retryPendingConnection(bool disconnect, bool refreshURL = false);
@@ -478,8 +475,17 @@ public:
      * perform pings at a single moment, to reduce mobile radio wakeup frequency */
     void heartbeat();
 
+    /** Returns true if apps should signal user's activity */
+    bool isSignalActivityRequired();
+
     /** Tells presenced that there's user's activity (notified by the app) */
     void signalActivity();
+
+    /** Tells presenced that user's activity stopped. Apps don't need to call this method explicitely,
+     * but when the app enters in background mode the user activity is not possible. */
+    void signalInactivity();
+
+    void notifyUserStatus();
 
     // peers management
     void updatePeerPresence(karere::Id peer, karere::Presence pres);
@@ -488,8 +494,8 @@ public:
     /** @brief Updates user last green if it's more recent than the current value.*/
     bool updateLastGreen(karere::Id userid, time_t lastGreen);
     time_t getLastGreen(karere::Id userid);
+
     ~Client();
-    void setIsInBackground(bool isInBackground);
 };
 
 class Listener

--- a/src/presenced.h
+++ b/src/presenced.h
@@ -441,7 +441,7 @@ protected:
     void removePeer(karere::Id peer, bool force=false);
     void pushPeers();
     bool isExContact(uint64_t userid);
-    bool isNeverContact(uint64_t userid);
+    bool isContact(uint64_t userid);
 
     // mega::MegaGlobalListener interface, called by worker thread
     virtual void onChatsUpdate(::mega::MegaApi*, ::mega::MegaTextChatList* rooms);


### PR DESCRIPTION
- Hide non-contacts presence status.
- Avoid to send `USERACTIVE 1` if connected in background.
- Add presence config to SettingsWindow in QtApp.