### PR TITLE
#12551 Use nickname if available

### DIFF
--- a/examples/qtmegachatapi/MainWindow.cpp
+++ b/examples/qtmegachatapi/MainWindow.cpp
@@ -1243,7 +1243,7 @@ void MainWindow::updateContactFirstname(MegaChatHandle contactHandle, const char
     if (itContacts != mContactControllers.end())
     {
         ContactListItemController *itemController = itContacts->second;
-        itemController->getWidget()->updateTitle(firstname);
+        itemController->getWidget()->updateName(firstname);
     }
 }
 

--- a/examples/qtmegachatapi/MegaChatApplication.cpp
+++ b/examples/qtmegachatapi/MegaChatApplication.cpp
@@ -259,7 +259,7 @@ void MegaChatApplication::onUsersUpdate(::mega::MegaApi *, ::mega::MegaUserList 
                     mMegaApi->getPushNotificationSettings();
                 }
 
-                if (user->hasChanged(MegaUser::CHANGE_TYPE_ALIAS) && !user->isOwnChange())
+                if (user->hasChanged(MegaUser::CHANGE_TYPE_ALIAS))
                 {
                     mMegaApi->getUserAttribute(::mega::MegaApi::USER_ATTR_ALIAS);
                 }
@@ -606,6 +606,11 @@ void MegaChatApplication::onRequestFinish(MegaApi *api, MegaRequest *request, Me
                 mMainWin->mSettings->onPushNotificationSettingsUpdate();
             }
         }
+        break;
+        case MegaRequest::TYPE_SET_ATTR_USER:
+        {
+        }
+        break;
 
         default:
             break;

--- a/examples/qtmegachatapi/MegaChatApplication.cpp
+++ b/examples/qtmegachatapi/MegaChatApplication.cpp
@@ -258,7 +258,20 @@ void MegaChatApplication::onUsersUpdate(::mega::MegaApi *, ::mega::MegaUserList 
                 {
                     mMegaApi->getPushNotificationSettings();
                 }
+
+                if (user->hasChanged(MegaUser::CHANGE_TYPE_ALIAS) && !user->isOwnChange())
+                {
+                    mMegaApi->getUserAttribute(::mega::MegaApi::USER_ATTR_ALIAS);
+                }
+
                 break;
+            }
+            else
+            {
+                if (user->hasChanged(MegaUser::CHANGE_TYPE_FIRSTNAME)&& !user->isOwnChange())
+                {
+                    getFirstname(user->getHandle(), NULL, true);
+                }
             }
         }
     }
@@ -279,7 +292,7 @@ void MegaChatApplication::onChatNotification(MegaChatApi *, MegaChatHandle chati
     delete [] msgid;
 }
 
