### PR TITLE
Cancel statistics when apps goes to background

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -4111,7 +4111,7 @@ std::string InitStats::toJson()
     jSonObject.AddMember(rapidjson::Value("sid"), jsonValue, jSonDocument.GetAllocator());
 
     // Add init stats version
-    uint32_t version = 2;
+    uint32_t version = INITSTATSVERSION;
     jsonValue.SetUint(version);
     jSonObject.AddMember(rapidjson::Value("v"), jsonValue, jSonDocument.GetAllocator());
 

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3956,7 +3956,7 @@ void InitStats::stageEnd(uint8_t stage)
     assert(mStageStats[stage]);
     mega::dstime aux = currentTime();
     mStageStats[stage] = aux - mStageStats[stage];
-    KR_LOG_WARNING("Stage: %d End: %ld Elap: %ld", stage, aux, mStageStats[stage]);
+    KR_LOG_DEBUG("Stage: %d End: %ld Elap: %ld", stage, aux, mStageStats[stage]);
 }
 
 void InitStats::setInitState(uint8_t state)

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3799,6 +3799,10 @@ bool InitStats::isCompleted() const
 void InitStats::onCanceled()
 {
     mCompleted = true;
+
+    // clear maps to free some memory
+    mStageShardStats.clear();
+    mStageStats.clear();
     KR_LOG_WARNING("Init stats have been cancelled");
 }
 
@@ -3939,6 +3943,7 @@ void InitStats::stageStart(uint8_t stage)
     }
 
     mStageStats[stage] = currentTime();
+    KR_LOG_WARNING("Stage: %d Start: %ld", stage, mStageStats[stage]);
 }
 
 void InitStats::stageEnd(uint8_t stage)
@@ -3949,7 +3954,9 @@ void InitStats::stageEnd(uint8_t stage)
     }
 
     assert(mStageStats[stage]);
-    mStageStats[stage] = currentTime() - mStageStats[stage];
+    mega::dstime aux = currentTime();
+    mStageStats[stage] = aux - mStageStats[stage];
+    KR_LOG_WARNING("Stage: %d End: %ld Elap: %ld", stage, aux, mStageStats[stage]);
 }
 
 void InitStats::setInitState(uint8_t state)

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3943,7 +3943,6 @@ void InitStats::stageStart(uint8_t stage)
     }
 
     mStageStats[stage] = currentTime();
-    KR_LOG_DEBUG("Stage: %d Start: %ld", stage, mStageStats[stage]);
 }
 
 void InitStats::stageEnd(uint8_t stage)
@@ -3954,9 +3953,7 @@ void InitStats::stageEnd(uint8_t stage)
     }
 
     assert(mStageStats[stage]);
-    mega::dstime aux = currentTime();
-    mStageStats[stage] = aux - mStageStats[stage];
-    KR_LOG_DEBUG("Stage: %d End: %ld Elap: %ld", stage, aux, mStageStats[stage]);
+    mStageStats[stage] = currentTime() - mStageStats[stage];
 }
 
 void InitStats::setInitState(uint8_t state)
@@ -4112,6 +4109,11 @@ std::string InitStats::toJson()
     // Add number of contacts
     jsonValue.SetInt64(mInitState);
     jSonObject.AddMember(rapidjson::Value("sid"), jsonValue, jSonDocument.GetAllocator());
+
+    // Add init stats version
+    uint32_t version = 2;
+    jsonValue.SetUint(version);
+    jSonObject.AddMember(rapidjson::Value("v"), jsonValue, jSonDocument.GetAllocator());
 
     // Add total elapsed
     jsonValue.SetInt64(totalElapsed);

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3943,7 +3943,7 @@ void InitStats::stageStart(uint8_t stage)
     }
 
     mStageStats[stage] = currentTime();
-    KR_LOG_WARNING("Stage: %d Start: %ld", stage, mStageStats[stage]);
+    KR_LOG_DEBUG("Stage: %d Start: %ld", stage, mStageStats[stage]);
 }
 
 void InitStats::stageEnd(uint8_t stage)

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -362,6 +362,10 @@ promise::Promise<void> Client::notifyUserStatus(bool background)
 {
     bool oldStatus = mIsInBackground;
     mIsInBackground = background;
+    if (mIsInBackground && !mInitStats.isCompleted())
+    {
+        mInitStats.onCanceled();
+    }
 
     if (oldStatus == mIsInBackground)
     {
@@ -1097,6 +1101,11 @@ void Client::dumpContactList(::mega::MegaUserList& clist)
 promise::Promise<void> Client::connect(bool isInBackground)
 {
     mIsInBackground = isInBackground;
+
+    if (mIsInBackground && !mInitStats.isCompleted())
+    {
+        mInitStats.onCanceled();
+    }
 
 // only the first connect() needs to wait for the mSessionReadyPromise.
 // Any subsequent connect()-s (preceded by disconnect()) can initiate
@@ -3785,6 +3794,12 @@ std::string encodeFirstName(const std::string& first)
 bool InitStats::isCompleted() const
 {
     return mCompleted;
+}
+
+void InitStats::onCanceled()
+{
+    mCompleted = true;
+    KR_LOG_WARNING("Init stats have been cancelled");
 }
 
 std::string InitStats::onCompleted(long long numNodes, size_t numChats, size_t numContacts)

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -608,6 +608,10 @@ public:
 class InitStats
 {
     public:
+
+        /** @brief MEGAchat init stats version */
+        const uint32_t INITSTATSVERSION = 2;
+
         /** @brief Init states in init stats */
         enum
         {

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -639,7 +639,7 @@ class InitStats
 
         std::string onCompleted(long long numNodes, size_t numChats, size_t numContacts);
         bool isCompleted() const;
-
+        void onCanceled();
 
         /*  Stages Methods */
 


### PR DESCRIPTION
In order to discard samples with atypical values because of inactivity periods, we need to cancel statistics when the app tries to connect in background or when the apps goes to background.