### PR TITLE
Remove `getTranslatedErrorString` method from Android bindings

### DIFF
--- a/bindings/java/nz/mega/sdk/MegaChatApiJava.java
+++ b/bindings/java/nz/mega/sdk/MegaChatApiJava.java
@@ -6,11 +6,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import mega.privacy.android.app.MegaApplication;
-import mega.privacy.android.app.R;
 import mega.privacy.android.app.utils.VideoCaptureUtils;
-
-import static nz.mega.sdk.MegaChatError.*;
 
 public class MegaChatApiJava {
     MegaChatApi megaChatApi;
@@ -3076,36 +3072,5 @@ public class MegaChatApiJava {
         }
 
         return result;
-    }
-
-    /**
-     * Gets the translated string of an error received in a request.
-     *
-     * @param error MegaChatError received in the request
-     * @return The translated string
-     */
-    public static String getTranslatedErrorString(MegaChatError error) {
-        MegaApplication app = MegaApplication.getInstance();
-        if (app == null) {
-            return error.getErrorString();
-        }
-
-        switch (error.getErrorCode()) {
-            case ERROR_OK:
-                return app.getString(R.string.error_ok);
-            case ERROR_ARGS:
-                return app.getString(R.string.error_args);
-            case ERROR_ACCESS:
-                return app.getString(R.string.error_access);
-            case ERROR_NOENT:
-                return app.getString(R.string.error_noent);
-            case ERROR_EXIST:
-                return app.getString(R.string.error_exist);
-            case ERROR_TOOMANY:
-                return app.getString(R.string.error_toomany);
-            case ERROR_UNKNOWN:
-            default:
-                return app.getString(R.string.error_unknown);
-        }
     }
 };


### PR DESCRIPTION
This method uses string resources of the official MEGA app, so this code has been moved to the app code (https://github.com/meganz/android2/pull/1291/commits/13b0f7fab9940d309eb38d044c58ed5658dce2df)