-const char *MegaChatApplication::getFirstname(MegaChatHandle uh, const char *authorizationToken)
+const char *MegaChatApplication::getFirstname(MegaChatHandle uh, const char *authorizationToken, bool force)
 {
     if (uh == mMegaChatApi->getMyUserHandle())
     {
@@ -292,7 +305,7 @@ const char *MegaChatApplication::getFirstname(MegaChatHandle uh, const char *aut
     }
 
     auto it = mFirstnamesMap.find(uh);
-    if (it != mFirstnamesMap.end())
+    if (it != mFirstnamesMap.end() && !force)
     {
         return MegaApi::strdup(it->second.c_str());
     }

--- a/examples/qtmegachatapi/MegaChatApplication.cpp
+++ b/examples/qtmegachatapi/MegaChatApplication.cpp
@@ -107,7 +107,7 @@ void MegaChatApplication::login()
    mLoginDialog->show();
 }
 
-std::string MegaChatApplication::getText(std::string title)
+std::string MegaChatApplication::getText(std::string title, bool allowEmpty)
 {
     bool ok;
     std::string text;
@@ -121,7 +121,7 @@ std::string MegaChatApplication::getText(std::string title)
         if (ok)
         {
             text = qText.toStdString();
-            if (text.size() > 0)
+            if (text.size() > 0 || allowEmpty)
             {
                 return text;
             }

--- a/examples/qtmegachatapi/MegaChatApplication.h
+++ b/examples/qtmegachatapi/MegaChatApplication.h
@@ -36,6 +36,8 @@ class MegaChatApplication : public QApplication,
         void removeSid();
         LoginDialog *loginDialog() const;
         void resetLoginDialog();
+        std::string base64ToBinary(const char *base64);
+        std::string getLocalUserAlias(megachat::MegaChatHandle uh);
 
         virtual void onRequestFinish(megachat::MegaChatApi *mMegaChatApi, megachat::MegaChatRequest *request, megachat::MegaChatError *e);
         virtual void onRequestFinish(::mega::MegaApi *api, ::mega::MegaRequest *request, ::mega::MegaError *e);
@@ -67,6 +69,7 @@ protected:
 
     private:
         std::map<megachat::MegaChatHandle, std::string> mFirstnamesMap;
+        std::map<megachat::MegaChatHandle, std::string> mAliasesMap;
         std::map<megachat::MegaChatHandle, bool> mFirstnameFetching;
         bool useStaging = false;
         std::shared_ptr<::mega::MegaPushNotificationSettings> mNotificationSettings;

--- a/examples/qtmegachatapi/MegaChatApplication.h
+++ b/examples/qtmegachatapi/MegaChatApplication.h
@@ -29,7 +29,7 @@ class MegaChatApplication : public QApplication,
         void login();
         void configureLogs();
         bool initAnonymous(std::string chatlink);
-        std::string getText(std::string title);
+        std::string getText(std::string title, bool allowEmpty = false);
         const char *readSid();
         const char *sid() const;
         void saveSid(const char *sid);

--- a/examples/qtmegachatapi/MegaChatApplication.h
+++ b/examples/qtmegachatapi/MegaChatApplication.h
@@ -44,7 +44,7 @@ class MegaChatApplication : public QApplication,
         virtual void onUsersUpdate(::mega::MegaApi *api, ::mega::MegaUserList *userList);
         virtual void onChatNotification(megachat::MegaChatApi *api, megachat::MegaChatHandle chatid, megachat::MegaChatMessage *msg);
 
-        const char *getFirstname(megachat::MegaChatHandle uh, const char *authorizationToken);
+        const char *getFirstname(megachat::MegaChatHandle uh, const char *authorizationToken, bool force = false);
 
         bool isStagingEnabled();
         void enableStaging(bool enable);

--- a/examples/qtmegachatapi/contactItemWidget.cpp
+++ b/examples/qtmegachatapi/contactItemWidget.cpp
@@ -20,7 +20,7 @@ ContactItemWidget::ContactItemWidget(QWidget *parent, MainWindow *mainWin, megac
     ui->mUnreadIndicator->hide();
     ui->mPreviewersIndicator->hide();
     QString text = QString::fromUtf8(contactEmail);
-    ui->mName->setText(contactEmail);
+    ui->mName->setText(text);
 
     const char *firstname = mMainWin->mApp->getFirstname(contact->getHandle(), NULL);
     mName = firstname ? std::string(firstname) : std::string();

--- a/examples/qtmegachatapi/contactItemWidget.cpp
+++ b/examples/qtmegachatapi/contactItemWidget.cpp
@@ -274,7 +274,7 @@ void ContactItemWidget::updateTitle()
         text = QString::fromUtf8(mAlias.c_str());
         if (!mName.empty())
         {
-            text.append("(")
+            text.append(" (")
             .append(QString::fromUtf8(mName.c_str()))
             .append(")");
         }

--- a/examples/qtmegachatapi/contactItemWidget.cpp
+++ b/examples/qtmegachatapi/contactItemWidget.cpp
@@ -272,6 +272,12 @@ void ContactItemWidget::updateTitle()
     if (!mAlias.empty())
     {
         text = QString::fromUtf8(mAlias.c_str());
+        if (!mName.empty())
+        {
+            text.append("(")
+            .append(QString::fromUtf8(mName.c_str()))
+            .append(")");
+        }
     }
     else if (!mName.empty())
     {

--- a/examples/qtmegachatapi/contactItemWidget.cpp
+++ b/examples/qtmegachatapi/contactItemWidget.cpp
@@ -48,33 +48,42 @@ void ContactItemWidget::setAvatarStyle()
 void ContactItemWidget::contextMenuEvent(QContextMenuEvent *event)
 {
     QMenu menu(this);
-    auto chatPeerInviteAction = menu.addAction(tr("Invite to 1on1 chat"));
+
+    QMenu *chatMenu = menu.addMenu("Chats");
+
+    auto chatPeerInviteAction = chatMenu->addAction(tr("Invite to 1on1 chat"));
     connect(chatPeerInviteAction, SIGNAL(triggered()), this, SLOT(onCreatePeerChat()));
 
-    auto chatInviteAction = menu.addAction(tr("Invite to group chat"));
+    auto chatInviteAction = chatMenu->addAction(tr("Invite to group chat"));
     connect(chatInviteAction, SIGNAL(triggered()), this, SLOT(onCreateGroupChat()));
 
-    auto publicChatInviteAction = menu.addAction(tr("Invite to PUBLIC group chat"));
+    auto publicChatInviteAction = chatMenu->addAction(tr("Invite to PUBLIC group chat"));
     connect(publicChatInviteAction, SIGNAL(triggered()), this, SLOT(onCreatePublicGroupChat()));
-
-    auto printAction = menu.addAction(tr("Print contact info"));
-    connect(printAction, SIGNAL(triggered()), this, SLOT(onPrintContactInfo()));
-
-    if (mUserVisibility == ::mega::MegaUser::VISIBILITY_VISIBLE)
-    {
-        auto removeAction = menu.addAction(tr("Remove contact"));
-        connect(removeAction, SIGNAL(triggered()), this, SLOT(onContactRemove()));
-    }
-    else if (mUserVisibility == ::mega::MegaUser::VISIBILITY_HIDDEN)
-    {
-        auto addAction = menu.addAction(tr("Invite ex-contact"));
-        connect(addAction, SIGNAL(triggered()), this, SLOT(onExContactInvite()));
-    }
 
     auto lastGreenAction = menu.addAction(tr("Last time user was online"));
     connect(lastGreenAction, SIGNAL(triggered()), this, SLOT(onRequestLastGreen()));
 
+    QMenu *othersMenu = menu.addMenu("Others");
+
+    auto printAction = othersMenu->addAction(tr("Print contact info"));
+    connect(printAction, SIGNAL(triggered()), this, SLOT(onPrintContactInfo()));
+
+    if (mUserVisibility == ::mega::MegaUser::VISIBILITY_VISIBLE)
+    {
+        auto removeAction = othersMenu->addAction(tr("Remove contact"));
+        connect(removeAction, SIGNAL(triggered()), this, SLOT(onContactRemove()));
+    }
+    else if (mUserVisibility == ::mega::MegaUser::VISIBILITY_HIDDEN)
+    {
+        auto addAction = othersMenu->addAction(tr("Invite ex-contact"));
+        connect(addAction, SIGNAL(triggered()), this, SLOT(onExContactInvite()));
+    }
+
+    auto aliasAction = othersMenu->addAction(tr("Set nickname"));
+    connect(aliasAction, SIGNAL(triggered()), this, SLOT(onSetNickname()));
+
     menu.addSeparator();
+
     auto copyHandleAction = menu.addAction(tr("Copy to clipboard user id"));
     connect(copyHandleAction, SIGNAL(triggered()), this, SLOT(onCopyHandle()));
 
@@ -243,6 +252,12 @@ void ContactItemWidget::onCopyHandle()
     QClipboard *clipboard = QApplication::clipboard();
     clipboard->setText(handel_64);
     delete []handel_64;
+}
+
+void ContactItemWidget::onSetNickname()
+{
+    std::string nickname = mMainWin->mApp->getText("Set nickname: ", true);
+    mMegaApi->setUserAlias(mUserHandle, nickname.c_str());
 }
 
 void ContactItemWidget::updateName(const char *name)

--- a/examples/qtmegachatapi/contactItemWidget.cpp
+++ b/examples/qtmegachatapi/contactItemWidget.cpp
@@ -21,14 +21,12 @@ ContactItemWidget::ContactItemWidget(QWidget *parent, MainWindow *mainWin, megac
     ui->mPreviewersIndicator->hide();
     QString text = QString::fromUtf8(contactEmail);
     ui->mName->setText(contactEmail);
-    ui->mAvatar->setText(QString(text[0].toUpper()));
 
     const char *firstname = mMainWin->mApp->getFirstname(contact->getHandle(), NULL);
-    if (firstname)
-    {
-        updateTitle(firstname);
-    }
+    mName = firstname ? std::string(firstname) : std::string();
     delete [] firstname;
+    mAlias = mMainWin->mApp->getLocalUserAlias(mUserHandle);
+    updateTitle();
 
     int status = mMegaChatApi->getUserOnlineStatus(mUserHandle);
     updateOnlineIndicator(status);
@@ -247,18 +245,28 @@ void ContactItemWidget::onCopyHandle()
     delete []handel_64;
 }
 
-void ContactItemWidget::updateTitle(const char *firstname)
+void ContactItemWidget::updateName(const char *name)
+{
+    mName = name ? name : std::string();
+    updateTitle();
+}
+
+void ContactItemWidget::updateTitle()
 {
     QString text;
-    if (strcmp(firstname, "") == 0)
+    if (!mAlias.empty())
+    {
+        text = QString::fromUtf8(mAlias.c_str());
+    }
+    else if (!mName.empty())
+    {
+        text = QString::fromUtf8(mName.c_str());
+    }
+    else
     {
         const char *auxEmail = mMegaChatApi->getContactEmail(mUserHandle);
         text = QString::fromUtf8(auxEmail);
         delete [] auxEmail;
-    }
-    else
-    {
-        text = QString::fromUtf8(firstname);
     }
 
     switch (mUserVisibility)

--- a/examples/qtmegachatapi/contactItemWidget.h
+++ b/examples/qtmegachatapi/contactItemWidget.h
@@ -20,7 +20,8 @@ class ContactItemWidget : public QWidget
         void setAvatarStyle();
         void updateOnlineIndicator(int newState);
         void updateToolTip(mega::MegaUser *contact);
-        void updateTitle(const char *firstname);
+        void updateName(const char *name);
+        void updateTitle();
         QListWidgetItem *getWidgetItem() const;
         void setWidgetItem(QListWidgetItem *item);
         void createChatRoom(megachat::MegaChatHandle uh, bool isGroup, bool isPublic);
@@ -33,6 +34,8 @@ class ContactItemWidget : public QWidget
         ::mega::MegaApi *mMegaApi;
         QListWidgetItem *mListWidgetItem;
         MainWindow *mMainWin;
+        std::string mName;
+        std::string mAlias;
 
     void createChatRoom(megachat::MegaChatHandle uh, bool isGroup);
 

--- a/examples/qtmegachatapi/contactItemWidget.h
+++ b/examples/qtmegachatapi/contactItemWidget.h
@@ -48,5 +48,6 @@ class ContactItemWidget : public QWidget
         void onRequestLastGreen();
         void onExContactInvite();
         void onCopyHandle();
+        void onSetNickname();
 };
 #endif // CONTACITEMWIDGET_H

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2167,6 +2167,11 @@ void PeerChatRoom::initContact(const uint64_t& peer)
     }
 }
 
+void PeerChatRoom::updateContactTitle(const std::string& str)
+{
+    mContact->updateTitle(str);
+}
+
 uint64_t PeerChatRoom::getSdkRoomPeer(const ::mega::MegaTextChat& chat)
 {
     auto peers = chat.getPeerList();

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2153,7 +2153,7 @@ void PeerChatRoom::initContact(const uint64_t& peer)
 
             // If the contact has alias don't update the title
             auto self = static_cast<PeerChatRoom*>(userp);
-            const char *alias = self->parent.mKarereClient.getUserAlias(self->contact()->userId());
+            const char *alias = self->parent.mKarereClient.getUserAlias(self->mPeer);
             if (!alias)
             {
                 if (!data || data->empty() || (*data->buf() == 0 && data->size() == 1))

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2155,7 +2155,7 @@ void PeerChatRoom::initContact(const uint64_t& peer)
             // If the contact has alias don't update the title
             auto self = static_cast<PeerChatRoom*>(userp);
             std::string alias = self->parent.mKarereClient.getUserAlias(self->mPeer);
-            if (alias.size() <= 1)
+            if (!alias.size())
             {
                 if (!data || data->empty() || (*data->buf() == 0 && data->size() == 1))
                 {
@@ -2683,7 +2683,7 @@ void GroupChatRoom::makeTitleFromMemberNames()
         for (auto& m: mPeers)
         {
             std::string alias = parent.mKarereClient.getUserAlias(m.first);
-            if (alias.size() > 1)
+            if (alias.size())
             {
                 // Add user's alias to the title
                 newTitle.append(alias).append(", ");
@@ -3707,7 +3707,7 @@ Contact::Contact(ContactList& clist, const uint64_t& userid,
             // If the contact has alias don't update the title
             auto self = static_cast<Contact*>(userp);
             std::string alias = self->mClist.client.getUserAlias(self->userId());
-            if (alias.size() <= 1)
+            if (!alias.size())
             {
                 if (!data || data->empty() || (*data->buf() == 0 && data->size() == 1))
                     self->updateTitle(encodeFirstName(self->mEmail));

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1512,7 +1512,6 @@ void Client::terminate(bool deleteDb)
         mUserAttrCache->removeCb(mAliasAttrHandle);
         mUserAttrCache->onLogOut();
         mUserAttrCache.reset();
-        mAliasesMap.clear();
 
         // stop heartbeats
         if (mHeartbeatTimer)

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2661,28 +2661,38 @@ void GroupChatRoom::makeTitleFromMemberNames()
     {
         for (auto& m: mPeers)
         {
+            const char *alias = parent.mKarereClient.getUserAlias(m.first);
             //name has binary layout
             auto& name = m.second->mName;
             assert(!name.empty()); //is initialized to '\0', so is never empty
-            if (name.size() <= 1)
+
+            if (alias)
             {
+                // Add user's alias to the title
+                newTitle.append(alias).append(", ");
+            }
+            else if (name.size() > 1)
+            {
+                int firstnameLen = name.at(0);
+                if (firstnameLen)
+                {
+                    // Add user's first name to the title
+                    newTitle.append(name.substr(1, firstnameLen)).append(", ");
+                }
+                else
+                {
+                    // Add user's last name to the title
+                    newTitle.append(name.substr(1)).append(", ");
+                }
+            }
+            else
+            {
+                // Add user's email to the title
                 auto& email = m.second->mEmail;
                 if (!email.empty())
                     newTitle.append(email).append(", ");
                 else
                     newTitle.append("..., ");
-            }
-            else
-            {
-                int firstnameLen = name.at(0);
-                if (firstnameLen)
-                {
-                    newTitle.append(name.substr(1, firstnameLen)).append(", ");
-                }
-                else
-                {
-                    newTitle.append(name.substr(1)).append(", ");
-                }
             }
         }
         newTitle.resize(newTitle.size()-2); //truncate last ", "

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1508,8 +1508,10 @@ void Client::terminate(bool deleteDb)
 
         // stop syncing own-name and close user-attributes cache
         mUserAttrCache->removeCb(mOwnNameAttrHandle);
+        mUserAttrCache->removeCb(mAliasAttrHandle);
         mUserAttrCache->onLogOut();
         mUserAttrCache.reset();
+        mAliasesMap.clear();
 
         // stop heartbeats
         if (mHeartbeatTimer)

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2123,14 +2123,20 @@ PeerChatRoom::PeerChatRoom(ChatRoomList& parent, const mega::MegaTextChat& chat)
 }
 PeerChatRoom::~PeerChatRoom()
 {
-    if (mRoomGui && !parent.mKarereClient.isTerminated())
+    auto &client = parent.mKarereClient;
+    if (!client.isTerminated())
     {
-        parent.mKarereClient.app.chatListHandler()->removePeerChatItem(*mRoomGui);
+        client.userAttrCache().removeCb(mUsernameAttrCbId);
+
+        if (mRoomGui)
+        {
+            client.app.chatListHandler()->removePeerChatItem(*mRoomGui);
+        }
     }
 
-    if (parent.mKarereClient.mChatdClient)
+    if (client.mChatdClient)
     {
-        parent.mKarereClient.mChatdClient->leave(mChatid);
+        client.mChatdClient->leave(mChatid);
     }
 }
 

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2150,14 +2150,20 @@ void PeerChatRoom::initContact(const uint64_t& peer)
             //one byte - the firstname-size-prefix, which will be zero but
             //if lastname is not null the first byte will contain the
             //firstname-size-prefix but datasize will be bigger than 1 byte.
+
+            // If the contact has alias don't update the title
             auto self = static_cast<PeerChatRoom*>(userp);
-            if (!data || data->empty() || (*data->buf() == 0 && data->size() == 1))
+            const char *alias = self->parent.mKarereClient.getUserAlias(self->contact()->userId());
+            if (!alias)
             {
-                self->updateTitle(self->mEmail);
-            }
-            else
-            {
-                self->updateTitle(std::string(data->buf()+1, data->dataSize()-1));
+                if (!data || data->empty() || (*data->buf() == 0 && data->size() == 1))
+                {
+                    self->updateTitle(self->mEmail);
+                }
+                else
+                {
+                    self->updateTitle(std::string(data->buf()+1, data->dataSize()-1));
+                }
             }
         });
 
@@ -3686,11 +3692,17 @@ Contact::Contact(ContactList& clist, const uint64_t& userid,
             //one byte - the firstname-size-prefix, which will be zero but
             //if lastname is not null the first byte will contain the
             //firstname-size-prefix but datasize will be bigger than 1 byte.
+
+            // If the contact has alias don't update the title
             auto self = static_cast<Contact*>(userp);
-            if (!data || data->empty() || (*data->buf() == 0 && data->size() == 1))
-                self->updateTitle(encodeFirstName(self->mEmail));
-            else
-                self->updateTitle(std::string(data->buf(), data->dataSize()));
+            const char *alias = self->mClist.client.getUserAlias(self->userId());
+            if (!alias)
+            {
+                if (!data || data->empty() || (*data->buf() == 0 && data->size() == 1))
+                    self->updateTitle(encodeFirstName(self->mEmail));
+                else
+                    self->updateTitle(std::string(data->buf(), data->dataSize()));
+            }
         });
     if (mTitleString.empty()) // user attrib fetch was not synchornous
     {

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2182,15 +2182,25 @@ void PeerChatRoom::initContact(const uint64_t& peer)
     }
 }
 
-void PeerChatRoom::updateChatRoomTitle(const std::string& str)
+void PeerChatRoom::updateChatRoomTitle()
 {
+    std::string title = parent.mKarereClient.getUserAlias(mPeer);
+    if (title.empty())
+    {
+        title = mContact->getContactName();
+        if (title.empty())
+        {
+            title = mEmail;
+        }
+    }
+
     if (mContact)
     {
-        mContact->updateTitle(encodeFirstName(str));
+        mContact->updateTitle(encodeFirstName(title));
     }
     else
     {
-        updateTitle(str);
+        updateTitle(title);
     }
 }
 

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -797,6 +797,17 @@ void Client::initWithDbSession(const char* sid)
         mContactsLoaded = true;
         mChatdClient.reset(new chatd::Client(this));
         chats->loadFromDb();
+
+        // Get aliases once contacts and chats has been loaded
+        mAliasAttrHandle = mUserAttrCache->getAttr(mMyHandle,
+        ::mega::MegaApi::USER_ATTR_ALIAS, this,
+        [](Buffer *data, void *userp)
+        {
+            if (data && !data->empty())
+            {
+                static_cast<Client*>(userp)->updateAliases(data);
+            }
+        });
     }
     catch(std::runtime_error& e)
     {
@@ -1197,6 +1208,16 @@ promise::Promise<void> Client::doConnect()
         auto& name = static_cast<Client*>(userp)->mMyName;
         name.assign(buf->buf(), buf->dataSize());
         KR_LOG_DEBUG("Own screen name is: '%s'", name.c_str()+1);
+    });
+
+    mAliasAttrHandle = mUserAttrCache->getAttr(mMyHandle,
+    ::mega::MegaApi::USER_ATTR_ALIAS, this,
+    [](Buffer *data, void *userp)
+    {
+        if (data && !data->empty())
+        {
+            static_cast<Client*>(userp)->updateAliases(data);
+        }
     });
 
 #ifndef KARERE_DISABLE_WEBRTC

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3936,14 +3936,11 @@ void Client::updateAliases(Buffer *data)
 std::string Client::getUserAlias(uint64_t userId)
 {
     std::string aliasBin;
-    std::map<uint64_t, std::string>::iterator it;
-    it = mAliasesMap.find(userId);
+    AliasesMap::iterator it = mAliasesMap.find(userId);
     if (it != mAliasesMap.end())
     {
-        std::string aliasB64 = it->second;
-        Buffer buf(aliasB64.size());
-        size_t decLen = base64urldecode(aliasB64.c_str(), aliasB64.size(), buf.buf(), buf.bufSize());
-        aliasBin.assign(buf.buf(), decLen);
+        const std::string &aliasB64 = it->second;
+        ::mega::Base64::atob(aliasB64, aliasBin);
     }
     return aliasBin;
 }

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3906,7 +3906,7 @@ void Client::updateAliases(Buffer *data)
                 // in aliasesUpdated map we need to re-generate the default title
                 // if there's no custom title
                 GroupChatRoom *room = static_cast<GroupChatRoom *>(chatroom);
-                if (room->hasTitle() || room->peers().find(userHandle) != room->peers().end())
+                if (room->hasTitle() || room->peers().find(userHandle) == room->peers().end())
                 {
                     continue;
                 }

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3827,6 +3827,21 @@ bool Client::isCallInProgress(karere::Id chatid) const
     return participantingInCall;
 }
 
+const char *Client::getUserAlias(uint64_t userId)
+{
+    std::map<uint64_t, std::string>::iterator it;
+    it = mAliasesMap.find(userId);
+    if (it != mAliasesMap.end())
+    {
+        std::string alias = it->second;
+        if (alias.size() > 1)
+        {
+            return it->second.c_str();
+        }
+    }
+    return NULL;
+}
+
 std::string encodeFirstName(const std::string& first)
 {
     std::string result;

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3586,6 +3586,16 @@ void Contact::onVisibilityChanged(int newVisibility)
     }
 }
 
+void Contact::setContactName(std::string name)
+{
+    mName = name;
+}
+
+std::string Contact::getContactName()
+{
+    return mName;
+}
+
 void ContactList::syncWithApi(mega::MegaUserList& users)
 {
     std::set<uint64_t> apiUsers;
@@ -3724,7 +3734,9 @@ Contact::Contact(ContactList& clist, const uint64_t& userid,
             }
             else
             {
-                self->updateTitle(std::string(data->buf(), data->dataSize()));
+                std::string name(data->buf(), data->dataSize());
+                self->setContactName(name.substr(1));
+                self->updateTitle(name);
             }
         }
     });

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -1015,6 +1015,10 @@ void Client::onRequestFinish(::mega::MegaApi* /*apiObj*/, ::mega::MegaRequest *r
         {
             changeType = ::mega::MegaUser::CHANGE_TYPE_LASTNAME;
         }
+        else if (attrType == ::mega::MegaApi::USER_ATTR_ALIAS)
+        {
+            changeType = ::mega::MegaUser::CHANGE_TYPE_ALIAS;
+        }
         else
         {
             return;
@@ -3901,7 +3905,6 @@ void Client::updateAliases(Buffer *data)
         const std::string container(data->buf(), data->size());
         ::mega::TLVstore *tlvRecords = ::mega::TLVstore::containerToTLVrecords(&container);
         std::vector<std::string> *keys = tlvRecords->getKeys();
-
 
         // Create a new map <uhBin, aliasB64> for the aliases that have been updated
         for (size_t i = 0; i < keys->size(); i++)

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -2175,11 +2175,15 @@ void PeerChatRoom::initContact(const uint64_t& peer)
     }
 }
 
-void PeerChatRoom::updateContactTitle(const std::string& str)
+void PeerChatRoom::updateChatRoomTitle(const std::string& str)
 {
     if (mContact)
     {
         mContact->updateTitle(str);
+    }
+    else
+    {
+        updateTitle(str.substr(1));
     }
 }
 
@@ -3899,7 +3903,7 @@ void Client::updateAliases(Buffer *data)
                 PeerChatRoom *room = static_cast<PeerChatRoom *>(chatroom);
                 if (userHandle == room->peer())
                 {
-                    room->updateContactTitle(encodeFirstName(aliasBin));
+                    room->updateChatRoomTitle(encodeFirstName(aliasBin));
                 }
             }
         }

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -1105,7 +1105,9 @@ public:
 
     bool isInBackground() const;
     void updateAliases(Buffer *data);
