### PR TITLE
#13262. Refactor session notifications

### DIFF
--- a/bindings/Objective-C/MEGAChatCall.h
+++ b/bindings/Objective-C/MEGAChatCall.h
@@ -42,19 +42,20 @@ typedef NS_ENUM (NSInteger, MEGAChatCallChangeType) {
     MEGAChatCallChangeTypeNoChages = 0x00,
     MEGAChatCallChangeTypeStatus = 0x01,
     MEGAChatCallChangeTypeLocalAVFlags = 0x02,
-    MEGAChatCallChangeTypeRemoteAVFlags = 0x04,
-    MEGAChatCallChangeTypeTemporaryError = 0x08,
-    MEGAChatCallChangeTypeRingingStatus = 0x10,
-    MEGAChatCallChangeTypeSessionStatus = 0x20,
-    MEGAChatCallChangeTypeCallComposition = 0x40,
-    MEGAChatCallChangeTypeNetworkQuality = 0x80,
-    MEGAChatCallChangeTypeAudioLevel = 0x100
+    MEGAChatCallChangeTypeRingingStatus = 0x04,
+    MEGAChatCallChangeTypeCallComposition = 0x08,
 };
 
 typedef NS_ENUM (NSInteger, MEGAChatCallConfiguration) {
     MEGAChatCallConfigurationWithAudio = 0,
     MEGAChatCallConfigurationWithVideo = 1,
     MEGAChatCallConfigurationAnyFlag = 2,
+};
+
+typedef NS_ENUM (NSInteger, MEGAChatCallCompositionChange) {
+    MEGAChatCallCompositionChangePeerRemoved = -1,
+    MEGAChatCallCompositionChangeNoChange = 0,
+    MEGAChatCallCompositionChangePeerAdded = 1,
 };
 
 @interface MEGAChatCall : NSObject
