### PR TITLE
#13115. Fix isManagementMessage

### DIFF
--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -675,6 +675,7 @@ public:
     /** @brief Returns whether this message is a management message. */
     bool isManagementMessage() const
     {
+        // if message comes from API and uses keyid=0, it's a management message
         return isManagementMessageKnownType() || (userid == karere::Id::COMMANDER() && keyid == 0);
     }
     bool isManagementMessageKnownType() const

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -675,8 +675,7 @@ public:
     /** @brief Returns whether this message is a management message. */
     bool isManagementMessage() const
     {
-        return (userid == karere::Id::COMMANDER() || type == Message::kMsgTruncate)
-                && (isManagementMessageKnownType());
+        return isManagementMessageKnownType() || (userid == karere::Id::COMMANDER() && keyid == 0);
     }
     bool isManagementMessageKnownType() const
     {

--- a/src/chatdMsg.h
+++ b/src/chatdMsg.h
@@ -675,12 +675,12 @@ public:
     /** @brief Returns whether this message is a management message. */
     bool isManagementMessage() const
     {
-        return (keyid == 0) && !isSending();    // msgs in sending status use keyid=CHATD_KEYID_INVALID (0)
+        return (userid == karere::Id::COMMANDER() || type == Message::kMsgTruncate)
+                && (isManagementMessageKnownType());
     }
-    bool isManagementMessageKnownType()
+    bool isManagementMessageKnownType() const
     {
-        return (isManagementMessage()
-                && type >= Message::kMsgManagementLowest
+        return (type >= Message::kMsgManagementLowest
                 && type <= Message::kMsgManagementHighest);
     }
     bool isOwnMessage(karere::Id myHandle) const { return (userid == myHandle); }

--- a/src/strongvelope/strongvelope.cpp
+++ b/src/strongvelope/strongvelope.cpp
@@ -1168,8 +1168,7 @@ Promise<Message*> ProtocolHandler::msgDecrypt(Message* message)
         auto parsedMsg = std::make_shared<ParsedMessage>(*message, *this);
         message->type = parsedMsg->type;
 
-        // if message comes from API and uses keyid=0, it's a management message
-        if (message->userid == karere::Id::COMMANDER() && message->keyid == 0)
+        if (message->isManagementMessage())
         {
             return handleManagementMessage(parsedMsg, message);
         }


### PR DESCRIPTION
For public chats keyid is 0 for all messages, so we can't check keyid
to identify if a message is a management message or not.

To solve this problem now we will check if the userid is the API user,
except for truncate messages and if message type is a management known
type.