-    const char *getUserAlias(uint64_t userId);
+
+    /** @brief Returns a string that contains the user alias in UTF-8 if exists, otherwise returns an empty string*/
+    std::string getUserAlias(uint64_t userId);
 
 protected:
     void heartbeat();

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -907,6 +907,8 @@ protected:
 
     megaHandle mHeartbeatTimer = 0;
     InitStats mInitStats;
+
+    // Maps uhBin to user alias encoded in B64
     AliasesMap mAliasesMap;
     bool mIsInBackground = false;
 

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -305,7 +305,6 @@ public:
         UserAttrCache::Handle mEmailAttrCbHandle;
         std::string mName;
         std::string mEmail;
-        void subscribeForNameChanges();
         promise::Promise<void> mNameResolved;
 
     public:
@@ -468,7 +467,6 @@ class Contact: public karere::DeleteTrackable
 /** @cond PRIVATE */
 protected:
     ContactList& mClist;
-    Presence mPresence;
     uint64_t mUserid;
     PeerChatRoom* mChatRoom;
     UserAttrCache::Handle mUsernameAttrCbId;

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -278,6 +278,7 @@ public:
     virtual const std::string& email() const { return mEmail; }
 
     void initContact(const uint64_t& peer);
+    void updateContactTitle(const std::string& str);
 
 /** @cond PRIVATE */
     //chatd::Listener interface

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -1104,6 +1104,7 @@ public:
     uint64_t initMyIdentity();
 
     bool isInBackground() const;
