### PR TITLE
#14656.  Call gets in reconnected state after answer

### DIFF
--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -2408,8 +2408,7 @@ void Call::onClientLeftCall(Id userid, uint32_t clientid)
         destroyIfNoSessionsOrRetries(TermCode::kErrPeerOffline);
     }
 
-    // If we have sent a session we remove the information, that session isn't be succesfull becasuse
-    // we receive a ENDCALL, we don't destroy the call because we are trying to reconnect
+    // We discard the previous JOIN becasue we have rececived an ENDCALL from that peer
     mSessionsInfo.erase(EndpointId(userid, clientid));
 }
 

--- a/src/rtcModule/webrtc.cpp
+++ b/src/rtcModule/webrtc.cpp
@@ -2407,6 +2407,10 @@ void Call::onClientLeftCall(Id userid, uint32_t clientid)
         cancelSessionRetryTimer(userid, clientid);
         destroyIfNoSessionsOrRetries(TermCode::kErrPeerOffline);
     }
+
+    // If we have sent a session we remove the information, that session isn't be succesfull becasuse
+    // we receive a ENDCALL, we don't destroy the call because we are trying to reconnect
+    mSessionsInfo.erase(EndpointId(userid, clientid));
 }
 
 bool Call::changeLocalRenderer(IVideoRenderer* renderer)


### PR DESCRIPTION
In some situations, IOS app is forcing a network reconnection after answer a call. In normal condition, call reconnection is successful but when we have some network issue, the reconnection finishes with failure (after time-out) and call is finished unsuccessfully
This PR solve the issue and call reconnection will be successful if app recovers the network correctly