@@ -66,7 +67,6 @@ typedef NS_ENUM (NSInteger, MEGAChatCallConfiguration) {
 @property (nonatomic, readonly) int64_t duration;
 @property (nonatomic, readonly) int64_t initialTimeStamp;
 @property (nonatomic, readonly) int64_t finalTimeStamp;
-@property (nonatomic, readonly) NSString *temporaryError;
 @property (nonatomic, readonly, getter=hasLocalAudio) BOOL localAudio;
 @property (nonatomic, readonly, getter=hasLocalVideo) BOOL localVideo;
 @property (nonatomic, readonly, getter=hasAudioInitialCall) BOOL audioInitialCall;
@@ -74,8 +74,9 @@ typedef NS_ENUM (NSInteger, MEGAChatCallConfiguration) {
 @property (nonatomic, readonly) MEGAChatCallTermCode termCode;
 @property (nonatomic, readonly, getter=isLocalTermCode) BOOL localTermCode;
 @property (nonatomic, readonly, getter=isRinging) BOOL ringing;
-@property (nonatomic, readonly) uint64_t peerSessionStatusChange;
-@property (nonatomic, readonly) uint64_t clientSessionStatusChange;
+@property (nonatomic, readonly) uint64_t peeridCallCompositionChange;
+@property (nonatomic, readonly) uint64_t clientidCallCompositionChange;
+@property (nonatomic, readonly) uint64_t callCompositionChange;
 
 @property (nonatomic, readonly) NSInteger numParticipants;
 @property (nonatomic, readonly) MEGAHandleList *sessionsPeerId;
@@ -92,5 +93,7 @@ typedef NS_ENUM (NSInteger, MEGAChatCallConfiguration) {
 - (MEGAChatSession *)sessionForPeer:(uint64_t)peerId clientId:(uint64_t)clientId;
 
 - (instancetype)clone;
+
++ (NSString *)stringForTermCode:(MEGAChatCallTermCode)termCode;
 
 @end

--- a/bindings/Objective-C/MEGAChatCall.mm
+++ b/bindings/Objective-C/MEGAChatCall.mm
@@ -83,16 +83,6 @@ using namespace megachat;
     return self.megaChatCall ? self.megaChatCall->getInitialTimeStamp() : 0;
 }
 
-- (NSString *)error {
-    const char *val = self.megaChatCall->getTemporaryError();
-    if (!val) return nil;
-    
-    NSString *ret = [[NSString alloc] initWithUTF8String:val];
-    
-    delete [] val;
-    return ret;
-}
-
 - (BOOL)hasLocalAudio {
     return self.megaChatCall ? self.megaChatCall->hasLocalAudio() : NO;
 }
@@ -125,12 +115,16 @@ using namespace megachat;
     return self.megaChatCall ? self.megaChatCall->isRinging() : NO;
 }
 
-- (uint64_t)peerSessionStatusChange {
-    return self.megaChatCall ? self.megaChatCall->getPeerSessionStatusChange() : MEGACHAT_INVALID_HANDLE;
+- (uint64_t)peeridCallCompositionChange {
+    return self.megaChatCall ? self.megaChatCall->getPeeridCallCompositionChange() : MEGACHAT_INVALID_HANDLE;
 }
 
-- (uint64_t)clientSessionStatusChange {
-    return self.megaChatCall ? self.megaChatCall->getClientidSessionStatusChange() : MEGACHAT_INVALID_HANDLE;
+- (uint64_t)clientidCallCompositionChange {
+    return self.megaChatCall ? self.megaChatCall->getClientidCallCompositionChange() : MEGACHAT_INVALID_HANDLE;
+}
+
+- (uint64_t)callCompositionChange {
+    return self.megaChatCall ? self.megaChatCall->getCallCompositionChange() : MEGACHAT_INVALID_HANDLE;
 }
 
 - (MEGAHandleList *)sessionsPeerId {

--- a/bindings/Objective-C/MEGAChatCallDelegate.h
+++ b/bindings/Objective-C/MEGAChatCallDelegate.h
@@ -11,4 +11,6 @@
 
 - (void)onChatCallUpdate:(MEGAChatSdk *)api call:(MEGAChatCall *)call;
 
+- (void)onChatSessionUpdate:(MEGAChatSdk *)api chatId:(uint64_t)chatId callId:(uint64_t)callId session:(MEGAChatSession *)session;
+
 @end

--- a/bindings/Objective-C/MEGAChatSession.h
+++ b/bindings/Objective-C/MEGAChatSession.h
@@ -8,6 +8,15 @@ typedef NS_ENUM (NSInteger, MEGAChatSessionStatus) {
     MEGAChatSessionStatusDestroyed
 };
 
+typedef NS_ENUM (NSInteger, MEGAChatSessionChange) {
+    MEGAChatSessionChangeNoChanges = 0x00,
+    MEGAChatSessionChangeStatus = 0x01,
+    MEGAChatSessionChangeRemoteAvFlags = 0x02,
+    MEGAChatSessionChangeNetworkQuality = 0x04,
+    MEGAChatSessionChangeAudioLevel = 0x08,
+    MEGAChatSessionChangeOperative = 0x10,
+};
+
 @interface MEGAChatSession : NSObject
 
 @property (nonatomic, readonly) MEGAChatSessionStatus status;
@@ -19,5 +28,10 @@ typedef NS_ENUM (NSInteger, MEGAChatSessionStatus) {
 @property (nonatomic, readonly) uint64_t clientId;
 @property (nonatomic, readonly) BOOL audioDetected;
 @property (nonatomic, readonly) NSInteger networkQuality;
+@property (nonatomic, readonly) NSInteger termCode;
+@property (nonatomic, readonly) BOOL isLocalTermCode;
+@property (nonatomic, readonly) NSInteger changes;
+
+- (BOOL)hasChanged:(MEGAChatSessionChange)change;
 
 @end

--- a/bindings/Objective-C/MEGAChatSession.mm
+++ b/bindings/Objective-C/MEGAChatSession.mm
@@ -1,6 +1,8 @@
 
 #import "MEGAChatSession.h"
 #import "megachatapi.h"
+#import "MEGAChatCall.h"
+#import "MEGASdk.h"
 
 using namespace megachat;
 
@@ -64,6 +66,73 @@ using namespace megachat;
 
 - (BOOL)audioDetected {
     return self.megaChatSession ? self.megaChatSession->getAudioDetected() : NO;
+}
+
+- (NSInteger)termCode {
+    return self.megaChatSession ? self.megaChatSession->getTermCode() : 0;
+}
+
+- (BOOL)isLocalTermCode {
+    return self.megaChatSession ? self.megaChatSession->isLocalTermCode() : NO;
+}
+
+- (NSInteger)changes {
+    return self.megaChatSession ? self.megaChatSession->getChanges() : 0;
+}
+
+- (BOOL)hasChanged:(MEGAChatSessionChange)change {
+    return self.megaChatSession ? self.megaChatSession->hasChanged((int)change) : NO;
+}
+
+- (NSString *)description {
+    NSString *peerId = [MEGASdk base64HandleForUserHandle:self.peerId];
+    NSString *clientId = [MEGASdk base64HandleForUserHandle:self.clientId];
+    NSString *termCode = [MEGAChatCall stringForTermCode:(MEGAChatCallTermCode)self.termCode];
+    NSString *hasAudio = self.hasAudio ? @"ON" : @"OFF";
+    NSString *hasVideo = self.hasVideo ? @"ON" : @"OFF";
+    NSString *localTermCode = self.isLocalTermCode ? @"YES" : @"NO";
+    NSString *audioDetected = self.audioDetected ? @"YES" : @"NO";
+    NSString *changes = [self stringForChanges];
+    return [NSString stringWithFormat:@"<%@: peerId=%@; clientId=%@; hasAudio=%@; hasVideo=%@; changes=%@; audioDetected=%@; networkQuality=%ld; termCode=%@; is local term code %@>", self.class, peerId, clientId, hasAudio, hasVideo, changes, audioDetected, self.networkQuality, termCode, localTermCode];
+}
+
+- (NSString *)stringForChanges {
+    NSString *changes = @"";
+    if ([self hasChanged:MEGAChatSessionChangeNoChanges]) {
+        changes = [changes stringByAppendingString:@" | NO CHANGES"];
+    }
+    if ([self hasChanged:MEGAChatSessionChangeStatus]) {
+        switch (self.status) {
+            case MEGAChatSessionStatusInitial:
+                changes = [changes stringByAppendingString:@" | STATUS INITIAL"];
+                break;
+                
+            case MEGAChatSessionStatusDestroyed:
+                changes = [changes stringByAppendingString:@" | STATUS DESTROYED"];
+                break;
+                
+            case MEGAChatSessionStatusInvalid:
+                changes = [changes stringByAppendingString:@" | STATUS INVALID"];
+                break;
+                
+            case MEGAChatSessionStatusInProgress:
+                changes = [changes stringByAppendingString:@" | STATUS IN PROGRESS"];
+                break;
+        }
+    }
+    if ([self hasChanged:MEGAChatSessionChangeRemoteAvFlags]) {
+        changes = [changes stringByAppendingString:@" | AV FLAGS"];
+    }
+    if ([self hasChanged:MEGAChatSessionChangeNetworkQuality]) {
+        changes = [changes stringByAppendingString:@" | NETWORK QUALITY"];
+    }
+    if ([self hasChanged:MEGAChatSessionChangeAudioLevel]) {
+        changes = [changes stringByAppendingString:@" | AUDIO LEVEL"];
+    }
+    if ([self hasChanged:MEGAChatSessionChangeOperative]) {
+        changes = [changes stringByAppendingString:@" | OPERATIVE"];
+    }
+    return [changes substringFromIndex:3];
 }
 
 @end

--- a/bindings/Objective-C/Private/DelegateMEGAChatCallListener.h
+++ b/bindings/Objective-C/Private/DelegateMEGAChatCallListener.h
@@ -9,6 +9,7 @@ public:
     id<MEGAChatCallDelegate>getUserListener();
     
     void onChatCallUpdate(megachat::MegaChatApi* api, megachat::MegaChatCall *call);
+    void onChatSessionUpdate(megachat::MegaChatApi *api, megachat::MegaChatHandle chatid, megachat::MegaChatHandle callid, megachat::MegaChatSession *session);
     
 private:
     __weak MEGAChatSdk *megaChatSdk;

--- a/bindings/Objective-C/Private/DelegateMEGAChatCallListener.mm
+++ b/bindings/Objective-C/Private/DelegateMEGAChatCallListener.mm
@@ -2,6 +2,7 @@
 #import "DelegateMEGAChatCallListener.h"
 #import "MEGAChatCall+init.h"
 #import "MEGAChatError+init.h"
+#import "MEGAChatSession+init.h"
 
 using namespace megachat;
 
@@ -22,6 +23,17 @@ void DelegateMEGAChatCallListener::onChatCallUpdate(megachat::MegaChatApi *api, 
         id<MEGAChatCallDelegate>tempListener = this->listener;
         dispatch_async(dispatch_get_main_queue(), ^{
             [tempListener onChatCallUpdate:tempMEGAChatSdk call:[[MEGAChatCall alloc] initWithMegaChatCall:tempCall cMemoryOwn:YES]];
+        });
+    }
+}
+
+void DelegateMEGAChatCallListener::onChatSessionUpdate(megachat::MegaChatApi *api, megachat::MegaChatHandle chatid, megachat::MegaChatHandle callid, megachat::MegaChatSession *session) {
+    if (listener != nil && [listener respondsToSelector:@selector(onChatSessionUpdate:chatId:callId:session:)]) {
+        MegaChatSession *tempSession = session->copy();
+        MEGAChatSdk *tempMEGAChatSdk = this->megaChatSdk;
+        id<MEGAChatCallDelegate>tempListener = this->listener;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [tempListener onChatSessionUpdate:tempMEGAChatSdk chatId:chatid callId:callid session:[MEGAChatSession.alloc initWithMegaChatSession:tempSession cMemoryOwn:YES]];
         });
     }
 }

--- a/bindings/java/nz/mega/sdk/DelegateMegaChatCallListener.java
+++ b/bindings/java/nz/mega/sdk/DelegateMegaChatCallListener.java
@@ -40,4 +40,16 @@ class DelegateMegaChatCallListener extends MegaChatCallListener{
             });
         }
     }