+    void updateAliases(Buffer *data);
     const char *getUserAlias(uint64_t userId);
 
 protected:

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -56,7 +56,7 @@ class Contact;
 class ContactList;
 
 typedef std::map<Id, chatd::Priv> UserPrivMap;
-typedef std::map<uint64_t, std::string> AliasMap;
+typedef std::map<uint64_t, std::string> AliasesMap;
 class ChatRoomList;
 
 /** @brief An abstract class representing a chatd chatroom. It has two
@@ -888,6 +888,7 @@ protected:
     uint64_t mMyIdentity = 0; // seed for CLIENTID
     std::unique_ptr<UserAttrCache> mUserAttrCache;
     UserAttrCache::Handle mOwnNameAttrHandle;
+    UserAttrCache::Handle mAliasAttrHandle;
 
     std::string mSid;
     std::string mLastScsn;
@@ -906,7 +907,7 @@ protected:
 
     megaHandle mHeartbeatTimer = 0;
     InitStats mInitStats;
-    AliasMap aliasMap;
+    AliasesMap mAliasesMap;
     bool mIsInBackground = false;
 
 public:

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -56,6 +56,7 @@ class Contact;
 class ContactList;
 
 typedef std::map<Id, chatd::Priv> UserPrivMap;
+typedef std::map<uint64_t, std::string> AliasMap;
 class ChatRoomList;
 
 /** @brief An abstract class representing a chatd chatroom. It has two
@@ -904,7 +905,7 @@ protected:
 
     megaHandle mHeartbeatTimer = 0;
     InitStats mInitStats;
-
+    AliasMap aliasMap;
     bool mIsInBackground = false;
 
 public:

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -473,6 +473,7 @@ protected:
     std::string mEmail;
     int64_t mSince;
     std::string mTitleString;
+    std::string mName;
     int mVisibility;
     bool mIsInitializing = true;
     void updateTitle(const std::string& str);
@@ -523,6 +524,12 @@ public:
     bool isInitializing() const { return mIsInitializing; }
     /** @cond PRIVATE */
     void onVisibilityChanged(int newVisibility);
