### PR TITLE
#14205. Keep pending edits upon reconnect

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3963,7 +3963,9 @@ void Chat::onMsgUpdated(Message* cipherMsg)
         {
             auto& item = *it;
             if (((item.opcode() != OP_MSGUPD) && (item.opcode() != OP_MSGUPDX))
-                || (item.msg->id() != cipherMsg->id()))
+                    || (item.msg->id() != cipherMsg->id())
+                    || (cipherMsg->type != Message::kMsgTruncate)   // a truncate prevents any further edit
+                    || (item.msg->updated > cipherMsg->updated))    // the newer edition prevails
             {
                 it++;
                 continue;

--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3964,8 +3964,8 @@ void Chat::onMsgUpdated(Message* cipherMsg)
             auto& item = *it;
             if (((item.opcode() != OP_MSGUPD) && (item.opcode() != OP_MSGUPDX))
                     || (item.msg->id() != cipherMsg->id())
-                    || (cipherMsg->type != Message::kMsgTruncate)   // a truncate prevents any further edit
-                    || (item.msg->updated > cipherMsg->updated))    // the newer edition prevails
+                    || (cipherMsg->type != Message::kMsgTruncate        // a truncate prevents any further edit
+                        && (item.msg->updated > cipherMsg->updated)))   // the newer edition prevails
             {
                 it++;
                 continue;


### PR DESCRIPTION
When an edited message is edited again, but being offline, upon reconnection chatd sends the previous edit, which used to discard the pending (newer) edit. That edition should be resent if it is newer than
the received edition.
Additionally, if a message is truncated, any further edit is futile, so the item can be discarded from the pending queue as well.