### PR TITLE
Use uploads for chat

### DIFF
--- a/examples/qtmegachatapi/chatWindow.cpp
+++ b/examples/qtmegachatapi/chatWindow.cpp
@@ -1268,7 +1268,7 @@ void ChatWindow::onAttachNode(bool isVoiceClip)
     }
     else
     {
-        mMegaApi->startUpload(node.toStdString().c_str(), parent);
+        mMegaApi->startUploadForChat(node.toStdString().c_str(), parent, nullptr, false);
     }
 
     delete parent;


### PR DESCRIPTION
In case of media files, this method ensures that the thumbnail/preview are created in case they are missing in a existing node for the same file.