### PR TITLE
#16499. Upgrade chatd version to 8. Hotfix over 2.3.6

### DIFF
--- a/src/chatd.h
+++ b/src/chatd.h
@@ -1526,7 +1526,9 @@ public:
     //  * Add commands ADDREACTION DELREACTION REACTIONSN
     // - Version 7:
     //  * Add commands MSGIDTIMESTAMP NEWMSGIDTIMESTAMP
-    static const unsigned chatdVersion = 7;
+    // - Version 8:
+    //  * Solves several bugs related to missing RETENTION time upon re-joins, anonymous previewers and others
+    static const unsigned chatdVersion = 8;
 
     // Minimum retention history check period (in seconds)
     static const unsigned kMinRetentionTimeout = 60;


### PR DESCRIPTION
DO NOT merge this PR until chatd v8 has been deployed to all shards (currently only in shard2).

Once v8 is deployed, reconsider whether this patch should make to v2.3.6, since apps don't provide the retention-history feature yet, so it may not worth to patch it.