+
+    @Override
+    public void onChatSessionUpdate(MegaChatApi api, long chatid, long callid, MegaChatSession session) {
+        if (listener != null) {
+            final MegaChatSession megaChatSession = session.copy();
+            megaChatApi.runCallback(new Runnable() {
+                public void run() {
+                    listener.onChatSessionUpdate(megaChatApi, chatid, callid, megaChatSession);
+                }
+            });
+        }
+    }
 }

--- a/bindings/java/nz/mega/sdk/MegaChatCallListenerInterface.java
+++ b/bindings/java/nz/mega/sdk/MegaChatCallListenerInterface.java
@@ -18,4 +18,5 @@ package nz.mega.sdk;
 
 public interface MegaChatCallListenerInterface {
     public void onChatCallUpdate(MegaChatApiJava api, MegaChatCall call);
+    public void onChatSessionUpdate(MegaChatApiJava api, long chatid, long callid, MegaChatSession session);
 }

--- a/bindings/qt/QTMegaChatCallListener.cpp
+++ b/bindings/qt/QTMegaChatCallListener.cpp
@@ -21,6 +21,15 @@ void QTMegaChatCallListener::onChatCallUpdate(MegaChatApi *api, MegaChatCall *ca
     QCoreApplication::postEvent(this, event, INT_MIN);
 }
 
+void QTMegaChatCallListener::onChatSessionUpdate(MegaChatApi *api, MegaChatHandle chatid, MegaChatHandle callid, MegaChatSession *session)
+{
+    QTMegaChatEvent *event = new QTMegaChatEvent(api, (QEvent::Type)QTMegaChatEvent::onChatSessionUpdate);
+    event->setChatSession(session->copy());
+    event->setChatHandle(chatid);
+    event->setChatCallid(callid);
+    QCoreApplication::postEvent(this, event, INT_MIN);
+}
+
 
 void QTMegaChatCallListener::customEvent(QEvent *e)
 {
@@ -29,6 +38,9 @@ void QTMegaChatCallListener::customEvent(QEvent *e)
     {
         case QTMegaChatEvent::OnChatCallUpdate:
             if (listener) listener->onChatCallUpdate(event->getMegaChatApi(), event->getChatCall());
+            break;
+        case QTMegaChatEvent::onChatSessionUpdate:
+            if (listener) listener->onChatSessionUpdate(event->getMegaChatApi(), event->getChatHandle(), event->getChatCallid(), event->getChatSession());
             break;
         default:
             break;

--- a/bindings/qt/QTMegaChatCallListener.h
+++ b/bindings/qt/QTMegaChatCallListener.h
@@ -14,6 +14,7 @@ public:
     QTMegaChatCallListener(MegaChatApi *megaChatApi, MegaChatCallListener *parent = NULL);
     virtual ~QTMegaChatCallListener();
     virtual void onChatCallUpdate(MegaChatApi *api, MegaChatCall *call);
+    virtual void onChatSessionUpdate(MegaChatApi *api, MegaChatHandle chatid, MegaChatHandle callid, MegaChatSession *session);
 
 protected:
     virtual void customEvent(QEvent * event);

--- a/bindings/qt/QTMegaChatEvent.cpp
+++ b/bindings/qt/QTMegaChatEvent.cpp
@@ -6,17 +6,19 @@ using namespace std;
 QTMegaChatEvent::QTMegaChatEvent(MegaChatApi *megaChatApi, Type type) : QEvent(type)
 {
     this->megaChatApi = megaChatApi;
-    request = NULL;
-    error = NULL;
-    item = NULL;
+    request = nullptr;
+    error = nullptr;
+    item = nullptr;
     handle = ::mega::INVALID_HANDLE;
-    config = NULL;
-    chat = NULL;
-    msg = NULL;
-    buffer = NULL;
+    config = nullptr;
+    chat = nullptr;
+    msg = nullptr;
+    buffer = nullptr;
     inProgress = false;
     status = 0;
-    call = NULL;
+    call = nullptr;
+    callid = MEGACHAT_INVALID_HANDLE;
+    session = nullptr;
 }
 
 QTMegaChatEvent::~QTMegaChatEvent()
@@ -29,6 +31,7 @@ QTMegaChatEvent::~QTMegaChatEvent()
     delete chat;
     delete msg;
     delete call;
+    delete session;
 }
 
 MegaChatApi *QTMegaChatEvent::getMegaChatApi()
@@ -106,6 +109,16 @@ size_t QTMegaChatEvent::getSize()
     return size;
 }
 
+MegaChatSession *QTMegaChatEvent::getChatSession()
+{
+    return session;
+}
+
+MegaChatHandle QTMegaChatEvent::getChatCallid()
+{
+    return callid;
+}
+
 void QTMegaChatEvent::setChatRequest(MegaChatRequest *request)
 {
     this->request = request;
@@ -179,4 +192,14 @@ void QTMegaChatEvent::setBuffer(char *buffer)
 void QTMegaChatEvent::setSize(size_t size)
 {
     this->size = size;
+}
+
+void QTMegaChatEvent::setChatSession(MegaChatSession *session)
+{
+    this->session = session;
+}
+
+void QTMegaChatEvent::setChatCallid(MegaChatHandle callid)
+{
+    this->callid = callid;
 }

--- a/bindings/qt/QTMegaChatEvent.h
+++ b/bindings/qt/QTMegaChatEvent.h
@@ -30,6 +30,7 @@ public:
         OnChatNotification,
         OnChatVideoData,
         OnChatCallUpdate,
+        onChatSessionUpdate,
         OnAttachmentLoaded,
         OnAttachmentReceived,
         OnAttachmentDeleted,
@@ -55,6 +56,8 @@ public:
     int getHeight();
     char *getBuffer();
     size_t getSize();
+    MegaChatSession *getChatSession();
+    MegaChatHandle getChatCallid();
 
     void setChatRequest(MegaChatRequest *request);
     void setChatError(MegaChatError *error);
@@ -70,6 +73,8 @@ public:
     void setHeight(int height);
     void setBuffer(char *buffer);
     void setSize(size_t size);
+    void setChatSession(MegaChatSession *session);
+    void setChatCallid(MegaChatHandle callid);
 
 private:
     MegaChatApi *megaChatApi;
@@ -81,6 +86,8 @@ private:
     MegaChatRoom *chat;
     MegaChatMessage *msg;
     MegaChatCall *call;
+    MegaChatSession *session;
+    MegaChatHandle callid;
     bool inProgress;
     int status;
     int width;

--- a/examples/qtmegachatapi/MainWindow.cpp
+++ b/examples/qtmegachatapi/MainWindow.cpp
@@ -207,6 +207,19 @@ void MainWindow::onChatCallUpdate(megachat::MegaChatApi */*api*/, megachat::Mega
                     window->connectPeerCallGui(mMegaChatApi->getMyUserHandle(), mMegaChatApi->getMyClientidHandle(call->getChatid()));
                 }
 
+                MegaHandleList* clientids = call->getClientidParticipants();
+                MegaHandleList* peerids = call->getPeeridParticipants();
+                for (unsigned int i = 0; i < peerids->size(); i++)
+                {
+                    if (peerids->get(i) != mMegaChatApi->getMyUserHandle() || mMegaChatApi->getMyClientidHandle(call->getChatid()) != clientids->get(i))
+                    {
+                        window->createCallGui(false, peerids->get(i), clientids->get(i));
+                    }
+                }
+
+                delete clientids;
+                delete peerids;
+
                 break;
             }
             case megachat::MegaChatCall::CALL_STATUS_USER_NO_PRESENT:
