### PR TITLE
Updated Objective-C bindings

### DIFF
--- a/bindings/Objective-C/MEGAChatSdk.h
+++ b/bindings/Objective-C/MEGAChatSdk.h
@@ -280,10 +280,9 @@ typedef NS_ENUM (NSInteger, MEGAChatConnection) {
 
 #ifndef KARERE_DISABLE_WEBRTC
 
-- (MEGAStringList *)chatAudioInDevices;
 - (MEGAStringList *)chatVideoInDevices;
-- (BOOL)setChatAudioInDevices:(NSString *)devices;
 - (void)setChatVideoInDevices:(NSString *)devices;
+- (NSString *)videoDeviceSelected;
 - (void)startChatCall:(uint64_t)chatId enableVideo:(BOOL)enableVideo delegate:(id<MEGAChatRequestDelegate>)delegate;
 - (void)startChatCall:(uint64_t)chatId enableVideo:(BOOL)enableVideo;
 - (void)answerChatCall:(uint64_t)chatId enableVideo:(BOOL)enableVideo delegate:(id<MEGAChatRequestDelegate>)delegate;

--- a/bindings/Objective-C/MEGAChatSdk.mm
+++ b/bindings/Objective-C/MEGAChatSdk.mm
@@ -894,6 +894,10 @@ static DelegateMEGAChatLoggerListener *externalLogger = NULL;
     return self.megaChatApi->setChatVideoInDevice(devices ? [devices UTF8String] : NULL);
 }
 
+- (NSString *)videoDeviceSelected {
+    return self.megaChatApi ? [[NSString alloc] initWithUTF8String:self.megaChatApi->getVideoDeviceSelected()] : nil;
+}
+
 - (void)startChatCall:(uint64_t)chatId enableVideo:(BOOL)enableVideo delegate:(id<MEGAChatRequestDelegate>)delegate {
     self.megaChatApi->startChatCall(chatId, enableVideo, [self createDelegateMEGAChatRequestListener:delegate singleListener:YES]);
 }

--- a/src/rtcModule/OBJCCaptureModule.mm
+++ b/src/rtcModule/OBJCCaptureModule.mm
@@ -18,9 +18,7 @@ namespace artc
         mCaptureDevice = nil;
         for (AVCaptureDevice *captureDevice in AVCaptureDevice.devices)
         {
-            // TODO: Choose captureDevice by its localizedName
-            //if ([captureDevice.localizedName isEqualToString:[NSString stringWithUTF8String:deviceName.c_str()]])
-            if (captureDevice.position == AVCaptureDevicePositionFront)
+            if ([captureDevice.localizedName isEqualToString:[NSString stringWithUTF8String:deviceName.c_str()]])
             {
                 mCaptureDevice = captureDevice;
             }


### PR DESCRIPTION
- Don't force the front camera in `OBJCCaptureModule` class.
- Removed unused method declarations.

Should be merged along with https://github.com/meganz/iOS_dev/pull/555