### PR TITLE
#14601. HotFix: Marshall the callback from libwebsockets for DNS resolution

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -755,7 +755,7 @@ Promise<void> Connection::reconnect()
 
             auto retryCtrl = mRetryCtrl.get();
             int statusDNS = wsResolveDNS(mChatdClient.mKarereClient->websocketIO, host.c_str(),
-                         [wptr, cachedIPs, this, retryCtrl, attemptNo](int statusDNS, std::vector<std::string> &ipsv4, std::vector<std::string> &ipsv6)
+                         [wptr, cachedIPs, this, retryCtrl, attemptNo](int statusDNS, const std::vector<std::string> &ipsv4, const std::vector<std::string> &ipsv6)
             {
                 if (wptr.deleted())
                 {

--- a/src/net/libwebsocketsIO.cpp
+++ b/src/net/libwebsocketsIO.cpp
@@ -99,6 +99,7 @@ static void onDnsResolved(uv_getaddrinfo_t *req, int status, struct addrinfo *re
     }, msg->appCtx);
 
     uv_freeaddrinfo(res);
+    delete req;
 }
 
 bool LibwebsocketsIO::wsResolveDNS(const char *hostname, std::function<void (int, const vector<string>&, const vector<string>&)> f)

--- a/src/net/libwebsocketsIO.h
+++ b/src/net/libwebsocketsIO.h
@@ -21,7 +21,7 @@ public:
     virtual void addevents(::mega::Waiter*, int);
     
 protected:
-    virtual bool wsResolveDNS(const char *hostname, std::function<void(int, std::vector<std::string>&, std::vector<std::string>&)> f);
+    virtual bool wsResolveDNS(const char *hostname, std::function<void(int, const std::vector<std::string>&, const std::vector<std::string>&)> f);
     virtual WebsocketsClientImpl *wsConnect(const char *ip, const char *host,
                                            int port, const char *path, bool ssl,
                                            WebsocketsClient *client);

--- a/src/net/websocketsIO.cpp
+++ b/src/net/websocketsIO.cpp
@@ -74,7 +74,7 @@ WebsocketsClient::~WebsocketsClient()
     ctx = NULL;
 }
 
-bool WebsocketsClient::wsResolveDNS(WebsocketsIO *websocketIO, const char *hostname, std::function<void (int, std::vector<std::string>&, std::vector<std::string>&)> f)
+bool WebsocketsClient::wsResolveDNS(WebsocketsIO *websocketIO, const char *hostname, std::function<void (int, const std::vector<std::string>&, const std::vector<std::string>&)> f)
 {
     return websocketIO->wsResolveDNS(hostname, f);
 }

--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -416,7 +416,7 @@ Client::reconnect()
 
             auto retryCtrl = mRetryCtrl.get();
             int statusDNS = wsResolveDNS(mKarereClient->websocketIO, host.c_str(),
-                         [wptr, cachedIPs, this, retryCtrl, attemptNo](int statusDNS, std::vector<std::string> &ipsv4, std::vector<std::string> &ipsv6)
+                         [wptr, cachedIPs, this, retryCtrl, attemptNo](int statusDNS, const std::vector<std::string> &ipsv4, const std::vector<std::string> &ipsv6)
             {
                 if (wptr.deleted())
                 {


### PR DESCRIPTION
Avoid concurrent access to the DB due to callbacks from libwebsockets skipping the `sdkMutex.lock()`