### PR TITLE
Use rtc::scoped_refptr to manage VideoManager

### DIFF
--- a/src/rtcModule/OBJCCaptureModule.mm
+++ b/src/rtcModule/OBJCCaptureModule.mm
@@ -131,15 +131,6 @@ namespace artc
         mVideoSource->RemoveSink(sink);
     }
 
-    void OBJCCaptureModule::AddRef() const
-    {
-    }
-
-    rtc::RefCountReleaseStatus OBJCCaptureModule::Release() const
-    {
-        return rtc::RefCountReleaseStatus::kOtherRefsRemained;
-    }
-
     void OBJCCaptureModule::RegisterObserver(webrtc::ObserverInterface* observer)
     {
         mVideoSource->RegisterObserver(observer);

--- a/src/rtcModule/OBJCCaptureModule.mm
+++ b/src/rtcModule/OBJCCaptureModule.mm
@@ -137,6 +137,7 @@ namespace artc
 
     rtc::RefCountReleaseStatus OBJCCaptureModule::Release() const
     {
+        return rtc::RefCountReleaseStatus::kOtherRefsRemained;
     }
 
     void OBJCCaptureModule::RegisterObserver(webrtc::ObserverInterface* observer)

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -2137,7 +2137,7 @@ void Call::enableVideo(bool enable)
                 capabilities.maxFPS = 30;
             }
 
-            mVideoDevice = std::shared_ptr<artc::VideoManager>(artc::VideoManager::Create(capabilities, mManager.mVideoDeviceSelected, artc::gAsyncWaiter->guiThread()));
+            mVideoDevice = artc::VideoManager::Create(capabilities, mManager.mVideoDeviceSelected, artc::gAsyncWaiter->guiThread());
             assert(mVideoDevice);
 
             videoTrack = artc::gWebrtcContext->CreateVideoTrack("v"+std::to_string(artc::generateId()), mVideoDevice->getVideoTrackSource());
@@ -2509,7 +2509,7 @@ bool Call::isCaller(Id userid, uint32_t clientid)
 void Call::changeVideoInDevice()
 {
     enableVideo(false);
-    mVideoDevice.reset();
+    mVideoDevice = nullptr;
     enableVideo(true);
 }
 

--- a/src/rtcModule/webrtcAdapter.cpp
+++ b/src/rtcModule/webrtcAdapter.cpp
@@ -160,6 +160,7 @@ void CaptureModuleLinux::AddRef() const
 
 rtc::RefCountReleaseStatus CaptureModuleLinux::Release() const
 {
+    return rtc::RefCountReleaseStatus::kOtherRefsRemained;
 }
 
 std::set<std::pair<std::string, std::string> > CaptureModuleLinux::getVideoDevices()
@@ -417,6 +418,7 @@ void CaptureModuleAndroid::AddRef() const
 
 rtc::RefCountReleaseStatus CaptureModuleAndroid::Release() const
 {
+    return rtc::RefCountReleaseStatus::kOtherRefsRemained;
 }
 
 void CaptureModuleAndroid::RegisterObserver(webrtc::ObserverInterface* observer)

--- a/src/rtcModule/webrtcAdapter.cpp
+++ b/src/rtcModule/webrtcAdapter.cpp
@@ -154,15 +154,6 @@ void CaptureModuleLinux::OnFrame(const webrtc::VideoFrame& frame)
     mBroadcaster.OnFrame(frame);
 }
 
-void CaptureModuleLinux::AddRef() const
-{
-}
-
-rtc::RefCountReleaseStatus CaptureModuleLinux::Release() const
-{
-    return rtc::RefCountReleaseStatus::kOtherRefsRemained;
-}
-
 std::set<std::pair<std::string, std::string> > CaptureModuleLinux::getVideoDevices()
 {
     std::set<std::pair<std::string, std::string>> videoDevices;
@@ -301,6 +292,15 @@ std::set<std::pair<std::string, std::string> > VideoManager::getVideoDevices()
     #endif
 }
 
+void VideoManager::AddRef() const
+{
+}
+
+rtc::RefCountReleaseStatus VideoManager::Release() const
+{
+    return rtc::RefCountReleaseStatus::kOtherRefsRemained;
+}
+
 #ifdef __ANDROID__
 CaptureModuleAndroid::CaptureModuleAndroid(const webrtc::VideoCaptureCapability &capabilities, const std::string &deviceName, rtc::Thread *thread)
     : mCapabilities(capabilities)
