### PR TITLE
#14151. Avoid callback if deleted

### DIFF
--- a/src/sdkApi.h
+++ b/src/sdkApi.h
@@ -86,6 +86,9 @@ public:
     promise::Promise<void> mPromise;
     virtual void onRequestFinish(::mega::MegaApi* /*api*/, ::mega::MegaRequest * /*request*/, ::mega::MegaError* e)
     {
+        if (wptr.deleted())
+            return;
+
         int errCode = e->getErrorCode();
         karere::marshallCall([this, errCode]()
         {


### PR DESCRIPTION
The instance could have been deleted by the time the `onRequestFinish()` is called. Without this protection (already available at `MyListener::onRequestFinish()`), the marshall call will access to the
`EventQueue` that has already been destroyed.