### PR TITLE
Use a valid app key for QtApp

### DIFF
--- a/examples/qtmegachatapi/MegaChatApplication.cpp
+++ b/examples/qtmegachatapi/MegaChatApplication.cpp
@@ -33,7 +33,7 @@ MegaChatApplication::MegaChatApplication(int &argc, char **argv) : QApplication(
     mSid = NULL;
 
     // Initialize the SDK and MEGAchat
-    mMegaApi = new MegaApi("karere-native", mAppDir.c_str(), "MEGAChatQtApp");
+    mMegaApi = new MegaApi("PssTQSqb", mAppDir.c_str(), "MEGAChatQtApp");
     mMegaChatApi = new MegaChatApi(mMegaApi);
 
     // Create delegate listeners


### PR DESCRIPTION
As per requested by MEGA, any app connecting to the API should provide a valid `appKey`

> https://mega.nz/sdk