@@ -228,19 +241,41 @@ void MainWindow::onChatCallUpdate(megachat::MegaChatApi */*api*/, megachat::Mega
         }
     }
 
-    if (call->hasChanged(MegaChatCall::CHANGE_TYPE_REMOTE_AVFLAGS) &&
+    if (call->hasChanged(megachat::MegaChatCall::CHANGE_TYPE_CALL_COMPOSITION) &&
             call->getStatus() == megachat::MegaChatCall::CALL_STATUS_IN_PROGRESS)
+    {
+        if (call->getClientIsAddedOrRemoved())
+        {
+            window->createCallGui(false, call->getPeeridCallCompositionChange(), call->getClientidCallCompositionChange());
+        }
+        else
+        {
+            window->destroyCallGui(call->getPeeridCallCompositionChange(), call->getClientidCallCompositionChange());
+        }
+    }
+}
+
+void MainWindow::onChatSessionUpdate(MegaChatApi *api, MegaChatHandle chatid, MegaChatHandle callid, MegaChatSession *session)
+{
+    ChatListItemController *itemController = getChatControllerById(chatid);
+    if (!itemController)
+    {
+        throw std::runtime_error("Session notification in a call without associated item");
+    }
+
+    ChatWindow *window = itemController->showChatWindow();
+    assert(window);
+
+    if (session->hasChanged(MegaChatSession::CHANGE_TYPE_REMOTE_AVFLAGS) &&
+            session->getStatus() == megachat::MegaChatSession::SESSION_STATUS_IN_PROGRESS)
     {
         std::set<CallGui *> *setOfCallGui = window->getCallGui();
         std::set<CallGui *>::iterator it;
         for (it = setOfCallGui->begin(); it != setOfCallGui->end(); ++it)
         {
             CallGui *callGui = *it;
-            MegaChatHandle peerid = call->getPeerSessionStatusChange();
-            MegaChatHandle clientid = call->getClientidSessionStatusChange();
-            if (callGui->getPeerid() == peerid && callGui->getClientid() == clientid)
+            if (callGui->getPeerid() == session->getPeerid() && callGui->getClientid() == session->getClientid())
             {
-                MegaChatSession *session = call->getMegaChatSession(peerid, clientid);
                 if (session->hasVideo())
                 {
                     callGui->ui->videoRenderer->disableStaticImage();
@@ -256,27 +291,20 @@ void MainWindow::onChatCallUpdate(megachat::MegaChatApi */*api*/, megachat::Mega
     }
 
     //NEW SESSIONS
-    if (call->hasChanged(MegaChatCall::CHANGE_TYPE_SESSION_STATUS))
+    if (session->hasChanged(MegaChatSession::CHANGE_TYPE_STATUS))
     {
-       MegaChatHandle peerid = call->getPeerSessionStatusChange();
-       MegaChatHandle clientid = call->getClientidSessionStatusChange();
-       MegaChatSession *session = call->getMegaChatSession(peerid, clientid);
        assert(session);
        switch (session->getStatus())
        {
            case MegaChatSession::SESSION_STATUS_IN_PROGRESS:
            {
-               window->createCallGui(call->hasVideoInitialCall(), peerid, clientid);
-               window->connectPeerCallGui(peerid, clientid);
+               window->connectPeerCallGui(session->getPeerid(), session->getClientid());
 
                break;
            }
-
-           case MegaChatSession::SESSION_STATUS_DESTROYED:
-               window->destroyCallGui(peerid, clientid);
-               break;
        }
     }
+
 }
 
 MegaChatApplication* MainWindow::getApp() const

--- a/examples/qtmegachatapi/MainWindow.cpp
+++ b/examples/qtmegachatapi/MainWindow.cpp
@@ -244,11 +244,11 @@ void MainWindow::onChatCallUpdate(megachat::MegaChatApi */*api*/, megachat::Mega
     if (call->hasChanged(megachat::MegaChatCall::CHANGE_TYPE_CALL_COMPOSITION) &&
             call->getStatus() == megachat::MegaChatCall::CALL_STATUS_IN_PROGRESS)
     {
-        if (call->getClientIsAddedOrRemoved())
+        if (call->getCallCompositionChange() == MegaChatCall::PEER_ADDED)
         {
             window->createCallGui(false, call->getPeeridCallCompositionChange(), call->getClientidCallCompositionChange());
         }
-        else
+        else if (call->getCallCompositionChange() == MegaChatCall::PEER_REMOVED)
         {
             window->destroyCallGui(call->getPeeridCallCompositionChange(), call->getClientidCallCompositionChange());
         }

--- a/examples/qtmegachatapi/MainWindow.h
+++ b/examples/qtmegachatapi/MainWindow.h
@@ -163,6 +163,7 @@ class MainWindow :
 
 #ifndef KARERE_DISABLE_WEBRTC
         void onChatCallUpdate(megachat::MegaChatApi *api, megachat::MegaChatCall *call);
+        void onChatSessionUpdate(megachat::MegaChatApi *api, megachat::MegaChatHandle chatid, megachat::MegaChatHandle callid, megachat::MegaChatSession *session);
 #endif
         MegaChatApplication* getApp() const;
 

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -222,9 +222,9 @@ MegaChatHandle MegaChatCall::getClientidCallCompositionChange() const
     return MEGACHAT_INVALID_HANDLE;
 }
 
-bool MegaChatCall::getClientIsAddedOrRemoved() const
+int MegaChatCall::getCallCompositionChange() const
 {
-    return false;
+    return NO_COMPOSITION_CHANGE;
 }
 
 MegaHandleList *MegaChatCall::getPeeridParticipants() const

--- a/src/megachatapi.cpp
+++ b/src/megachatapi.cpp
@@ -78,12 +78,32 @@ bool MegaChatSession::hasVideo() const
     return false;
 }
 
+int MegaChatSession::getTermCode() const
+{
+    return 0;
+}
+
+bool MegaChatSession::isLocalTermCode() const
+{
+    return false;
+}
+
 int MegaChatSession::getNetworkQuality() const
 {
     return 0;
 }
 
 bool MegaChatSession::getAudioDetected() const
+{
+    return false;
+}
+
+int MegaChatSession::getChanges() const
+{
+    return CHANGE_TYPE_NO_CHANGES;
+}
+
+bool MegaChatSession::hasChanged(int changeType) const
 {
     return false;
 }
@@ -192,14 +212,19 @@ MegaChatSession *MegaChatCall::getMegaChatSession(MegaChatHandle /*peerid*/, Meg
     return NULL;
 }
 
-MegaChatHandle MegaChatCall::getPeerSessionStatusChange() const
+MegaChatHandle MegaChatCall::getPeeridCallCompositionChange() const
 {
     return MEGACHAT_INVALID_HANDLE;
 }
 
-MegaChatHandle MegaChatCall::getClientidSessionStatusChange() const
+MegaChatHandle MegaChatCall::getClientidCallCompositionChange() const
 {
     return MEGACHAT_INVALID_HANDLE;
+}
+
+bool MegaChatCall::getClientIsAddedOrRemoved() const
+{
+    return false;
 }
 
 MegaHandleList *MegaChatCall::getPeeridParticipants() const
@@ -1366,6 +1391,11 @@ void MegaChatVideoListener::onChatVideoData(MegaChatApi * /*api*/, MegaChatHandl
 
 
 void MegaChatCallListener::onChatCallUpdate(MegaChatApi * /*api*/, MegaChatCall * /*call*/)
+{
+
+}
+
+void MegaChatCallListener::onChatSessionUpdate(MegaChatApi * /*api*/, MegaChatHandle /*chatid*/, MegaChatHandle /*callid*/, MegaChatSession * /*session*/)
 {
 
 }

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -154,22 +154,17 @@ public:
      *
      * Possible values are:
      *
-     *   MegaChatCall::TERM_CODE_USER_HANGUP       = 0,    /// Normal user hangup
-     *   MegaChatCall::TERM_CODE_CALL_REQ_CANCEL   = 1,    /// Call request was canceled before call was answered
-     *   MegaChatCall::TERM_CODE_CALL_REJECT       = 2,    /// Outgoing call has been rejected by the peer OR incoming call has been rejected in
-                                            /// the current device
-     *   MegaChatCall::TERM_CODE_ANSWER_ELSE_WHERE = 3,    /// Call was answered on another device of ours
-     *   MegaChatCall::TEMR_CODE_REJECT_ELSE_WHERE = 4,    /// Call was rejected on another device of ours
-     *   MegaChatCall::TERM_CODE_ANSWER_TIMEOUT    = 5,    /// Call was not answered in a timely manner
-     *   MegaChatCall::TERM_CODE_RING_OUT_TIMEOUT  = 6,    /// We have sent a call request but no RINGING received within this timeout - no other
-                                            /// users are online
-     *   MegaChatCall::TERM_CODE_APP_TERMINATING   = 7,    /// The application is terminating
-     *   MegaChatCall::TERM_CODE_BUSY              = 9,    /// Peer is in another call
-     *   MegaChatCall::TERM_CODE_NOT_FINISHED      = 10,   /// The call is in progress, no termination code yet
-     *   MegaChatCall::TERM_CODE_DESTROY_BY_COLLISION   = 19,   /// The call has finished by a call collision
-     *   MegaChatCall::TERM_CODE_ERROR             = 21    /// Notify any error type
+     *   - MegaChatCall::TERM_CODE_USER_HANGUP       = 0
+     *  Normal user hangup. User has left the call
+     *
+     *   - MegaChatCall::TERM_CODE_NOT_FINISHED      = 10
+     *  The session is in progress, no termination code yet
+     *
+     *   -MegaChatCall::TERM_CODE_ERROR             = 21
+     *  Notify any error type. A reconnection is launched
      *
      * @note If the session is not finished yet, it returns MegaChatCall::TERM_CODE_NOT_FINISHED.
+     * The rest of values are invalid as term code  for a session
      *
      * To check if the call was terminated locally or remotely, see MegaChatSession::isLocalTermCode().
      *

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -686,7 +686,7 @@ public:
     /**
      * @brief Returns if call is outgoing
      *
-     * @return Ture if outgoing call, false if incoming
+     * @return True if outgoing call, false if incoming
      */
     virtual bool isOutgoing() const;
 

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -338,6 +338,12 @@ public:
         ANY_FLAG = 2
     };
 
+    enum {
+        PEER_REMOVED = -1,
+        NO_COMPOSITION_CHANGE = 0,
+        PEER_ADDED = 1,
+    };
+
     virtual ~MegaChatCall();
 
     /**
@@ -613,14 +619,23 @@ public:
     virtual MegaChatHandle getClientidCallCompositionChange() const;
 
     /**
-     * @brief Returns true if the user with peerid/clientid has been added to the call
+     * @brief Returns if peer has been added or removed from the call
      *
      * This function only returns a valid value when MegaChatCall::CHANGE_TYPE_CALL_COMPOSITION is notified
      * via MegaChatCallListener::onChatCallUpdate
      *
-     * @return true/false if user with peerid-clientid has been added/removed from call
+     * Valid values:
+     *   PEER_REMOVED = -1,
+     *   NO_COMPOSITION_CHANGE = 0,
+     *   PEER_ADDED = 1,
+     *
+     * @note During reconnection this callback has to be ignored to avoid notify that all users
+     * in the call have left the call and have joined again. When status change to In-progres again,
+     * the GUI can be adapted to all participants in the call
+     *
+     * @return if peer with peerid-clientid has been added/removed from call
      */
-    virtual bool getClientIsAddedOrRemoved() const;
+    virtual int  getCallCompositionChange() const;
 
     /**
      * @brief Get a list with the ids of peers that are participating in the call

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -164,7 +164,7 @@ public:
      *  Notify any error type. A reconnection is launched
      *
      * @note If the session is not finished yet, it returns MegaChatCall::TERM_CODE_NOT_FINISHED.
-     * The rest of values are invalid as term code  for a session
+     * The rest of values are invalid as term code for a session
      *
      * To check if the call was terminated locally or remotely, see MegaChatSession::isLocalTermCode().
      *

--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -222,10 +222,10 @@ public:
      * Check MegaChatSession::hasAudio() and MegaChatSession::hasVideo() value
      *
      *  - CHANGE_TYPE_SESSION_NETWORK_QUALITY = 0x04
-     * Check if the network quality of the session changed
+     * Check if the network quality of the session changed. Check MegaChatSession::getNetworkQuality
      *
      *  - CHANGE_TYPE_SESSION_AUDIO_LEVEL = 0x08
-     * Check if the level audio of the session changed
+     * Check if the level audio of the session changed. Check MegaChatSession::getAudioDetected
      *
      *  - CHANGE_TYPE_SESSION_OPERATIVE = 0x10
      * Notify session is fully operative
@@ -251,10 +251,10 @@ public:
      * Check MegaChatSession::hasAudio() and MegaChatSession::hasVideo() value
      *
      *  - CHANGE_TYPE_SESSION_NETWORK_QUALITY = 0x04
-     * Check if the network quality of the session changed
+     * Check if the network quality of the session changed. Check MegaChatSession::getNetworkQuality
      *
      *  - CHANGE_TYPE_SESSION_AUDIO_LEVEL = 0x08
-     * Check if the level audio of the session changed
+     * Check if the level audio of the session changed. Check MegaChatSession::getAudioDetected
      *
      *  - CHANGE_TYPE_SESSION_OPERATIVE = 0x10
      * Notify session is fully operative
@@ -598,7 +598,7 @@ public:
      * This function only returns a valid value when MegaChatCall::CHANGE_TYPE_CALL_COMPOSITION is notified
      * via MegaChatCallListener::onChatCallUpdate
      *
-     * @return Handle of the peer which session has been added/removed to call
+     * @return Handle of the peer which has been added/removed to call
      */
     virtual MegaChatHandle getPeeridCallCompositionChange() const;
 

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -8220,7 +8220,7 @@ void MegaChatSessionHandler::onSessStateChange(uint8_t newState)
         }
         case rtcModule::ISession::kStateDestroyed:
         {
-            if (callHandler->getCall()->state() < rtcModule::ICall::kStateTerminating)
+            if (callHandler->getCall()->state() < rtcModule::ICall::kStateDestroyed)
             {
                 MegaChatCallPrivate *chatCall = callHandler->getMegaChatCall();
                 megaChatSession->setState(newState);

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -5261,6 +5261,7 @@ MegaChatCallPrivate::MegaChatCallPrivate(Id chatid, Id callid, uint32_t duration
     clientid = 0;
     callerId = MEGACHAT_INVALID_HANDLE;
     mIsCaller = false;
+    callCompositionChange = NO_COMPOSITION_CHANGE;
 }
 
 MegaChatCallPrivate::MegaChatCallPrivate(const MegaChatCallPrivate &call)
@@ -5280,7 +5281,7 @@ MegaChatCallPrivate::MegaChatCallPrivate(const MegaChatCallPrivate &call)
     this->ringing = call.ringing;
     this->ignored = call.ignored;
     this->peerId = call.peerId;
-    this->addedOrRemoved = call.addedOrRemoved;
+    this->callCompositionChange = call.callCompositionChange;
     this->clientid = call.clientid;
     this->callerId = call.callerId;
 
@@ -5436,9 +5437,9 @@ MegaChatHandle MegaChatCallPrivate::getClientidCallCompositionChange() const
     return clientid;
 }
 
-bool MegaChatCallPrivate::getClientIsAddedOrRemoved() const
+int MegaChatCallPrivate::getCallCompositionChange() const
 {
-    return addedOrRemoved;
+    return callCompositionChange;
 }
 
 MegaChatSession *MegaChatCallPrivate::getMegaChatSession(MegaChatHandle peerid, MegaChatHandle clientid)
@@ -5566,6 +5567,7 @@ void MegaChatCallPrivate::removeChanges()
 {
     changed = MegaChatCall::CHANGE_TYPE_NO_CHANGES;
     temporaryError.clear();
+    callCompositionChange = NO_COMPOSITION_CHANGE;
 }
 
 void MegaChatCallPrivate::setError(const string &temporaryError)
@@ -5710,7 +5712,7 @@ bool MegaChatCallPrivate::addOrUpdateParticipant(Id userid, uint32_t clientid, A
         this->changed |= MegaChatCall::CHANGE_TYPE_CALL_COMPOSITION;
         this->peerId = userid;
         this->clientid = clientid;
-        this->addedOrRemoved = true;
+        this->callCompositionChange = MegaChatCall::PEER_ADDED;
         notify = true;
         participants[endPointId] = flags;
     }
@@ -5734,7 +5736,7 @@ bool MegaChatCallPrivate::removeParticipant(Id userid, uint32_t clientid)
         this->changed |= MegaChatCall::CHANGE_TYPE_CALL_COMPOSITION;
         this->peerId = userid;
         this->clientid = clientid;
-        this->addedOrRemoved = false;
+        this->callCompositionChange = MegaChatCall::PEER_REMOVED;
         notify = true;
     }
 

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -8095,12 +8095,19 @@ bool MegaChatCallHandler::isParticipating(Id userid)
     return chatCall->isParticipating(userid);
 }
 
-void MegaChatCallHandler::removeAllParticipants()
+void MegaChatCallHandler::removeAllParticipants(bool exceptMe)
 {
     MegaHandleList* clientids = chatCall->getClientidParticipants();
     MegaHandleList* peerids = chatCall->getPeeridParticipants();
     for (unsigned int i = 0; i < peerids->size(); i++)
     {
+        if (exceptMe &&
+                peerids->get(i) == megaChatApi->getMyUserHandle() &&
+                clientids->get(i) == megaChatApi->getMyClientidHandle(chatCall->getChatid()))
+        {
+            continue;
+        }
+
         chatCall->removeParticipant(peerids->get(i), clientids->get(i));
         megaChatApi->fireOnChatCallUpdate(chatCall);
     }

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -5214,6 +5214,11 @@ void MegaChatSessionPrivate::setSessionFullyOperative()
     changed |= MegaChatSession::CHANGE_TYPE_SESSION_OPERATIVE;
 }
 
+void MegaChatSessionPrivate::setTermCode(int termCode)
+{
+    this->termCode = termCode;
+}
+
 void MegaChatSessionPrivate::removeChanges()
 {
     changed = MegaChatSession::CHANGE_TYPE_NO_CHANGES;
@@ -8219,6 +8224,7 @@ void MegaChatSessionHandler::onSessStateChange(uint8_t newState)
             {
                 MegaChatCallPrivate *chatCall = callHandler->getMegaChatCall();
                 megaChatSession->setState(newState);
+                megaChatSession->setTermCode(session->getTermCode());
                 megaChatApi->fireOnChatSessionUpdate(chatCall->getChatid(), chatCall->getId(), megaChatSession);
             }
 

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -5216,7 +5216,11 @@ void MegaChatSessionPrivate::setSessionFullyOperative()
 
 void MegaChatSessionPrivate::setTermCode(int termCode)
 {
-    this->termCode = termCode;
+    int megaTermCode;
+    bool local;
+    MegaChatCallPrivate::convertTermCode(static_cast<rtcModule::TermCode>(termCode), megaTermCode, local);
+    this->termCode = megaTermCode;
+    this->localTermCode = local;
 }
 
 void MegaChatSessionPrivate::removeChanges()
@@ -5574,61 +5578,61 @@ void MegaChatCallPrivate::removeChanges()
 
 void MegaChatCallPrivate::setTermCode(rtcModule::TermCode termCode)
 {
-    convertTermCode(termCode);
+    convertTermCode(termCode, this->termCode, localTermCode);
 }
 
-void MegaChatCallPrivate::convertTermCode(rtcModule::TermCode termCode)
+void MegaChatCallPrivate::convertTermCode(rtcModule::TermCode termCode, int &megaTermCode, bool &local)
 {
     // Last four bits indicate the termination code and fifth bit indicate local or peer
     switch (termCode & (~rtcModule::TermCode::kPeer))
     {
         case rtcModule::TermCode::kUserHangup:
-            this->termCode = MegaChatCall::TERM_CODE_USER_HANGUP;
+            megaTermCode = MegaChatCall::TERM_CODE_USER_HANGUP;
             break;        
         case rtcModule::TermCode::kCallReqCancel:
-            this->termCode = MegaChatCall::TERM_CODE_CALL_REQ_CANCEL;
+            megaTermCode = MegaChatCall::TERM_CODE_CALL_REQ_CANCEL;
             break;
         case rtcModule::TermCode::kCallRejected:
-            this->termCode = MegaChatCall::TERM_CODE_CALL_REJECT;
+            megaTermCode = MegaChatCall::TERM_CODE_CALL_REJECT;
             break;
         case rtcModule::TermCode::kAnsElsewhere:
-            this->termCode = MegaChatCall::TERM_CODE_ANSWER_ELSE_WHERE;
+            megaTermCode = MegaChatCall::TERM_CODE_ANSWER_ELSE_WHERE;
             break;
         case rtcModule::TermCode::kRejElsewhere:
-            this->termCode = MegaChatCall::TEMR_CODE_REJECT_ELSE_WHERE;
+            megaTermCode = MegaChatCall::TEMR_CODE_REJECT_ELSE_WHERE;
             break;
         case rtcModule::TermCode::kAnswerTimeout:
-            this->termCode = MegaChatCall::TERM_CODE_ANSWER_TIMEOUT;
+            megaTermCode = MegaChatCall::TERM_CODE_ANSWER_TIMEOUT;
             break;
         case rtcModule::TermCode::kRingOutTimeout:
-            this->termCode = MegaChatCall::TERM_CODE_RING_OUT_TIMEOUT;
+            megaTermCode = MegaChatCall::TERM_CODE_RING_OUT_TIMEOUT;
             break;
         case rtcModule::TermCode::kAppTerminating:
-            this->termCode = MegaChatCall::TERM_CODE_APP_TERMINATING;
+            megaTermCode = MegaChatCall::TERM_CODE_APP_TERMINATING;
             break;
         case rtcModule::TermCode::kBusy:
-            this->termCode = MegaChatCall::TERM_CODE_BUSY;
+            megaTermCode = MegaChatCall::TERM_CODE_BUSY;
             break;
         case rtcModule::TermCode::kNotFinished:
-            this->termCode = MegaChatCall::TERM_CODE_NOT_FINISHED;
+            megaTermCode = MegaChatCall::TERM_CODE_NOT_FINISHED;
             break;
         case rtcModule::TermCode::kDestroyByCallCollision:
-            this->termCode = MegaChatCall::TERM_CODE_DESTROY_BY_COLLISION;
+            megaTermCode = MegaChatCall::TERM_CODE_DESTROY_BY_COLLISION;
             break;
         case rtcModule::TermCode::kCallerGone:
         case rtcModule::TermCode::kInvalid:
         default:
-            this->termCode = MegaChatCall::TERM_CODE_ERROR;
+            megaTermCode = MegaChatCall::TERM_CODE_ERROR;
             break;
     }
 
     if (termCode & rtcModule::TermCode::kPeer)
     {
-        localTermCode = false;
+        local = false;
     }
     else
     {
-        localTermCode = true;
+        local = true;
     }
 }
 

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -583,40 +583,40 @@ class MegaChatCallHandler : public rtcModule::ICallHandler
 {
 public:
     MegaChatCallHandler(MegaChatApiImpl *megaChatApi);
-    virtual ~MegaChatCallHandler();
-    virtual void setCall(rtcModule::ICall* call);
-    virtual void onStateChange(uint8_t newState);
-    virtual void onDestroy(rtcModule::TermCode reason, bool byPeer, const std::string& msg);
-    virtual rtcModule::ISessionHandler *onNewSession(rtcModule::ISession& sess);
-    virtual void onLocalStreamObtained(rtcModule::IVideoRenderer*& rendererOut);
-    virtual void onLocalMediaError(const std::string errors);
-    virtual void onRingOut(karere::Id peer);
-    virtual void onCallStarting();
-    virtual void onCallStarted();
-    virtual void addParticipant(karere::Id userid, uint32_t clientid, karere::AvFlags flags);
-    virtual bool removeParticipant(karere::Id userid, uint32_t clientid);
-    virtual int callParticipants();
-    virtual bool isParticipating(karere::Id userid);
-    virtual void removeAllParticipants();
-    virtual karere::Id getCallId() const;
-    virtual void setCallId(karere::Id callid);
-    virtual void setInitialTimeStamp(int64_t timeStamp);
-    virtual int64_t getInitialTimeStamp();
-    virtual bool hasBeenNotifiedRinging() const;
-    virtual void onReconnectingState(bool start);
+    virtual ~MegaChatCallHandler() override;
+    virtual void setCall(rtcModule::ICall* call) override;
+    virtual void onStateChange(uint8_t newState) override;
+    virtual void onDestroy(rtcModule::TermCode reason, bool byPeer, const std::string& msg) override;
+    virtual rtcModule::ISessionHandler *onNewSession(rtcModule::ISession& sess) override;
+    virtual void onLocalStreamObtained(rtcModule::IVideoRenderer*& rendererOut) override;
+    virtual void onLocalMediaError(const std::string errors) override;
+    virtual void onRingOut(karere::Id peer) override;
+    virtual void onCallStarting() override;
+    virtual void onCallStarted() override;
+    virtual void addParticipant(karere::Id userid, uint32_t clientid, karere::AvFlags flags) override;
+    virtual bool removeParticipant(karere::Id userid, uint32_t clientid) override;
+    virtual int callParticipants() override;
+    virtual bool isParticipating(karere::Id userid) override;
+    virtual void removeAllParticipants() override;
+    virtual karere::Id getCallId() const override;
+    virtual void setCallId(karere::Id callid) override;
+    virtual void setInitialTimeStamp(int64_t timeStamp) override;
+    virtual int64_t getInitialTimeStamp() override;
+    virtual bool hasBeenNotifiedRinging() const override;
+    virtual void onReconnectingState(bool start) override;
     virtual void setReconnectionFailed() override;
-    virtual rtcModule::ICall *getCall();
+    virtual rtcModule::ICall *getCall() override;
 
     MegaChatCallPrivate *getMegaChatCall();
     void setCallNotPresent(karere::Id chatid, karere::Id callid, uint32_t duration);
 private:
     MegaChatApiImpl *megaChatApi;
-    rtcModule::ICall *call = NULL;
-    MegaChatCallPrivate *chatCall = NULL;
+    rtcModule::ICall *call = nullptr;
+    MegaChatCallPrivate *chatCall = nullptr;
     bool mHasBeenNotifiedRinging = false;
     bool mReconnectionFailed = false;
 
-    rtcModule::IVideoRenderer *localVideoReceiver = NULL;
+    rtcModule::IVideoRenderer *localVideoReceiver = nullptr;
 };
 
 class MegaChatSessionHandler : public rtcModule::ISessionHandler

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -235,7 +235,7 @@ public:
     virtual mega::MegaHandleList *getSessionsClientid() const override;
     virtual MegaChatHandle getPeeridCallCompositionChange() const override;
     virtual MegaChatHandle getClientidCallCompositionChange() const override;
-    virtual bool getClientIsAddedOrRemoved() const override;
+    virtual int getCallCompositionChange() const override;
     virtual MegaChatSession *getMegaChatSession(MegaChatHandle peerid, MegaChatHandle clientid) override;
     virtual int getNumParticipants(int audioVideo) const override;
     virtual mega::MegaHandleList *getPeeridParticipants() const override;
@@ -280,7 +280,7 @@ protected:
     std::map<chatd::EndpointId, karere::AvFlags> participants;
     MegaChatHandle peerId;  // to identify participant added or removed
     uint32_t clientid;  // to identify the participant added or removed
-    bool addedOrRemoved = false;
+    int callCompositionChange = MegaChatCall::NO_COMPOSITION_CHANGE;
     MegaChatHandle callerId;
 
     int termCode;

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -594,7 +594,7 @@ public:
     virtual bool removeParticipant(karere::Id userid, uint32_t clientid) override;
     virtual int callParticipants() override;
     virtual bool isParticipating(karere::Id userid) override;
-    virtual void removeAllParticipants() override;
+    virtual void removeAllParticipants(bool exceptMe = false) override;
     virtual karere::Id getCallId() const override;
     virtual void setCallId(karere::Id callid) override;
     virtual void setInitialTimeStamp(int64_t timeStamp) override;

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -263,7 +263,6 @@ public:
     bool addOrUpdateParticipant(karere::Id userid, uint32_t clientid, karere::AvFlags flags);
     bool removeParticipant(karere::Id userid, uint32_t clientid);
     bool isParticipating(karere::Id userid);
-    void removeAllParticipants();
     void setId(karere::Id callid);
     void setCaller(karere::Id caller);
 

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -187,6 +187,7 @@ public:
     void setNetworkQuality(int quality);
     void setAudioDetected(bool audioDetected);
     void setSessionFullyOperative();
+    void setTermCode(int termCode);
     void removeChanges();
 
 private:

--- a/src/megachatapi_impl.h
+++ b/src/megachatapi_impl.h
@@ -264,6 +264,7 @@ public:
     bool isParticipating(karere::Id userid);
     void setId(karere::Id callid);
     void setCaller(karere::Id caller);
+    static void convertTermCode(rtcModule::TermCode termCode, int &megaTermCode, bool &local);
 
 protected:
     MegaChatHandle chatid;
@@ -284,7 +285,6 @@ protected:
     int termCode;
     bool ignored;
     bool localTermCode;
-    void convertTermCode(rtcModule::TermCode termCode);
 
     bool ringing;
     bool mIsCaller;

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -859,6 +859,7 @@ void RtcModule::abortCallRetry(Id chatid)
     if (itHandler != mCallHandlers.end())
     {
         itHandler->second->onReconnectingState(false);
+        Chat& chat = mManager.mKarereClient.mChatdClient->chats(chatid);
         itHandler->second->removeParticipant(mManager.mKarereClient.myHandle(), chat.connection().clientId());
     }
 

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -745,11 +745,10 @@ void RtcModule::updatePeerAvState(Id chatid, Id callid, Id userid, uint32_t clie
 
     callHandler->addParticipant(userid, clientid, av);
 
-
-    auto itCall = mCalls.find(chatid);
-    if (itCall != mCalls.end())
+    Call *call  = static_cast<Call *>(callHandler->getCall());
+    if (call)
     {
-        itCall->second->updateAvFlags(userid, clientid, av);
+        call->updateAvFlags(userid, clientid, av);
     }
 }
 

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -661,6 +661,10 @@ void RtcModule::handleInCall(karere::Id chatid, karere::Id userid, uint32_t clie
     {
         updatePeerAvState(chatid, Id::inval(), userid, clientid, AvFlags(false, false));
     }
+    else
+    {
+        callHandlerIt->second->addParticipant(userid, clientid, AvFlags(false, false));
+    }
 }
 
 void RtcModule::handleCallTime(karere::Id chatid, uint32_t duration)

--- a/src/rtcModule/webrtc.h
+++ b/src/rtcModule/webrtc.h
@@ -222,7 +222,7 @@ public:
     virtual bool removeParticipant(karere::Id userid, uint32_t clientid) = 0;
     virtual int callParticipants() = 0;
     virtual bool isParticipating(karere::Id userid) = 0;
-    virtual void removeAllParticipants() = 0;
+    virtual void removeAllParticipants(bool exceptMe = false) = 0;
     virtual karere::Id getCallId() const = 0;
     virtual void setCallId(karere::Id callid) = 0;
     virtual rtcModule::ICall *getCall() = 0;

--- a/src/rtcModule/webrtc.h
+++ b/src/rtcModule/webrtc.h
@@ -263,6 +263,7 @@ protected:
     karere::Id mPeerAnonId;
     uint32_t mPeerClient;
     karere::AvFlags mPeerAv;
+    TermCode mTermCode = TermCode::kInvalid;
     ISession(Call& call, karere::Id peer, uint32_t peerClient): mCall(call), mPeer(peer), mPeerClient(peerClient){}
 public:
     enum: uint8_t
@@ -286,6 +287,7 @@ public:
     uint32_t peerClient() const { return mPeerClient; }
     karere::AvFlags receivedAv() const { return mPeerAv; }
     karere::Id sessionId() const {return mSid;}
+    TermCode getTermCode() {return mTermCode;}
 };
 
 class ICall: public karere::WeakReferenceable<ICall>

--- a/src/rtcModule/webrtcPrivate.h
+++ b/src/rtcModule/webrtcPrivate.h
@@ -98,7 +98,6 @@ protected:
     long mAudioPacketLostAverage = 0;
     unsigned int mPreviousStatsSize = 0;
     std::unique_ptr<AudioLevelMonitor> mAudioLevelMonitor;
-    TermCode mTermCode = TermCode::kInvalid;
     bool mPeerSupportRenegotiation = false;
     bool mRenegotiationInProgress = false;
     megaHandle mStreamRenegotiationTimer = 0;


### PR DESCRIPTION
Do not merge this PR until Android and iOS are ready to merge the corresponding integrations.

 - Create new callback at MegaChatApi level onChatSessionUpdate
 - Notify all session changes with this new callback
 - Detail peerid and clientid at notification CHANGE_TYPE_CALL_COMPOSITION
 - Update QT app