### PR TITLE
#13891. Avoid Send a new JOIN to chatd upon re-join

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3401,7 +3401,7 @@ bool GroupChatRoom::syncWithApi(const mega::MegaTextChat& chat)
                 if (parent.mKarereClient.connected())
                 {
                     KR_LOG_DEBUG("Connecting existing room to chatd after re-join...");
-                    if (mChat->onlineState() != ::chatd::ChatState::kChatStateJoining)
+                    if (mChat->onlineState() < ::chatd::ChatState::kChatStateJoining)
                     {
                         mChat->connect();
                     }


### PR DESCRIPTION
**Risk area/s**
- Remove a participant from a chat and re-invite. After rejoin, new history (which user is entitled to see) must be received successfully.