@@ -410,15 +410,6 @@ void CaptureModuleAndroid::AddOrUpdateSink(rtc::VideoSinkInterface<webrtc::Video
 void CaptureModuleAndroid::RemoveSink(rtc::VideoSinkInterface<webrtc::VideoFrame>* sink)
 {
     mVideoSource->RemoveSink(sink);
-}
-
-void CaptureModuleAndroid::AddRef() const
-{
-}
-
-rtc::RefCountReleaseStatus CaptureModuleAndroid::Release() const
-{
-    return rtc::RefCountReleaseStatus::kOtherRefsRemained;
 }
 
 void CaptureModuleAndroid::RegisterObserver(webrtc::ObserverInterface* observer)

--- a/src/rtcModule/webrtcAdapter.cpp
+++ b/src/rtcModule/webrtcAdapter.cpp
@@ -294,11 +294,18 @@ std::set<std::pair<std::string, std::string> > VideoManager::getVideoDevices()
 
 void VideoManager::AddRef() const
 {
+    mRefCount.IncRef();
 }
 
 rtc::RefCountReleaseStatus VideoManager::Release() const
 {
-    return rtc::RefCountReleaseStatus::kOtherRefsRemained;
+    const auto status = mRefCount.DecRef();
+    if (status == rtc::RefCountReleaseStatus::kDroppedLastRef)
+    {
+        delete this;
+    }
+
+    return status;
 }
 
 #ifdef __ANDROID__

--- a/src/rtcModule/webrtcAdapter.h
+++ b/src/rtcModule/webrtcAdapter.h
@@ -299,6 +299,9 @@ public:
     virtual void releaseDevice() = 0;
     virtual rtc::scoped_refptr<webrtc::VideoTrackSourceInterface> getVideoTrackSource() = 0;
     static std::set<std::pair<std::string, std::string>> getVideoDevices();
+
+    void AddRef() const override;
+    rtc::RefCountReleaseStatus Release() const override;
 };
 
 class CaptureModuleLinux : public rtc::VideoSinkInterface<webrtc::VideoFrame>, public VideoManager
@@ -322,9 +325,6 @@ public:
 
     void AddOrUpdateSink(rtc::VideoSinkInterface<webrtc::VideoFrame>* sink, const rtc::VideoSinkWants& wants) override;
     void RemoveSink(rtc::VideoSinkInterface<webrtc::VideoFrame>* sink) override;
-
-    void AddRef() const override;
-    rtc::RefCountReleaseStatus Release() const override;
 
     void OnFrame(const webrtc::VideoFrame& frame) override;
 
@@ -363,9 +363,6 @@ public:
     void AddOrUpdateSink(rtc::VideoSinkInterface<webrtc::VideoFrame>* sink, const rtc::VideoSinkWants& wants) override;
     void RemoveSink(rtc::VideoSinkInterface<webrtc::VideoFrame>* sink) override;
 
-    void AddRef() const override;
-    rtc::RefCountReleaseStatus Release() const override;
-
     void RegisterObserver(webrtc::ObserverInterface* observer) override;
     void UnregisterObserver(webrtc::ObserverInterface* observer) override;
     
@@ -399,9 +396,6 @@ public:
 
     void AddOrUpdateSink(rtc::VideoSinkInterface<webrtc::VideoFrame>* sink, const rtc::VideoSinkWants& wants) override;
     void RemoveSink(rtc::VideoSinkInterface<webrtc::VideoFrame>* sink) override;
-
-    void AddRef() const override;
-    rtc::RefCountReleaseStatus Release() const override;
 
     void RegisterObserver(webrtc::ObserverInterface* observer) override;
     void UnregisterObserver(webrtc::ObserverInterface* observer) override;

--- a/src/rtcModule/webrtcAdapter.h
+++ b/src/rtcModule/webrtcAdapter.h
@@ -302,6 +302,9 @@ public:
 
     void AddRef() const override;
     rtc::RefCountReleaseStatus Release() const override;
+
+private:
+    mutable webrtc::webrtc_impl::RefCounter mRefCount{0};
 };
 
 class CaptureModuleLinux : public rtc::VideoSinkInterface<webrtc::VideoFrame>, public VideoManager

--- a/src/rtcModule/webrtcPrivate.h
+++ b/src/rtcModule/webrtcPrivate.h
@@ -211,7 +211,7 @@ protected:
     promise::Promise<void> mDestroyPromise;
     std::shared_ptr<artc::LocalStreamHandle> mLocalStream;
     std::shared_ptr<artc::StreamPlayer> mLocalPlayer;
-    std::shared_ptr<artc::VideoManager> mVideoDevice;
+    rtc::scoped_refptr<artc::VideoManager> mVideoDevice;
     megaHandle mDestroySessionTimer = 0;
     unsigned int mTotalSessionRetry = 0;
     uint8_t mPredestroyState;


### PR DESCRIPTION
We have change the way of manage a VideoManager object. Now, we use a rtc::scoped_refptr. 
During tests, we detect that changing  the video source during a call produce a memory invalid access.
Although, we have to define a rtc::scoped_refptr in webrtcPrivate.h this solution is less complicated than keep the shared_ptr