### PR TITLE
#14917. Add auto-logout when SDK logs out due to EBLOCKED

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -950,7 +950,7 @@ void Client::onRequestFinish(::mega::MegaApi* /*apiObj*/, ::mega::MegaRequest *r
     case ::mega::MegaRequest::TYPE_LOGOUT:
     {
         bool loggedOut = ((errorCode == ::mega::MegaError::API_OK || errorCode == ::mega::MegaError::API_ESID)
-                          && request->getFlag());    // SDK has been logged out normally closing session
+                          && (request->getFlag() || request->getParamType() == ::mega::MegaError::API_EBLOCKED));
 
         bool sessionExpired = request->getParamType() == ::mega::MegaError::API_ESID;       // SDK received ESID during login or any other request
         if (loggedOut)


### PR DESCRIPTION
When the account get blocked, depending on the reason, the SDK may automatically logout (without closing the session). In that case, MEGAchat should also logout.

NOTE: wait for https://github.com/meganz/sdk/pull/1919 to be merged first