### PR TITLE
#15770. Avoid to set SEEN back in history

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -3449,7 +3449,16 @@ void Chat::onLastSeen(Id msgid, bool resend)
             return;
         }
     }
-    // else --> msgid was found locally
+    else // msgid was found locally
+    {
+        // if both `msgid` and `mLastSeenId` are known and localy available, there's an index to compare
+        if (mLastSeenIdx != CHATD_IDX_INVALID && idx < mLastSeenIdx)
+        {
+            CHATID_LOG_WARNING("onLastSeen: ignoring attempt to set last seen msgid backwards. Current: %s Attempt: %s", ID_CSTR(mLastSeenId), ID_CSTR(msgid));
+            return; // `mLastSeenId` is newer than the received `msgid`
+        }
+    }
+
     assert(mLastSeenId.isValid());
 
     if (idx == mLastSeenIdx)


### PR DESCRIPTION
Now that SEEN pointer can be imported from the NSE, it might be outdated compared with the SEEN pointer in the app. In that case, we need to skip any update of the SEEN pointer, of the count of unread messages, etc.