+
+    /** @brief Set the full name of this contact */
+    void setContactName(std::string name);
+
+    /** @brief Returns the full name of this contact */
+    std::string getContactName();
 };
 
 /** @brief This is the karere contactlist class. It maps user ids

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -278,7 +278,7 @@ public:
     virtual const std::string& email() const { return mEmail; }
 
     void initContact(const uint64_t& peer);
-    void updateContactTitle(const std::string& str);
+    void updateChatRoomTitle(const std::string& str);
 
 /** @cond PRIVATE */
     //chatd::Listener interface

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -1104,6 +1104,7 @@ public:
     uint64_t initMyIdentity();
 
     bool isInBackground() const;
+    const char *getUserAlias(uint64_t userId);
 
 protected:
     void heartbeat();

--- a/src/chatClient.h
+++ b/src/chatClient.h
@@ -278,7 +278,7 @@ public:
     virtual const std::string& email() const { return mEmail; }
 
     void initContact(const uint64_t& peer);
-    void updateChatRoomTitle(const std::string& str);
+    void updateChatRoomTitle();
 
 /** @cond PRIVATE */
     //chatd::Listener interface

--- a/src/userAttrCache.cpp
+++ b/src/userAttrCache.cpp
@@ -150,6 +150,13 @@ UserAttrDescMap gUserAttrDescsMap =
 
     // VIRTUAL ATTRIBUTES
 
+    //RSA Public key
+      {
+        USER_ATTR_RSA_PUBKEY,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_SIG_PUBKEY_RSA)
+      },
     //email
       {
         USER_ATTR_EMAIL,

--- a/src/userAttrCache.cpp
+++ b/src/userAttrCache.cpp
@@ -88,133 +88,169 @@ Buffer* getDataNotImpl(const ::mega::MegaRequest& /*req*/)
      throw std::runtime_error("Not implemented");
 }
 
-UserAttrDesc gUserAttrDescs[22] =
-{ //attrib code, getData func, changeMask
-  //avatar
-    {
-      ::mega::MegaApi::USER_ATTR_AVATAR,
-      [](const ::mega::MegaRequest& req)->Buffer* { return bufFromCstr(req.getFile()); },
-      ::mega::MegaUser::CHANGE_TYPE_AVATAR
-    },
-  //first name
-    {
-      ::mega::MegaApi::USER_ATTR_FIRSTNAME,
-      [](const ::mega::MegaRequest& req)->Buffer* { return bufFromCstr(req.getText()); },
-      ::mega::MegaUser::CHANGE_TYPE_FIRSTNAME
-    },
-  //last name
-    {
-      ::mega::MegaApi::USER_ATTR_LASTNAME,
-      [](const ::mega::MegaRequest& req)->Buffer* { return bufFromCstr(req.getText()); },
-      ::mega::MegaUser::CHANGE_TYPE_LASTNAME
-    },
-  //authring
-    {
-      ::mega::MegaApi::USER_ATTR_AUTHRING,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_AUTHRING
-    },
-  //last interaction
-    {
-      ::mega::MegaApi::USER_ATTR_LAST_INTERACTION,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_LSTINT
-    },
-  //ed25519 signing key
-    {
-      ::mega::MegaApi::USER_ATTR_ED25519_PUBLIC_KEY,
-      [](const ::mega::MegaRequest& req)->Buffer* { return ecKeyBase64ToBin(req); },
-      ::mega::MegaUser::CHANGE_TYPE_PUBKEY_ED255
-    },
-  //cu25519 encryption key
-    {
-      ::mega::MegaApi::USER_ATTR_CU25519_PUBLIC_KEY,
-      [](const ::mega::MegaRequest& req)->Buffer* { return ecKeyBase64ToBin(req); },
-      ::mega::MegaUser::CHANGE_TYPE_PUBKEY_CU255
-    },
-  //keyring - not used by userAttrCache
-    {
-      ::mega::MegaApi::USER_ATTR_KEYRING,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_KEYRING
-    },
-
-  //RSA-pubk - not used by userAttrCache
-    {
-      ::mega::MegaApi::USER_ATTR_SIG_RSA_PUBLIC_KEY,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_SIG_PUBKEY_RSA
-    },
-  //CU255 - not used by userAttrCache
-    {
-      ::mega::MegaApi::USER_ATTR_SIG_CU255_PUBLIC_KEY,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_SIG_PUBKEY_CU255
-    },
-  //Country - not used by userAttrCache
-    {
-      10,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_COUNTRY
-    },
-  //BirthDay - not used by userAttrCache
-    {
-      11,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_BIRTHDAY
-    },
-  //BirthMonth - not used by userAttrCache
-    {
-      12,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_BIRTHDAY
-    },
-  //BirthYear - not used by userAttrCache
-    {
-      13,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_BIRTHDAY
-    },
-  //language - not used by userAttrCache
-    {
-      ::mega::MegaApi::USER_ATTR_LANGUAGE,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_LANGUAGE
-    },
-  //PWD reminder - not used by userAttrCache
-    {
-      ::mega::MegaApi::USER_ATTR_PWD_REMINDER,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_PWD_REMINDER
-    },
-  //Disable versions - not used by userAttrCache
-    {
-      ::mega::MegaApi::USER_ATTR_DISABLE_VERSIONS,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_DISABLE_VERSIONS
-    },
-  //Contact link verification - not used by userAttrCache
-    {
-      ::mega::MegaApi::USER_ATTR_CONTACT_LINK_VERIFICATION,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_CONTACT_LINK_VERIFICATION
-    },
-  //richLink
-    {
-      ::mega::MegaApi::USER_ATTR_RICH_PREVIEWS,
-      [](const ::mega::MegaRequest& req)->Buffer* { return bufFromTLV(req.getMegaStringMap(), "num"); },
-      ::mega::MegaUser::CHANGE_TYPE_RICH_PREVIEWS
-    },
-  //email
-    {
-      USER_ATTR_EMAIL,
-      &getDataNotImpl, ::mega::MegaUser::CHANGE_TYPE_EMAIL
-    },
-  //FULLNAME - virtual attrib with no DB backing
-    {
-      USER_ATTR_FULLNAME,
-      &getDataNotImpl,
-      ::mega::MegaUser::CHANGE_TYPE_FIRSTNAME | ::mega::MegaUser::CHANGE_TYPE_LASTNAME
-    },
-  //Aliases
-    {
-      ::mega::MegaApi::USER_ATTR_ALIAS,
-      [](const ::mega::MegaRequest& req)->Buffer* { return getAlias(req); },
-      ::mega::MegaUser::CHANGE_TYPE_ALIAS
-    },
-};
-
 UserAttrCache::~UserAttrCache()
 {
     mClient.api.sdk.removeGlobalListener(this);
 }
