### PR TITLE
#13690. Wait for DNS resolution if missing cached IP family

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -984,6 +984,13 @@ void Connection::doConnect()
             }
             CHATDS_LOG_DEBUG("Connection to chatd failed using the IP: %s", mTargetIp.c_str());
         }
+        else
+        {
+            // do not close the socket, which forces a new retry attempt and turns the DNS response obsolete
+            // Instead, let the DNS request to complete, in order to refresh IPs
+            CHATDS_LOG_DEBUG("Empty cached IP. Waiting for DNS resolution...");
+            return;
+        }
 
         onSocketClose(0, 0, "Websocket error on wsConnect (chatd)");
     }

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -873,6 +873,13 @@ void Client::doConnect()
                 return;
             }
             PRESENCED_LOG_DEBUG("Connection to presenced failed using the IP: %s", mTargetIp.c_str());
+        }        
+        else
+        {
+            // do not close the socket, which forces a new retry attempt and turns the DNS response obsolete
+            // Instead, let the DNS request to complete, in order to refresh IPs
+            PRESENCED_LOG_DEBUG("Empty cached IP. Waiting for DNS resolution...");
+            return;
         }
 
         onSocketClose(0, 0, "Websocket error on wsConnect (presenced)");


### PR DESCRIPTION
Some DNS servers reply with IPv6 only addresses when promted from IPv6-only networks. It results on cached IPs only for v6. After switch to a IPv4-only network, the connection attempt to IPv6 fails immediately and the IPv4 is empty, so it results on a new retry. When the DNS resolution arrives, it detects the received IPs corresponds to a previous attempt, so it discards them.
All the above results in a non-recoverable situation where only networks with IPv6 connectivity will successfully connect.

Risk area/s: 
- Switch between networks with different IP families: IPv4 <--> IPv6