### PR TITLE
#12877 Not manage as rich link mega urls

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -5094,7 +5094,7 @@ bool Message::parseUrl(const std::string &url)
         }
     }
 
-    std::regex megaUrlExpression("^((WWW.|www.)?mega.+(nz/|co.nz/)).*((#F!|#!|chat/)[a-z0-9A-Z-._~:\/?#!$&'()*+,;=\-@]+)$");
+    std::regex megaUrlExpression("^((WWW.|www.)?mega.+(nz/|co.nz/)).*((#F!|#!|C!|chat/)[a-z0-9A-Z-._~:\/?#!$&'()*+,;=\-@]+)$");
     if (regex_match(urlToParse, megaUrlExpression))
     {
         return false;

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -5094,15 +5094,13 @@ bool Message::parseUrl(const std::string &url)
         }
     }
 
-    if (urlToParse.find("mega.co.nz/#!") != std::string::npos || urlToParse.find("mega.co.nz/#F!") != std::string::npos ||
-            urlToParse.find("mega.nz/#!") != std::string::npos || urlToParse.find("mega.nz/#F!") != std::string::npos ||
-            urlToParse.find("mega.nz/chat/") != std::string::npos)
+    std::regex megaUrlExpression("^((WWW.|www.)?mega.+(nz/|co.nz/)).*((#F!|#!|chat/)[a-z0-9A-Z-._~:\/?#!$&'()*+,;=\-@]+)$");
+    if (regex_match(urlToParse, megaUrlExpression))
     {
         return false;
     }
 
     std::regex regularExpresion("^(WWW.|www.)?[a-z0-9A-Z-._~:/?#@!$&'()*+,;=]+[.][a-zA-Z]{2,5}(:[0-9]{1,5})?([a-z0-9A-Z-._~:/?#@!$&'()*+,;=]*)?$");
-
 
     return regex_match(urlToParse, regularExpresion);
 }


### PR DESCRIPTION
Some services as facebook introduce a special string in mega urls. Detect this special cases and avoid to manage as rich link