### PR TITLE
#14071. Avoid race conditions on DelegateChatRoomListener

### DIFF
--- a/bindings/java/nz/mega/sdk/DelegateMegaChatRoomListener.java
+++ b/bindings/java/nz/mega/sdk/DelegateMegaChatRoomListener.java
@@ -30,6 +30,14 @@ class DelegateMegaChatRoomListener extends MegaChatRoomListener {
     MegaChatRoomListenerInterface getUserListener() {
         return listener;
     }
+    
+    boolean invalidateUserListener() {
+		if (listener != null) {
+			listener = null;
+			return true;
+		}
+		return false;
+	}    
 
     @Override
     public void onChatRoomUpdate(MegaChatApi api, MegaChatRoom chat){
@@ -37,7 +45,8 @@ class DelegateMegaChatRoomListener extends MegaChatRoomListener {
             final MegaChatRoom megaChatRoom = chat.copy();
             megaChatApi.runCallback(new Runnable() {
                 public void run() {
-                    listener.onChatRoomUpdate(megaChatApi, megaChatRoom);
+					if (listener != null)
+						listener.onChatRoomUpdate(megaChatApi, megaChatRoom);
                 }
             });
         }
@@ -50,14 +59,16 @@ class DelegateMegaChatRoomListener extends MegaChatRoomListener {
                 final MegaChatMessage megaChatMessage = msg.copy();
                 megaChatApi.runCallback(new Runnable() {
                     public void run() {
-                        listener.onMessageLoaded(megaChatApi, megaChatMessage);
+						if (listener != null)
+							listener.onMessageLoaded(megaChatApi, megaChatMessage);
                     }
                 });
             }
             else{
                 megaChatApi.runCallback(new Runnable() {
                     public void run() {
-                        listener.onMessageLoaded(megaChatApi, null);
+						if (listener != null)
+							listener.onMessageLoaded(megaChatApi, null);
                     }
                 });
             }
@@ -70,7 +81,8 @@ class DelegateMegaChatRoomListener extends MegaChatRoomListener {
             final MegaChatMessage megaChatMessage = msg.copy();
             megaChatApi.runCallback(new Runnable() {
                 public void run() {
-                    listener.onMessageReceived(megaChatApi, megaChatMessage);
+					if (listener != null)
+						listener.onMessageReceived(megaChatApi, megaChatMessage);
                 }
             });
         }
@@ -82,7 +94,8 @@ class DelegateMegaChatRoomListener extends MegaChatRoomListener {
             final MegaChatMessage megaChatMessage = msg.copy();
             megaChatApi.runCallback(new Runnable() {
                 public void run() {
-                    listener.onMessageUpdate(megaChatApi, megaChatMessage);
+					if (listener != null)
+						listener.onMessageUpdate(megaChatApi, megaChatMessage);
                 }
             });
         }
@@ -94,126 +107,10 @@ class DelegateMegaChatRoomListener extends MegaChatRoomListener {
             final MegaChatRoom megaChatRoom = chat.copy();
             megaChatApi.runCallback(new Runnable() {
                 public void run() {
-                    listener.onHistoryReloaded(megaChatApi, megaChatRoom);
+					if (listener != null)
+						listener.onHistoryReloaded(megaChatApi, megaChatRoom);
                 }
             });
         }
     }
-
-//
-//    /**
-//     * This function is called when a request is about to start being processed.
-//     * <p>
-//     * The SDK retains the ownership of the request parameter. Do not use it after this functions returns.
-//     * The api object is the one created by the application, it will be valid until the application deletes it.
-//     *
-//     * @param api
-//     *            API that started the request.
-//     * @param request
-//     *            Information about the request.
-//     * @see MegaRequestListenerInterface#onRequestStart(MegaApiJava api, MegaRequest request)
-//     * @see MegaRequestListener#onRequestStart(MegaApi api, MegaRequest request)
-//     */
-//    @Override
-//    public void onRequestStart(MegaChatApi api, MegaChatRequest request) {
-//        if (listener != null) {
-//            final MegaChatRequest megaRequest = request.copy();
-//            megaChatApi.runCallback(new Runnable() {
-//                public void run() {
-//                    listener.onRequestStart(megaChatApi, megaRequest);
-//                }
-//            });
-//        }
-//    }
-//
-//    /**
-//     * This function is called to get details about the progress of a request.
-//     * <p>
-//     * Currently, this callback is only used for fetchNodes requests (MegaRequest.TYPE_FETCH_NODES).
-//     * The SDK retains the ownership of the request parameter. Do not use it after this function returns.
-//     * The api object is the one created by the application, it will be valid until the application deletes it.
-//     *
-//     * @param api
-//     *            API that started the request.
-//     * @param request
-//     *            Information about the request.
-//     * @see MegaRequestListenerInterface#onRequestUpdate(MegaApiJava api, MegaRequest request)
-//     * @see MegaRequestListener#onRequestUpdate(MegaApi api, MegaRequest request)
-//     */
-//    @Override
-//    public void onRequestUpdate(MegaChatApi api, MegaChatRequest request) {
-//        if (listener != null) {
-//            final MegaChatRequest megaRequest = request.copy();
-//            megaChatApi.runCallback(new Runnable() {
-//                public void run() {
-//                    listener.onRequestUpdate(megaChatApi, megaRequest);
-//                }
-//            });
-//        }
-//    }
-//
-//    /**
-//     * This function is called when a request has finished.
-//     * <p>
-//     * There will be no further callbacks related to this request.
-//     * The MegaError parameter provides the result of the request.
-//     * If the request completed without problems, the error code will be API_OK. The SDK retains the ownership
-//     * of the request and error parameters. Do not use them after this functions returns.
-//     * The api object is the one created by the application, it will be valid until the application deletes it.
-//     *
-//     * @param api
-//     *            API that started the request.
-//     * @param request
-//     *            Information about the request.
-//     * @param e
-//     *            Error Information.
-//     * @see MegaRequestListenerInterface#onRequestFinish(MegaApiJava api, MegaRequest request, MegaError e)
-//     * @see MegaRequestListener#onRequestFinish(MegaApi api, MegaRequest request, MegaError e)
-//     */
-//    @Override
-//    public void onRequestFinish(MegaChatApi api, MegaChatRequest request, MegaChatError e) {
-//        if (listener != null) {
-//            final MegaChatRequest megaRequest = request.copy();
-//            final MegaChatError megaError = e.copy();
-//            megaChatApi.runCallback(new Runnable() {
-//                public void run() {
-//                    listener.onRequestFinish(megaChatApi, megaRequest, megaError);
-//
-//                    if (singleListener) {
-//                        megaChatApi.privateFreeRequestListener(DelegateMegaChatRoomListener.this);
-//                    }
-//                }
-//            });
-//        }
-//    }
-//
-//    /**
-//     * This function is called when there is a temporary error processing a request.
-//     * <p>
-//     * The request continues after this callback, so expect more MegaRequestListener.onRequestTemporaryError
-//     * or a MegaRequestListener.onRequestFinish callback. The SDK retains the ownership of the request and
-//     * error parameters. Do not use them after this functions returns.
-//     * The api object is the one created by the application, it will be valid until the application deletes it.
-//     *
-//     * @param api
-//     *            API that started the request.
-//     * @param request
-//     *            Information about the request.
-//     * @param e
-//     *            Error Information.
-//     * @see MegaRequestListenerInterface#onRequestTemporaryError(MegaApiJava api, MegaRequest request, MegaError e)
-//     * @see MegaRequestListener#onRequestTemporaryError(MegaApi api, MegaRequest request, MegaError error)
-//     */
-//    @Override
-//    public void onRequestTemporaryError(MegaChatApi api, MegaChatRequest request, MegaChatError e) {
-//        if (listener != null) {
-//            final MegaChatRequest megaRequest = request.copy();
-//            final MegaChatError megaError = e.copy();
-//            megaChatApi.runCallback(new Runnable() {
-//                public void run() {
-//                    listener.onRequestTemporaryError(megaChatApi, megaRequest, megaError);
-//                }
-//            });
-//        }
-//    }
 }

--- a/bindings/java/nz/mega/sdk/MegaChatApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaChatApiJava.java
@@ -1750,6 +1750,8 @@ public class MegaChatApiJava {
             DelegateMegaChatRoomListener item = itr.next();
             if(item.getUserListener() == listener){
                 listenerToDelete = item;
+                boolean success = listenerToDelete.invalidateUserListener();
+                assert success; // failed if listener was already invalidated
                 itr.remove();
                 break;
             }


### PR DESCRIPTION
Callbacks from MegaChatRoomListener are queued by DelegateChatRoomListener in order to be executed by the app's thread. In result, the execution may happen when the chatroom has been closed.

Since the MegaChatRoomListenerInterface is reused by the app for a new DelegateChatRoomListener when another chatroom is opened, it may receive outdated callbacks, corresponding to the already closed chatroom.

This commit aims to avoid such race condition by properly invalidating the listener when the chatroom is closed.