### PR TITLE
CHT-417. Fix wrong update of unread messages

### DIFF
--- a/src/chatd.cpp
+++ b/src/chatd.cpp
@@ -5154,33 +5154,10 @@ void Chat::msgIncomingAfterDecrypt(bool isNew, bool isLocal, Message& msg, Idx i
         }
     }
 
-    if (isNew)
+    if (msg.isValidUnread(mChatdClient.myHandle())
+            && (isNew || mLastSeenIdx == CHATD_IDX_INVALID))
     {
-        if (msg.isValidUnread(mChatdClient.myHandle()))
-        {
-            mUnreadCount++;
-            CALL_LISTENER(onUnreadChanged);
-        }
-    }
-    else
-    {
-        if (mLastSeenIdx == CHATD_IDX_INVALID)
-        {
-            assert(mUnreadCount <= 0);
-            if (msg.isValidUnread(mChatdClient.myHandle()))
-            {
-                if (mLastSeenId == msg.id())
-                {
-                    mUnreadCount = -mUnreadCount;
-                }
-                else
-                {
-                    mUnreadCount--;
-                }
-
-                CALL_LISTENER(onUnreadChanged);
-            }
-        }
+        calculateUnreadCount();
     }
 
     //handle last text message

--- a/src/chatdDb.h
+++ b/src/chatdDb.h
@@ -262,7 +262,7 @@ public:
         std::string query = "select idx from " + table + " where chatid = ? and msgid = ?";
         SqliteStmt stmt(mDb, query.c_str());
         stmt << mChat.chatId() << msgid;
-        return (stmt.step()) ? stmt.int64Col(0) : CHATD_IDX_INVALID;
+        return (stmt.step()) ? stmt.intCol(0) : CHATD_IDX_INVALID;
     }
 
     virtual chatd::Idx getIdxOfMsgidFromHistory(karere::Id msgid)


### PR DESCRIPTION
When messages are imported, they can pass twice through `msgIncomingAfterDecrypt()`, which results on increasing the unread
count more than once for the same message. Better to recalculate.