### PR TITLE
#13283. Fix QtApp construction by adding libraw as dependency

### DIFF
--- a/contrib/QtCreator/MEGAChatQt/MEGAChatQt.pro
+++ b/contrib/QtCreator/MEGAChatQt/MEGAChatQt.pro
@@ -4,6 +4,10 @@
 #
 #-------------------------------------------------
 
+# We assume libraw as a dependency for QtApp, because HAVE_LIBRAW is added to config.h
+# if libraw is available in the system, although is not specified in the configure.
+CONFIG += USE_LIBRAW
+
 # The following define makes your compiler emit warnings if you use
 # any feature of Qt which has been marked as deprecated (the exact warnings
 # depend on your compiler). Please consult the documentation of the


### PR DESCRIPTION
The SDK doesn't need libraw to work, but it improves UX because it generates previews of RAW format images. Altough is not specified in configure, HAVE_LIBRAW is added to config.h as long as libraw is available in the system.

We need to add libraw as QtApp dependency.

**Risk area/s:**
- QtApp construction