+
+UserAttrDescMap gUserAttrDescsMap =
+{
+    //avatar
+      {
+        ::mega::MegaApi::USER_ATTR_AVATAR,
+        UserAttrDesc(
+            [](const ::mega::MegaRequest& req)->Buffer* { return bufFromCstr(req.getFile()); },
+            ::mega::MegaUser::CHANGE_TYPE_AVATAR)
+
+      },
+    //first name
+      {
+        ::mega::MegaApi::USER_ATTR_FIRSTNAME,
+        UserAttrDesc(
+            [](const ::mega::MegaRequest& req)->Buffer* { return bufFromCstr(req.getText()); },
+            ::mega::MegaUser::CHANGE_TYPE_FIRSTNAME)
+      },
+    //last name
+      {
+        ::mega::MegaApi::USER_ATTR_LASTNAME,
+        UserAttrDesc(
+            [](const ::mega::MegaRequest& req)->Buffer* { return bufFromCstr(req.getText()); },
+            ::mega::MegaUser::CHANGE_TYPE_LASTNAME)
+      },
+    //authring
+      {
+        ::mega::MegaApi::USER_ATTR_AUTHRING,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_AUTHRING)
+      },
+    //last interaction
+      {
+        ::mega::MegaApi::USER_ATTR_LAST_INTERACTION,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_LSTINT)
+      },
+    //ed25519 signing key
+      {
+        ::mega::MegaApi::USER_ATTR_ED25519_PUBLIC_KEY,
+        UserAttrDesc(
+            [](const ::mega::MegaRequest& req)->Buffer* { return ecKeyBase64ToBin(req); },
+            ::mega::MegaUser::CHANGE_TYPE_PUBKEY_ED255)
+      },
+    //cu25519 encryption key
+      {
+        ::mega::MegaApi::USER_ATTR_CU25519_PUBLIC_KEY,
+        UserAttrDesc(
+            [](const ::mega::MegaRequest& req)->Buffer* { return ecKeyBase64ToBin(req); },
+            ::mega::MegaUser::CHANGE_TYPE_PUBKEY_CU255)
+      },
+    //keyring - not used by userAttrCache
+      {
+        ::mega::MegaApi::USER_ATTR_KEYRING,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_KEYRING)
+      },
+    //RSA-pubk - not used by userAttrCache
+      {
+        ::mega::MegaApi::USER_ATTR_SIG_RSA_PUBLIC_KEY,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_SIG_PUBKEY_RSA)
+      },
+    //CU255 - not used by userAttrCache
+      {
+        ::mega::MegaApi::USER_ATTR_SIG_CU255_PUBLIC_KEY,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_SIG_PUBKEY_CU255)
+      },
+    //Country - not used by userAttrCache
+      {
+        10,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_COUNTRY)
+      },
+    //BirthDay - not used by userAttrCache
+      {
+        11,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_BIRTHDAY)
+      },
+    //BirthMonth - not used by userAttrCache
+      {
+        12,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_BIRTHDAY)
+      },
+    //BirthYear - not used by userAttrCache
+      {
+        13,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_BIRTHDAY)
+      },
+    //language - not used by userAttrCache
+      {
+        ::mega::MegaApi::USER_ATTR_LANGUAGE,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_LANGUAGE)
+      },
+    //PWD reminder - not used by userAttrCache
+      {
+        ::mega::MegaApi::USER_ATTR_PWD_REMINDER,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_PWD_REMINDER)
+      },
+    //Disable versions - not used by userAttrCache
+      {
+        ::mega::MegaApi::USER_ATTR_DISABLE_VERSIONS,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_DISABLE_VERSIONS)
+      },
+    //Contact link verification - not used by userAttrCache
+      {
+        ::mega::MegaApi::USER_ATTR_CONTACT_LINK_VERIFICATION,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_CONTACT_LINK_VERIFICATION)
+      },
+    //richLink
+      {
+        ::mega::MegaApi::USER_ATTR_RICH_PREVIEWS,
+        UserAttrDesc(
+            [](const ::mega::MegaRequest& req)->Buffer* { return bufFromTLV(req.getMegaStringMap(), "num"); },
+            ::mega::MegaUser::CHANGE_TYPE_RICH_PREVIEWS)
+      },
+    //email
+      {
+        USER_ATTR_EMAIL,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_EMAIL)
+      },
+    //FULLNAME - virtual attrib with no DB backing
+      {
+        USER_ATTR_FULLNAME,
+        UserAttrDesc(
+            &getDataNotImpl,
+            ::mega::MegaUser::CHANGE_TYPE_FIRSTNAME | ::mega::MegaUser::CHANGE_TYPE_LASTNAME)
+      },
+    //Aliases
+      {
+        ::mega::MegaApi::USER_ATTR_ALIAS,
+        UserAttrDesc(
+            [](const ::mega::MegaRequest& req)->Buffer* { return getAlias(req); },
+            ::mega::MegaUser::CHANGE_TYPE_ALIAS)
+      },
+};
 
 void UserAttrCache::dbWrite(UserAttrPair key, const Buffer& data)
 {
@@ -285,13 +321,14 @@ void UserAttrCache::onUserAttrChange(::mega::MegaUser& user)
 }
 void UserAttrCache::onUserAttrChange(uint64_t userid, int changed)
 {
-//  printf("user %s changed %u\n", Id(user.getHandle()).toString().c_str(), changed);
-    for (size_t i = 0; i < sizeof(gUserAttrDescs)/sizeof(gUserAttrDescs[0]); i++)
+    UserAttrDescMap::iterator it;
+    for (it = gUserAttrDescsMap.begin(); it != gUserAttrDescsMap.end(); it++)
     {
-        auto& desc = gUserAttrDescs[i];
+        auto& desc = it->second;
         if ((changed & desc.changeMask) == 0)
             continue; //the change is not of this attrib type
-        int type = desc.type;
+
+        int type = it->first;
         UserAttrPair key(userid, type);
         auto it = find(key);
         if (it == end()) //we don't have such attribute
@@ -474,15 +511,12 @@ void UserAttrCache::fetchStandardAttr(UserAttrPair key, std::shared_ptr<UserAttr
     {
         wptr.throwIfDeleted();
 
-        for (size_t i = 0; i < sizeof(gUserAttrDescs)/sizeof(gUserAttrDescs[0]); i++)
+        UserAttrDescMap::iterator it = gUserAttrDescsMap.find(key.attrType);
+        if (it != gUserAttrDescsMap.end())
         {
-            auto& desc = gUserAttrDescs[i];
-            if (desc.type == key.attrType)
-            {
-                item->data.reset(desc.getData(*result));
-                item->resolve(key);
-                break;
-            }
+            auto& desc = it->second;
+            item->data.reset(desc.getData(*result));
+            item->resolve(key);
         }
     })
     .fail([wptr, this, key, item](const ::promise::Error& err)

--- a/src/userAttrCache.cpp
+++ b/src/userAttrCache.cpp
@@ -428,14 +428,9 @@ void UserAttrCache::fetchStandardAttr(UserAttrPair key, std::shared_ptr<UserAttr
     .then([wptr, this, key, item](ReqResult result)
     {
         wptr.throwIfDeleted();
-
-        UserAttrDescMap::iterator it = gUserAttrDescsMap.find(key.attrType);
-        if (it != gUserAttrDescsMap.end())
-        {
-            auto& desc = it->second;
-            item->data.reset(desc.getData(*result));
-            item->resolve(key);
-        }
+        auto& desc = gUserAttrDescsMap.at(key.attrType);
+        item->data.reset(desc.getData(*result));
+        item->resolve(key);
     })
     .fail([wptr, this, key, item](const ::promise::Error& err)
     {

--- a/src/userAttrCache.cpp
+++ b/src/userAttrCache.cpp
@@ -44,12 +44,11 @@ Buffer* getAlias(const ::mega::MegaRequest& result)
         tlv.set(std::string(key), std::string(stringMap->get(key)));
     }
 
-    Buffer *buf = nullptr;
+    // If attr alias is empty generate a valid empty buffer with bufsize 1
     std::unique_ptr<string> aux(tlv.tlvRecordsToContainer());
-    if (aux)
-    {
-        buf = new Buffer(aux->c_str(), aux->size());
-    }
+    Buffer *buf = aux->size()
+            ? new Buffer(aux->data(), aux->size())
+            : new Buffer(1);
     return buf;
 }
 

--- a/src/userAttrCache.cpp
+++ b/src/userAttrCache.cpp
@@ -96,14 +96,8 @@ UserAttrCache::~UserAttrCache()
 
 UserAttrDescMap gUserAttrDescsMap =
 {
-    //avatar
-      {
-        ::mega::MegaApi::USER_ATTR_AVATAR,
-        UserAttrDesc(
-            [](const ::mega::MegaRequest& req)->Buffer* { return bufFromCstr(req.getFile()); },
-            ::mega::MegaUser::CHANGE_TYPE_AVATAR)
+    // STANDARD ATTRIBUTES
 
-      },
     //first name
       {
         ::mega::MegaApi::USER_ATTR_FIRSTNAME,
@@ -117,20 +111,6 @@ UserAttrDescMap gUserAttrDescsMap =
         UserAttrDesc(
             [](const ::mega::MegaRequest& req)->Buffer* { return bufFromCstr(req.getText()); },
             ::mega::MegaUser::CHANGE_TYPE_LASTNAME)
-      },
-    //authring
-      {
-        ::mega::MegaApi::USER_ATTR_AUTHRING,
-        UserAttrDesc(
-            &getDataNotImpl,
-            ::mega::MegaUser::CHANGE_TYPE_AUTHRING)
-      },
-    //last interaction
-      {
-        ::mega::MegaApi::USER_ATTR_LAST_INTERACTION,
-        UserAttrDesc(
-            &getDataNotImpl,
-            ::mega::MegaUser::CHANGE_TYPE_LSTINT)
       },
     //ed25519 signing key
       {
@@ -153,76 +133,6 @@ UserAttrDescMap gUserAttrDescsMap =
             &getDataNotImpl,
             ::mega::MegaUser::CHANGE_TYPE_KEYRING)
       },
-    //RSA-pubk - not used by userAttrCache
-      {
-        ::mega::MegaApi::USER_ATTR_SIG_RSA_PUBLIC_KEY,
-        UserAttrDesc(
-            &getDataNotImpl,
-            ::mega::MegaUser::CHANGE_TYPE_SIG_PUBKEY_RSA)
-      },
-    //CU255 - not used by userAttrCache
-      {
-        ::mega::MegaApi::USER_ATTR_SIG_CU255_PUBLIC_KEY,
-        UserAttrDesc(
-            &getDataNotImpl,
-            ::mega::MegaUser::CHANGE_TYPE_SIG_PUBKEY_CU255)
-      },
-    //Country - not used by userAttrCache
-      {
-        10,
-        UserAttrDesc(
-            &getDataNotImpl,
-            ::mega::MegaUser::CHANGE_TYPE_COUNTRY)
-      },
-    //BirthDay - not used by userAttrCache
-      {
-        11,
-        UserAttrDesc(
-            &getDataNotImpl,
-            ::mega::MegaUser::CHANGE_TYPE_BIRTHDAY)
-      },
-    //BirthMonth - not used by userAttrCache
-      {
-        12,
-        UserAttrDesc(
-            &getDataNotImpl,
-            ::mega::MegaUser::CHANGE_TYPE_BIRTHDAY)
-      },
-    //BirthYear - not used by userAttrCache
-      {
-        13,
-        UserAttrDesc(
-            &getDataNotImpl,
-            ::mega::MegaUser::CHANGE_TYPE_BIRTHDAY)
-      },
-    //language - not used by userAttrCache
-      {
-        ::mega::MegaApi::USER_ATTR_LANGUAGE,
-        UserAttrDesc(
-            &getDataNotImpl,
-            ::mega::MegaUser::CHANGE_TYPE_LANGUAGE)
-      },
-    //PWD reminder - not used by userAttrCache
-      {
-        ::mega::MegaApi::USER_ATTR_PWD_REMINDER,
-        UserAttrDesc(
-            &getDataNotImpl,
-            ::mega::MegaUser::CHANGE_TYPE_PWD_REMINDER)
-      },
-    //Disable versions - not used by userAttrCache
-      {
-        ::mega::MegaApi::USER_ATTR_DISABLE_VERSIONS,
-        UserAttrDesc(
-            &getDataNotImpl,
-            ::mega::MegaUser::CHANGE_TYPE_DISABLE_VERSIONS)
-      },
-    //Contact link verification - not used by userAttrCache
-      {
-        ::mega::MegaApi::USER_ATTR_CONTACT_LINK_VERIFICATION,
-        UserAttrDesc(
-            &getDataNotImpl,
-            ::mega::MegaUser::CHANGE_TYPE_CONTACT_LINK_VERIFICATION)
-      },
     //richLink
       {
         ::mega::MegaApi::USER_ATTR_RICH_PREVIEWS,
@@ -230,6 +140,16 @@ UserAttrDescMap gUserAttrDescsMap =
             [](const ::mega::MegaRequest& req)->Buffer* { return bufFromTLV(req.getMegaStringMap(), "num"); },
             ::mega::MegaUser::CHANGE_TYPE_RICH_PREVIEWS)
       },
+    //Aliases
+      {
+        ::mega::MegaApi::USER_ATTR_ALIAS,
+        UserAttrDesc(
+            [](const ::mega::MegaRequest& req)->Buffer* { return getAlias(req); },
+            ::mega::MegaUser::CHANGE_TYPE_ALIAS)
+      },
+
+    // VIRTUAL ATTRIBUTES
+
     //email
       {
         USER_ATTR_EMAIL,
@@ -243,13 +163,6 @@ UserAttrDescMap gUserAttrDescsMap =
         UserAttrDesc(
             &getDataNotImpl,
             ::mega::MegaUser::CHANGE_TYPE_FIRSTNAME | ::mega::MegaUser::CHANGE_TYPE_LASTNAME)
-      },
-    //Aliases
-      {
-        ::mega::MegaApi::USER_ATTR_ALIAS,
-        UserAttrDesc(
-            [](const ::mega::MegaRequest& req)->Buffer* { return getAlias(req); },
-            ::mega::MegaUser::CHANGE_TYPE_ALIAS)
       },
 };
 
@@ -300,11 +213,8 @@ const char* attrName(uint8_t type)
 {
     switch (type)
     {
-    case ::mega::MegaApi::USER_ATTR_AVATAR: return "AVATAR";
     case ::mega::MegaApi::USER_ATTR_FIRSTNAME: return "FIRSTNAME";
     case ::mega::MegaApi::USER_ATTR_LASTNAME: return "LASTNAME";
-    case ::mega::MegaApi::USER_ATTR_AUTHRING: return "AUTHRING";
-    case ::mega::MegaApi::USER_ATTR_LAST_INTERACTION: return "LAST_INTERACTION";
     case ::mega::MegaApi::USER_ATTR_ED25519_PUBLIC_KEY: return "PUB_ED25519";
     case ::mega::MegaApi::USER_ATTR_CU25519_PUBLIC_KEY: return "PUB_CU25519";
     case ::mega::MegaApi::USER_ATTR_KEYRING: return "KEYRING";

--- a/src/userAttrCache.cpp
+++ b/src/userAttrCache.cpp
@@ -38,7 +38,7 @@ Buffer* getAlias(const ::mega::MegaRequest& result)
         for (int i=0; i < keys->size(); i++)
         {
             key = keys->get(i);
-            tlv.set(key, stringMap->get(key));
+            tlv.set(std::string(key), std::string(stringMap->get(key)));
         }
         delete keys;
     }
@@ -48,6 +48,7 @@ Buffer* getAlias(const ::mega::MegaRequest& result)
     if (aux)
     {
         buf = new Buffer(aux->c_str(), aux->size());
+        delete aux;
     }
     return buf;
 }

--- a/src/userAttrCache.cpp
+++ b/src/userAttrCache.cpp
@@ -29,26 +29,26 @@ Buffer* ecKeyBase64ToBin(const ::mega::MegaRequest& result)
 Buffer* getAlias(const ::mega::MegaRequest& result)
 {
     // Create a TLV and serialize the aliases map
-    ::mega::TLVstore tlv;
     ::mega::MegaStringMap *stringMap = result.getMegaStringMap();
-    if (stringMap)
+    if (!stringMap)
     {
-        ::mega::MegaStringList *keys = stringMap->getKeys();
-        const char *key = NULL;
-        for (int i=0; i < keys->size(); i++)
-        {
-            key = keys->get(i);
-            tlv.set(std::string(key), std::string(stringMap->get(key)));
-        }
-        delete keys;
+        return nullptr;
     }
 
-    Buffer *buf = NULL;
-    string *aux = tlv.tlvRecordsToContainer();
+    ::mega::TLVstore tlv;
+    std::unique_ptr<::mega::MegaStringList> keys(stringMap->getKeys());
+    const char *key = nullptr;
+    for (int i = 0; i < keys->size(); i++)
+    {
+        key = keys->get(i);
+        tlv.set(std::string(key), std::string(stringMap->get(key)));
+    }
+
+    Buffer *buf = nullptr;
+    std::unique_ptr<string> aux(tlv.tlvRecordsToContainer());
     if (aux)
     {
         buf = new Buffer(aux->c_str(), aux->size());
-        delete aux;
     }
     return buf;
 }

--- a/src/userAttrCache.h
+++ b/src/userAttrCache.h
@@ -48,14 +48,15 @@ class Client;
 struct UserAttrDesc
 {
     typedef Buffer*(*GetDataFunc)(const ::mega::MegaRequest&);
-    int type;
     GetDataFunc getData;
     int changeMask;
-    UserAttrDesc(int aType, GetDataFunc aGetData, int aChangeMask)
-        :type(aType), getData(aGetData), changeMask(aChangeMask){}
+    UserAttrDesc(GetDataFunc aGetData, int aChangeMask):
+        getData(aGetData), changeMask(aChangeMask){}
 };
 
-extern UserAttrDesc gUserAttrDescs[22];
+// Maps uh_Bin to UserAttrDesc struct
+typedef std::map <int, UserAttrDesc> UserAttrDescMap;
+extern UserAttrDescMap gUserAttrDescsMap;
 
 struct UserAttrPair
 {
@@ -73,10 +74,10 @@ struct UserAttrPair
     }
     UserAttrPair(uint64_t aUser, uint8_t aType, uint64_t ph = Id::inval()): user(aUser), attrType(aType), mPh(ph)
     {
-        if ((attrType >= sizeof(gUserAttrDescs)/sizeof(gUserAttrDescs[0]))
-         && (attrType != USER_ATTR_RSA_PUBKEY) && (attrType != USER_ATTR_FULLNAME)
-         && (attrType != USER_ATTR_EMAIL) && (attrType != ::mega::MegaApi::USER_ATTR_ALIAS))
+        if (gUserAttrDescsMap.find(attrType) == gUserAttrDescsMap.end())
+        {
             throw std::runtime_error("UserAttrPair: Invalid user attribute id specified");
+        }
     }
     std::string toString()
     {

--- a/src/userAttrCache.h
+++ b/src/userAttrCache.h
@@ -55,7 +55,7 @@ struct UserAttrDesc
         :type(aType), getData(aGetData), changeMask(aChangeMask){}
 };
 
-extern UserAttrDesc gUserAttrDescs[21];
+extern UserAttrDesc gUserAttrDescs[22];
 
 struct UserAttrPair
 {
@@ -75,7 +75,7 @@ struct UserAttrPair
     {
         if ((attrType >= sizeof(gUserAttrDescs)/sizeof(gUserAttrDescs[0]))
          && (attrType != USER_ATTR_RSA_PUBKEY) && (attrType != USER_ATTR_FULLNAME)
-         && (attrType != USER_ATTR_EMAIL))
+         && (attrType != USER_ATTR_EMAIL) && (attrType != ::mega::MegaApi::USER_ATTR_ALIAS))
             throw std::runtime_error("UserAttrPair: Invalid user attribute id specified");
     }
     std::string toString()

--- a/src/userAttrCache.h
+++ b/src/userAttrCache.h
@@ -54,7 +54,7 @@ struct UserAttrDesc
         getData(aGetData), changeMask(aChangeMask){}
 };
 
-// Maps uh_Bin to UserAttrDesc struct
+// Maps uhBin to UserAttrDesc struct
 typedef std::map <int, UserAttrDesc> UserAttrDescMap;
 extern UserAttrDescMap gUserAttrDescsMap;
 


### PR DESCRIPTION
Wherever a firstname / fullname is currently displayed, if the user has assigned to him/her a nickname, it should prevail. In example, default groupchat title, notifications about new messages, sender of a message, etc.