### PR TITLE
Adjust checks at presenced onUsersUpdate

### DIFF
--- a/src/presenced.cpp
+++ b/src/presenced.cpp
@@ -552,6 +552,12 @@ bool Client::isContact(uint64_t userid)
 
 void Client::onUsersUpdate(::mega::MegaApi *api, ::mega::MegaUserList *usersUpdated)
 {
+    if (!mLastScsn.isValid())
+    {
+        PRESENCED_LOG_DEBUG("onUsersUpdate: still catching-up with actionpackets");
+        return;
+    }
+
     const char *buf = api->getSequenceNumber();
     Id scsn(buf, strlen(buf));
     delete [] buf;
@@ -573,7 +579,7 @@ void Client::onUsersUpdate(::mega::MegaApi *api, ::mega::MegaUserList *usersUpda
 
         if (!mLastScsn.isValid())
         {
-            PRESENCED_LOG_DEBUG("onUsersUpdate: still catching-up with actionpackets");
+            PRESENCED_LOG_DEBUG("onUsersUpdate (marshall): still catching-up with actionpackets");
             return;
         }
 


### PR DESCRIPTION
Now that the SDK includes an assert to not retrieve the `scsn` earlier than initialized, MEGAchat fails that assertion by getting it too early. There was no bug, since the `mLastScsn` is invalid until the SDK notifies, via `onEvent(EVENT_NODES_CURRENT)`, that the `scsn` has been initialized.