### PR TITLE
#15729.  Avoid to notify about messages being decrypted

### DIFF
--- a/examples/qtmegachatapi/chatMessage.cpp
+++ b/examples/qtmegachatapi/chatMessage.cpp
@@ -36,12 +36,15 @@ ChatMessage::ChatMessage(ChatWindow *parent, megachat::MegaChatApi *mChatApi, me
     delete chatRoom;
     updateContent();
 
-    mega::unique_ptr<::mega::MegaStringList> reactions(mChatWindow->mMegaChatApi->getMessageReactions(mChatId, mMessage->getMsgId()));
-    for (int i = 0; i < reactions->size(); i++)
+    if (mMessage->hasReactions())
     {
-        int count = megaChatApi->getMessageReactionCount(mChatId, mMessage->getMsgId(), reactions->get(i));
-        Reaction *reaction = new Reaction(this, reactions->get(i), count);
-        ui->mReactions->layout()->addWidget(reaction);  // takes ownership
+        mega::unique_ptr<::mega::MegaStringList> reactions(mChatWindow->mMegaChatApi->getMessageReactions(mChatId, mMessage->getMsgId()));
+        for (int i = 0; i < reactions->size(); i++)
+        {
+            int count = megaChatApi->getMessageReactionCount(mChatId, mMessage->getMsgId(), reactions->get(i));
+            Reaction *reaction = new Reaction(this, reactions->get(i), count);
+            ui->mReactions->layout()->addWidget(reaction);  // takes ownership
+        }
     }
 
     connect(ui->mMsgDisplay, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(onMessageCtxMenu(const QPoint&)));

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3386,7 +3386,11 @@ void ChatRoom::onMessageEdited(const chatd::Message& msg, chatd::Idx idx)
 
 void ChatRoom::onMessageStatusChange(chatd::Idx idx, chatd::Message::Status status, const chatd::Message& msg)
 {
-    parent.mKarereClient.app.onChatNotification(mChatid, msg, status, idx);
+    if (msg.userid != parent.mKarereClient.myHandle()
+            && status == chatd::Message::kSeen)  // received message from a peer changed to seen
+    {
+        parent.mKarereClient.app.onChatNotification(mChatid, msg, status, idx);
+    }
 }
 
 void ChatRoom::onUnreadChanged()

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3386,10 +3386,7 @@ void ChatRoom::onMessageEdited(const chatd::Message& msg, chatd::Idx idx)
 
 void ChatRoom::onMessageStatusChange(chatd::Idx idx, chatd::Message::Status status, const chatd::Message& msg)
 {
-    if (msg.userid != parent.mKarereClient.myHandle() && status == chatd::Message::kSeen)  // received message from a peer changed to seen
-    {
-        parent.mKarereClient.app.onChatNotification(mChatid, msg, status, idx);
-    }
+    parent.mKarereClient.app.onChatNotification(mChatid, msg, status, idx);
 }
 
 void ChatRoom::onUnreadChanged()

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3337,8 +3337,8 @@ void ChatRoom::onMsgOrderVerificationFail(const chatd::Message &msg, chatd::Idx 
 
 void ChatRoom::onRecvNewMessage(chatd::Idx idx, chatd::Message& msg, chatd::Message::Status status)
 {
-    if ( (msg.type == chatd::Message::kMsgTruncate)   // truncate received from a peer or from myself in another client
-         || (msg.userid != parent.mKarereClient.myHandle() && status == chatd::Message::kNotSeen) )  // new (unseen) message received from a peer
+    if (msg.userid != parent.mKarereClient.myHandle()
+            && status == chatd::Message::kNotSeen)  // new (unseen) message received from a peer
     {
         parent.mKarereClient.app.onChatNotification(mChatid, msg, status, idx);
     }
@@ -3375,8 +3375,6 @@ void ChatRoom::onMessageEdited(const chatd::Message& msg, chatd::Idx idx)
 {
     chatd::Message::Status status = mChat->getMsgStatus(msg, idx);
 
-    //TODO: check a truncate always comes as an edit, even if no history exist at all (new chat)
-    // and, if so, remove the block from `onRecvNewMessage()`
     if ( (msg.type == chatd::Message::kMsgTruncate) // truncate received from a peer or from myself in another client
          || (msg.userid != parent.mKarereClient.myHandle() && status == chatd::Message::kNotSeen) )    // received message from a peer, still unseen, was edited / deleted
     {

--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3337,8 +3337,9 @@ void ChatRoom::onMsgOrderVerificationFail(const chatd::Message &msg, chatd::Idx 
 
 void ChatRoom::onRecvNewMessage(chatd::Idx idx, chatd::Message& msg, chatd::Message::Status status)
 {
-    if (msg.userid != parent.mKarereClient.myHandle()
-            && status == chatd::Message::kNotSeen)  // new (unseen) message received from a peer
+    // truncate can be received as NEWMSG when the `msgid` is new for the client (later on the MSGUPD is also received)
+    if ( (msg.type == chatd::Message::kMsgTruncate)   // truncate received from a peer or from myself in another client
+         || (msg.userid != parent.mKarereClient.myHandle() && status == chatd::Message::kNotSeen) )  // new (unseen) message received from a peer
     {
         parent.mKarereClient.app.onChatNotification(mChatid, msg, status, idx);
     }

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -4551,8 +4551,11 @@ void MegaChatApiImpl::onInitStateChange(int newState)
 
 void MegaChatApiImpl::onChatNotification(karere::Id chatid, const Message &msg, Message::Status status, Idx idx)
 {
-    if (megaApi->isChatNotifiable(chatid))
-     {
+    if (megaApi->isChatNotifiable(chatid)
+            && msg.userid != chatApi->getMyUserHandle()
+            && status == chatd::Message::kSeen  // received message from a peer changed to seen
+            && !msg.isEncrypted())  // messages can be "seen" while being decrypted
+    {
          MegaChatMessagePrivate *message = new MegaChatMessagePrivate(msg, status, idx);
          fireOnChatNotification(chatid, message);
      }
@@ -6254,7 +6257,10 @@ void MegaChatRoomHandler::onMessageStatusChange(Idx idx, Message::Status status,
     message->setStatus(status);
     fireOnMessageUpdate(message);
 
-    if (megaApi->isChatNotifiable(chatid) && msg.userid != chatApi->getMyUserHandle() && status == chatd::Message::kSeen)  // received message from a peer changed to seen
+    if (megaApi->isChatNotifiable(chatid)
+            && msg.userid != chatApi->getMyUserHandle()
+            && status == chatd::Message::kSeen  // received message from a peer changed to seen
+            && !msg.isEncrypted())  // messages can be "seen" while being decrypted
     {
         MegaChatMessagePrivate *message = new MegaChatMessagePrivate(msg, status, idx);
         chatApiImpl->fireOnChatNotification(chatid, message);

--- a/src/megachatapi_impl.cpp
+++ b/src/megachatapi_impl.cpp
@@ -4551,10 +4551,8 @@ void MegaChatApiImpl::onInitStateChange(int newState)
 
 void MegaChatApiImpl::onChatNotification(karere::Id chatid, const Message &msg, Message::Status status, Idx idx)
 {
-    if (megaApi->isChatNotifiable(chatid)
-            && msg.userid != chatApi->getMyUserHandle()
-            && status == chatd::Message::kSeen  // received message from a peer changed to seen
-            && !msg.isEncrypted())  // messages can be "seen" while being decrypted
+    if (megaApi->isChatNotifiable(chatid)   // filtering based on push-notification settings
+            && !msg.isEncrypted())          // avoid msgs to be notified when marked as "seen", but still decrypting
     {
          MegaChatMessagePrivate *message = new MegaChatMessagePrivate(msg, status, idx);
          fireOnChatNotification(chatid, message);


### PR DESCRIPTION
When a new message is received, but it is already SEEN, the `onChatNotification()` should not be called in case the message is still being decrypted. Once decrypted, a callback, if suitable, will be
triggered.