### PR TITLE
Add search string new property in MEGAChatListItem

### DIFF
--- a/bindings/Objective-C/MEGAChatListItem.h
+++ b/bindings/Objective-C/MEGAChatListItem.h
@@ -40,6 +40,7 @@ typedef NS_ENUM (NSInteger, MEGAChatRoomPrivilege);
 @property (readonly, nonatomic) NSDate *lastMessageDate;
 @property (readonly, nonatomic) MEGAChatMessageType lastMessagePriv;
 @property (readonly, nonatomic) uint64_t lastMessageHandle;
+@property (strong, nonatomic) NSString *searchString;
 
 - (instancetype)clone;
 

--- a/bindings/Objective-C/MEGAChatListItem.mm
+++ b/bindings/Objective-C/MEGAChatListItem.mm
@@ -21,6 +21,7 @@ using namespace megachat;
     if (self != nil) {
         _megaChatListItem = megaChatListItem;
         _cMemoryOwn = cMemoryOwn;
+        _searchString = @"";
     }
     
     return self;


### PR DESCRIPTION
Add search string new property in MEGAChatListItem to store static info about chat components related to chat list search. This feature is part of [4193. App is crashing after trying to search on the chat list](https://github.com/meganz/iOS_dev/pull/886) pull request.