### PR TITLE
#13187. Avoid finish call with kErrSessSetupTimeout if caller drop internet

### DIFF
--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -1533,13 +1533,13 @@ void Call::msgJoin(RtMessage& packet)
             }
         }
 
-        if (mState == Call::kStateReqSent)
+        if (mState == Call::kStateReqSent || mState == Call::kStateJoining)
         {
             setState(Call::kStateInProgress);
             monitorCallSetupTimeout();
 
             // Send OP_CALLDATA with call inProgress
-            if (!chat().isGroup())
+            if (mState == Call::kStateReqSent && !chat().isGroup())
             {
                 mIsRingingOut = false;
                 if (!sendCallData(CallDataState::kCallDataNotRinging))


### PR DESCRIPTION
This is a special case in group call where caller drop internet but several partipants answer the call. This call has to continue because it has been established correctly

Risk area/s:
- Group call where caller drop internet before none answer, immediately several participants answer the call