### PR TITLE
#15994. Cannot create chat upon canceled contact restore

### DIFF
--- a/src/chatClient.cpp
+++ b/src/chatClient.cpp
@@ -3991,7 +3991,6 @@ void ContactList::syncWithApi(mega::MegaUserList &users)
             // If the user was part of a group before being added as a contact, we need to update user attributes,
             // currently firstname, lastname and email, in order to ensure that are re-fetched for users
             // with group chats previous to establish contact relationship
-            assert(!changed || userid == client.myHandle());   // new users have no changes (expect own user, who updates some attrs upon login)
             changed = ::mega::MegaUser::CHANGE_TYPE_FIRSTNAME | ::mega::MegaUser::CHANGE_TYPE_LASTNAME | ::mega::MegaUser::CHANGE_TYPE_EMAIL;
             updateCache = true;
         }


### PR DESCRIPTION
In case of canceled accounts, the peerchat remains, but not the ex-contact. If the account is restored and the user becomes a contact again, it's needed to attach the orphan 1on1 room to the contact.