### PR TITLE
#15019. Improve performance for edits

### DIFF
--- a/src/megachatapi.h
+++ b/src/megachatapi.h
@@ -2246,8 +2246,7 @@ public:
      * state is other than MegaChatApi::INIT_OFFLINE_SESSION or MegaChatApi::INIT_ONLINE_SESSION.
      *
      * @param externalDbPath path of the external BD
-     * @param listener MegaChatRequestListener to track this request
-     * @return Number of messages imported successfully, or a negative number in case of error.
+     * @param listener MegaChatRequestListener to track this request     
      */
     void importMessages(const char *externalDbPath, MegaChatRequestListener *listener = nullptr);
 


### PR DESCRIPTION
Checking every message that may have been edited via a new SQLite statement becomes a bottleneck with a relevant amount of chats. Better to check only those msgs that have been edited, and check if edit is newer.