### PR TITLE
#13077. An unknown user can be notified directly as ex-contact

### DIFF
--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -655,9 +655,11 @@ void Client::onUsersUpdate(::mega::MegaApi *api, ::mega::MegaUserList *usersUpda
             auto it = mContacts.find(userid);
             if (it == mContacts.end())  // new contact
             {
-                assert(newVisibility == ::mega::MegaUser::VISIBILITY_VISIBLE);
                 mContacts[userid] = newVisibility;
-                addPeer(userid);
+                if (newVisibility == ::mega::MegaUser::VISIBILITY_VISIBLE)
+                {
+                    addPeer(userid);
+                }
             }
             else    // existing (ex)contact
             {


### PR DESCRIPTION
The user received in the `onUsersUpdate()` is still an unknown user for presenced's client. However, it's added to the list of users not as contact, but directly as ex-contact. In that case, the visibility is
HIDDEN and it should not be added to the list of current peers managed by presenced.